### PR TITLE
Updated install instructions to use qrlSDK for sysroot

### DIFF
--- a/starting-installing-linux.md
+++ b/starting-installing-linux.md
@@ -116,17 +116,18 @@ source ~/.bashrc
 
 A sysroot is required to provide the libraries and header files needed to cross compile applications for the Snapdragon Flight applications processor.
 
-Currently, the trusty sysroot is used because the provided one by Intrinsyc has miraculously been removed from their download website.
+The qrlSDK sysroot provies the required header files and libraries for the camera, GPU, etc.
 
-```
+```sh
 cd cross_toolchain
-./trusty_sysroot.sh
+unset HEXAGON_ARM_SYSROOT
+./qrlinux_sysroot.sh
 ```
 
 Append the following to your ~/.bashrc:
 
-```
-export HEXAGON_ARM_SYSROOT=${HOME}/Qualcomm/ubuntu_14.04_armv7_sysroot
+```sh
+export HEXAGON_ARM_SYSROOT=${HOME}/Qualcomm/qrlinux_v3.1.1_sysroot
 ```
 
 Load the new configuration:

--- a/starting-installing-linux.md
+++ b/starting-installing-linux.md
@@ -118,6 +118,8 @@ A sysroot is required to provide the libraries and header files needed to cross 
 
 The qrlSDK sysroot provies the required header files and libraries for the camera, GPU, etc.
 
+Download the file [Flight_3.1.1_qrlSDK.zip](http://support.intrinsyc.com/attachments/download/690/Flight_3.1.1_qrlSDK.zip) and save it in `cross_toolchain/download/`.
+
 ```sh
 cd cross_toolchain
 unset HEXAGON_ARM_SYSROOT


### PR DESCRIPTION
The qrlSDK is now available again on the Intrinsyc website

Signed-off-by: Mark Charlebois charlebm@gmail.com
