### PR TITLE
Update Ubuntu PPA for gcc-arm-none-eabi

### DIFF
--- a/starting-installing-linux-boutique.md
+++ b/starting-installing-linux-boutique.md
@@ -129,9 +129,9 @@ Log out and log in for changes to take effect! Also remove the device and plug i
 
 ### Toolchain Installation
 
-Execute the script below to either install GCC 4.8.4 or 4.9.2:
+Execute the script below to either install GCC 4.8 or 5.4:
 
-<div class="host-code"></div>
+**GCC 4.8**:
 
 ```sh
 pushd .
@@ -144,16 +144,14 @@ if grep -Fxq "$exportline" ~/.profile; then echo nothing to do ; else echo $expo
 popd
 ```
 
-GCC 4.9:
-
-<div class="host-code"></div>
+**GCC 5.4**:
 
 ```sh
 pushd .
 cd ~
-wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2014-q4-major/+download/gcc-arm-none-eabi-4_9-2014q4-20141203-linux.tar.bz2
-tar -jxf gcc-arm-none-eabi-4_9-2014q4-20141203-linux.tar.bz2
-exportline="export PATH=$HOME/gcc-arm-none-eabi-4_9-2014q4/bin:\$PATH"
+wget https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2
+tar -jxf gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2
+exportline="export PATH=$HOME/gcc-arm-none-eabi-5_4-2016q2/bin:\$PATH"
 if grep -Fxq "$exportline" ~/.profile; then echo nothing to do ; else echo $exportline >> ~/.profile; fi
 . ~/.profile
 popd

--- a/starting-installing-linux-boutique.md
+++ b/starting-installing-linux-boutique.md
@@ -45,8 +45,8 @@ sudo usermod -a -G plugdev $USER
 
 ### CentOs
 
-The build requires Python 2.7.5. Therefore as of this writing Centos 7 should be used. 
-(For earlier Centos releases a side-by-side install of python v2.7.5 may be done. But it is not recommended because it can break yum.) 
+The build requires Python 2.7.5. Therefore as of this writing Centos 7 should be used.
+(For earlier Centos releases a side-by-side install of python v2.7.5 may be done. But it is not recommended because it can break yum.)
 
 The EPEL repositories are required for openocd libftdi-devel libftdi-python
 
@@ -74,7 +74,7 @@ Once the arm toolchain is installed test it with:
 ```sh
 arm-none-eabi-gcc --version
 ```
-If you receive the following message 
+If you receive the following message
 
 <div class="host-code"></div>
 
@@ -86,7 +86,7 @@ Then you will also need to install other 32-bit libraries glibc.i686 ncurses-lib
 <div class="host-code"></div>
 
 ```sh
-sudo yum install glibc.i686 ncurses-libs.i686 
+sudo yum install glibc.i686 ncurses-libs.i686
 ```
 <aside class="note">
 Pulling in ncurses-libs.i686 will pull in most of the other required 32 bit libraries. Centos 7 will install most all the PX4 related devices without the need for any added udev rules. The devices will be accessible to the predefined group ' dialout'. Therefore any references to adding udev rules can be ignored. The only requirement is that your user account is a member of the group 'dial out'

--- a/starting-installing-linux.md
+++ b/starting-installing-linux.md
@@ -48,7 +48,7 @@ Update the package list and install the following dependencies. Packages with sp
 
 
 ```sh
-sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded -y
+sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
 sudo apt-get update
 sudo apt-get install python-serial openocd \
     flex bison libncurses5-dev autoconf texinfo build-essential \
@@ -57,6 +57,11 @@ sudo apt-get install python-serial openocd \
 ```
 
 If the resulting `gcc-arm-none-eabi` version produces build errors for PX4/Firmware master, please refer to [the bare metal installation instructions](http://dev.px4.io/starting-installing-linux-boutique.html#toolchain-installation) to install version 4.8 manually.
+
+If it reports error message of conflict to gcc-arm-none-eabi, which is likely if upgrading from 4.x to 5+, please uninstall it first with:
+```sh
+sudo apt-get remove gcc-arm-none-eabi
+```
 
 ### Snapdragon Flight
 

--- a/starting-installing-linux.md
+++ b/starting-installing-linux.md
@@ -46,22 +46,20 @@ sudo apt-get remove modemmanager
 
 Update the package list and install the following dependencies. Packages with specified versions should be installed with this particular package version.
 
+Make sure to remove the packaged version before adding the ppa.
 
 ```sh
+sudo apt-get remove gcc-arm-none-eabi gdb-arm-none-eabi binutils-arm-none-eabi
 sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
 sudo apt-get update
 sudo apt-get install python-serial openocd \
     flex bison libncurses5-dev autoconf texinfo build-essential \
     libftdi-dev libtool zlib1g-dev \
-    python-empy gcc-arm-none-eabi -y
+    python-empy gcc-arm-embedded -y
 ```
 
-If the resulting `gcc-arm-none-eabi` version produces build errors for PX4/Firmware master, please refer to [the bare metal installation instructions](http://dev.px4.io/starting-installing-linux-boutique.html#toolchain-installation) to install version 4.8 manually.
+If the resulting `gcc-arm-none-eabi` version produces build errors for PX4/Firmware master, please refer to [the bare metal installation instructions](http://dev.px4.io/starting-installing-linux-boutique.html#toolchain-installation) to install version 4.8 or 5.4 manually.
 
-If it reports error message of conflict to gcc-arm-none-eabi, which is likely if upgrading from 4.x to 5+, please uninstall it first with:
-```sh
-sudo apt-get remove gcc-arm-none-eabi
-```
 
 ### Snapdragon Flight
 


### PR DESCRIPTION
- Use new PPA as suggested by #13.
- Actually install the new toolchain from the ppa (install gcc-arm-embedded instead of gcc-arm-none-eabi). This installs version 5.4.
- Suggest to use version 5.4 in boutique installation as well.
- Removal of version 4.9 in boutique installation because gdb is unable to open the build artefacts which is probably a bug resolved in versions 5+.

The firmware built by gcc version 5.4.1 has been tested on the bench, no errors observed so far.
