### PR TITLE
Adding udev rules

### DIFF
--- a/pixhawk-companion-computer.md
+++ b/pixhawk-companion-computer.md
@@ -38,3 +38,46 @@ The safe bet is to use an FTDI Chip USB-to-serial adapter board and the wiring b
 |4         | CTS (in) |6       | FTDI RTS (green) (out) |
 |5         | RTS (out)|2       | FTDI CTS (brown) (in) |
 |6         | GND     | 1       | FTDI GND (black)   |
+
+## Software setup on Linux
+
+On Linux the default name of a USB FTDI would be like `\dev\ttyUSB0`. If you have a second FTDI linked on the USB or an Arduino, it will registered as `\dev\ttyUSB1`. To avoid the confusion between the first plugged and the second plugged, it is a good maneer to create a symlink it by the . To do it, you can use UDEV rules based on the Vendor and Product ID of the USB device.
+
+Using `lsusb` we can get the vendor and product IDs.
+
+```sh
+$ lsusb
+
+Bus 006 Device 002: ID 0bda:8153 Realtek Semiconductor Corp.
+Bus 006 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+Bus 005 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+Bus 004 Device 002: ID 05e3:0616 Genesys Logic, Inc.
+Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+Bus 003 Device 004: ID 2341:0042 Arduino SA Mega 2560 R3 (CDC ACM)
+Bus 003 Device 005: ID 26ac:0011
+Bus 003 Device 002: ID 05e3:0610 Genesys Logic, Inc. 4-port hub
+Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+Bus 002 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub
+Bus 001 Device 002: ID 0bda:8176 Realtek Semiconductor Corp. RTL8188CUS 802.11n WLAN Adapter
+Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+```
+
+The Arduino is `Bus 003 Device 004: ID 2341:0042 Arduino SA Mega 2560 R3 (CDC ACM)`
+
+The Pixhawk is `Bus 003 Device 005: ID 26ac:0011`
+
+Therefore, we can create a new UDEV rule in a file called `/etc/udev/rules.d/99-pixhawk.rules` with the following content, changing the idVendor and idProduct to yours.
+
+```sh
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0042", SYMLINK+="ttyLasers"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="26ac", ATTRS{idProduct}=="0011", SYMLINK+="ttyPixHawk"
+```
+
+Finally, after a **reboot** you can be sure to know which device is what and put `/dev/ttyPixHawk` instead of `/dev/ttyUSB0` in your scripts.
+
+> Be sure to add yourself in the `tty` and `dialout` groups via `usermod`
+
+```sh
+usermod -a -G tty ros-user
+usermod -a -G dialout ros-user
+```

--- a/pixhawk-companion-computer.md
+++ b/pixhawk-companion-computer.md
@@ -41,7 +41,7 @@ The safe bet is to use an FTDI Chip USB-to-serial adapter board and the wiring b
 
 ## Software setup on Linux
 
-On Linux the default name of a USB FTDI would be like `\dev\ttyUSB0`. If you have a second FTDI linked on the USB or an Arduino, it will registered as `\dev\ttyUSB1`. To avoid the confusion between the first plugged and the second plugged, it is a good maneer to create a symlink it by the . To do it, you can use UDEV rules based on the Vendor and Product ID of the USB device.
+On Linux the default name of a USB FTDI would be like `\dev\ttyUSB0`. If you have a second FTDI linked on the USB or an Arduino, it will registered as `\dev\ttyUSB1`. To avoid the confusion between the first plugged and the second plugged, we recommend you to create a symlink from `ttyUSBx` to a friendly name, depending on the Vendor and Product ID of the USB device. 
 
 Using `lsusb` we can get the vendor and product IDs.
 
@@ -66,16 +66,18 @@ The Arduino is `Bus 003 Device 004: ID 2341:0042 Arduino SA Mega 2560 R3 (CDC AC
 
 The Pixhawk is `Bus 003 Device 005: ID 26ac:0011`
 
+> If you do not find your device, unplug it, execute `lsusb`, plug it, execute `lsusb` again and see the added device.
+
 Therefore, we can create a new UDEV rule in a file called `/etc/udev/rules.d/99-pixhawk.rules` with the following content, changing the idVendor and idProduct to yours.
 
 ```sh
-SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0042", SYMLINK+="ttyLasers"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0042", SYMLINK+="ttyArduino"
 SUBSYSTEM=="tty", ATTRS{idVendor}=="26ac", ATTRS{idProduct}=="0011", SYMLINK+="ttyPixhawk"
 ```
 
 Finally, after a **reboot** you can be sure to know which device is what and put `/dev/ttyPixhawk` instead of `/dev/ttyUSB0` in your scripts.
 
-> Be sure to add yourself in the `tty` and `dialout` groups via `usermod`
+> Be sure to add yourself in the `tty` and `dialout` groups via `usermod` to avoid to have to execute scripts as root.
 
 ```sh
 usermod -a -G tty ros-user

--- a/pixhawk-companion-computer.md
+++ b/pixhawk-companion-computer.md
@@ -70,10 +70,10 @@ Therefore, we can create a new UDEV rule in a file called `/etc/udev/rules.d/99-
 
 ```sh
 SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0042", SYMLINK+="ttyLasers"
-SUBSYSTEM=="tty", ATTRS{idVendor}=="26ac", ATTRS{idProduct}=="0011", SYMLINK+="ttyPixHawk"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="26ac", ATTRS{idProduct}=="0011", SYMLINK+="ttyPixhawk"
 ```
 
-Finally, after a **reboot** you can be sure to know which device is what and put `/dev/ttyPixHawk` instead of `/dev/ttyUSB0` in your scripts.
+Finally, after a **reboot** you can be sure to know which device is what and put `/dev/ttyPixhawk` instead of `/dev/ttyUSB0` in your scripts.
 
 > Be sure to add yourself in the `tty` and `dialout` groups via `usermod`
 


### PR DESCRIPTION
Dear,

This show how to create an automatic symlink from `/dev/ttyUSB0` to `/dev/ttyPixhawk`. 

It avoids the problem of multiple boards connected to the offboard computer, like an Arduino + Pixhawk which are linked to `/dev/ttyUSB0` or `/dev/ttyUSB1` depending on the first plugged in. And randomly when we reboot.
