### PR TITLE
RPi2: update build instructions

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -31,7 +31,7 @@
 * Autopilot Hardware
    * [Snapdragon Flight](hardware-snapdragon.md)
        * [Optical Flow](optical_flow.md)
-   * [Raspberry Pi 2](hardware-pi2.md)
+   * [Raspberry Pi](hardware-rpi.md)
    * [Pixhawk](hardware-pixhawk.md)
    * [Pixfalcon](hardware-pixfalcon.md)
    * [Pixracer](hardware-pixracer.md)
@@ -60,7 +60,7 @@
    * [DroneKit usage](dronekit-example.md)
 * Robotics using ROS
    * [Offboard Control from Linux](offboard-control.md)
-   * [ROS Installation on RPi 2](ros-raspberrypi-installation.md)
+   * [ROS Installation on RPi](ros-raspberrypi-installation.md)
    * [MAVROS (MAVLink on ROS)](ros-mavros-installation.md)
    * [MAVROS offboard example](ros-mavros-offboard.md)
    * [External Position Estimation](external-position.md)

--- a/hardware-rpi.md
+++ b/hardware-rpi.md
@@ -1,4 +1,4 @@
-# Raspberry Pi 2 Autopilot
+# Raspberry Pi 2/3 Autopilot
 
 ![](images/hardware/hardware-rpi2.jpg)
 
@@ -10,9 +10,9 @@ Use the [Emlid RT Raspbian image](http://docs.emlid.com/navio/Downloads/Real-tim
 
 ### Setting up access
 
-The Raspbian image has SSH setup already. Username is "pi" and password is "raspberry". You can connect to your RPi2 over a network (Ethernet is set to come up with DHCP by default) and then proceed to configure WiFi access. We assume that the username and password remain at their defaults for the purpose of this guide.
+The Raspbian image has SSH setup already. Username is "pi" and password is "raspberry". You can connect to your RPi2/3 over a network (Ethernet is set to come up with DHCP by default) and then proceed to configure WiFi access. We assume that the username and password remain at their defaults for the purpose of this guide.
 
-To setup the RPi2 to join your local wifi, follow [this guide](https://www.raspberrypi.org/documentation/configuration/wireless/wireless-cli.md).
+To setup the RPi2/3 to join your local wifi, follow [this guide](https://www.raspberrypi.org/documentation/configuration/wireless/wireless-cli.md).
 
 Find the IP address of your Pi from your network, and then you can proceed to connect to it using SSH.
 <div class="host-code"></div>

--- a/starting-building.md
+++ b/starting-building.md
@@ -54,18 +54,18 @@ Rebooting.
 
 [100%] Built target upload
 ```
-### Raspberry Pi 2 boards
+### Raspberry Pi 2/3 boards
 The command below builds the target for Raspbian.
 
 #### Cross-compiler build
 
 ```sh
 cd Firmware
-make posix_rpi2_cross # for cross-compiler build
+make posix_rpi_cross # for cross-compiler build
 ```
 
-The "mainapp" executable file is in the directory build_posix_rpi2_cross/src/firmware/posix.
-Make sure you can connect to your RPi over ssh, see [instructions how to access your RPi](hardware-pi2.md#developer-quick-start).
+The "mainapp" executable file is in the directory build_posix_rpi_cross/src/firmware/posix.
+Make sure you can connect to your RPi over ssh, see [instructions how to access your RPi](hardware-rpi.md#developer-quick-start).
 
 Then set the IP (or hostname) of your RPi using:
 
@@ -77,7 +77,7 @@ And upload it with:
 
 ```sh
 cd Firmware
-make posix_rpi2_cross upload # for cross-compiler build
+make posix_rpi_cross upload # for cross-compiler build
 ```
 
 Then, connect over ssh and run it with :
@@ -88,18 +88,18 @@ Then, connect over ssh and run it with :
 
 #### Native build
 
-If you're building *directly* on the Pi, you will want the native build target (posix_rpi2_native).
+If you're building *directly* on the Pi, you will want the native build target (posix_rpi_native).
 
 ```sh
 cd Firmware
-make posix_rpi2_native # for native build
+make posix_rpi_native # for native build
 ```
 
-The "mainapp" executable file is in the directory build_posix_rpi2_native/src/firmware/posix.
+The "mainapp" executable file is in the directory build_posix_rpi_native/src/firmware/posix.
 Run it directly with :
 
 ```sh
-./build_posix_rpi2_native/src/firmware/posix/mainapp ./posix-configs/rpi2/mainapp.config
+./build_posix_rpi_native/src/firmware/posix/mainapp ./posix-configs/rpi/mainapp.config
 ```
 
 A successful build followed by executing mainapp will give you this :

--- a/starting-building.md
+++ b/starting-building.md
@@ -55,39 +55,51 @@ Rebooting.
 [100%] Built target upload
 ```
 ### Raspberry Pi 2 boards
-The command below builds the target for Raspbian (posix_pi2_release).
+The command below builds the target for Raspbian.
+
+#### Cross-compiler build
 
 ```sh
 cd Firmware
-make posix_rpi2_release # for cross-compiler build
+make posix_rpi2_cross # for cross-compiler build
 ```
 
-The "mainapp" executable file is in the directory build_posix_rpi2_release/src/firmware/posix.
-Copy it over to the RPi (replace YOUR_PI with the IP or hostname of your RPi, [instructions how to access your RPi](hardware-pi2.md#developer-quick-start))
+The "mainapp" executable file is in the directory build_posix_rpi2_cross/src/firmware/posix.
+Make sure you can connect to your RPi over ssh, see [instructions how to access your RPi](hardware-pi2.md#developer-quick-start).
+
+Then set the IP (or hostname) of your RPi using:
 
 ```sh
-scp build_posix_rpi2_release/src/firmware/posix/mainapp pi@YOUR_PI:/home/pi/
+export AUTOPILOT_HOST=192.168.X.X
 ```
 
-And run it with :
-
-```sh
-./mainapp
-```
-
-
-If you're building *directly* on the Pi, you will want the native build target (posix_pi2_default).
+And upload it with:
 
 ```sh
 cd Firmware
-make posix_rpi2_default # for native build
+make posix_rpi2_cross upload # for cross-compiler build
 ```
 
-The "mainapp" executable file is in the directory build_posix_rpi2_default/src/firmware/posix.
+Then, connect over ssh and run it with :
+
+```sh
+./mainapp mainapp.config
+```
+
+#### Native build
+
+If you're building *directly* on the Pi, you will want the native build target (posix_rpi2_native).
+
+```sh
+cd Firmware
+make posix_rpi2_native # for native build
+```
+
+The "mainapp" executable file is in the directory build_posix_rpi2_native/src/firmware/posix.
 Run it directly with :
 
 ```sh
-./build_posix_rpi2_default/src/firmware/posix/mainapp
+./build_posix_rpi2_native/src/firmware/posix/mainapp ./posix-configs/rpi2/mainapp.config
 ```
 
 A successful build followed by executing mainapp will give you this :


### PR DESCRIPTION
This includes a general update on how to set the IP of your RPi2 as well
as the rename from _release to _cross and _default to _native.

Goes together with https://github.com/PX4/Firmware/pull/5063.
