### PR TITLE
Fixed a broken URL to the QGroundControl download page.

### DIFF
--- a/starting-initial-config.md
+++ b/starting-initial-config.md
@@ -2,7 +2,7 @@
 
 Before starting to develop on PX4, the system should be configured initially with a default configuration to ensure the hardware is set up properly and is tested. The video below explains the setup process with [Pixhawk hardware](hardware-pixhawk.md) and [QGroundControl](qgroundcontrol-intro.md). A list of supported reference airfames is [here](airframes-architecture.md).
 
-> **Info** [Download the DAILY BUILD of QGroundControl](http://qgroundcontrol.org/downloads) and follow the video instructions below to set up your vehicle. See the [QGroundControl Tutorial](http://dev.px4.io/qgroundcontrol-intro.html) for details on mission planning, flying and parameter setting.
+> **Info** [Download the DAILY BUILD of QGroundControl](http://qgroundcontrol.com/downloads) and follow the video instructions below to set up your vehicle. See the [QGroundControl Tutorial](http://dev.px4.io/qgroundcontrol-intro.html) for details on mission planning, flying and parameter setting.
 
 A list of setup options is below the video.
 


### PR DESCRIPTION
A broken link to the QGroundControl download page.
- Changed ".org" to ".com" on "http://qgroundcontrol.org/downloads"
