### PR TITLE
Snapdragon: Correction how to tell P1 from P2

### DIFF
--- a/advanced-snapdragon.md
+++ b/advanced-snapdragon.md
@@ -69,7 +69,7 @@ chmod +x fastboot-all.sh
 ./fastboot-all.sh
 ```
 
-On P1 boards, it is normal that the partitions `recovery`, `update`, and `factory` will fail.
+It is normal that the partitions `recovery`, `update`, and `factory` will fail.
 
 ### Updating the ADSP firmware
 

--- a/advanced-snapdragon.md
+++ b/advanced-snapdragon.md
@@ -397,6 +397,8 @@ REV A
 QUALCOMM
 ```
 
-The P1 of the second line is key.
+If you see **H9550**, it means you have a P2 board!
 
-<aside class="note">P1 boards don't have a factory partition/image and therefore can't be restored to factory state.</aside>
+**Please ignore that it says -P1.**
+
+Presumably P1 boards don't have a factory partition/image and therefore can't be restored to factory state.


### PR DESCRIPTION
Appearantly all Snapdragon Flight boards are hardware revision P2 according to https://groups.google.com/forum/#!topic/px4users/zu7U2ozTz0c.
