### PR TITLE
A broken link to the QGroundControl download page

### DIFF
--- a/qgroundcontrol-intro.md
+++ b/qgroundcontrol-intro.md
@@ -25,7 +25,7 @@ Switch to the setup tab. Scroll the menu on the left all the way to the bottom a
 
 ## Installation
 
-QGroundControl can be downloaded from its [website](http://qgroundcontrol.org/downloads).
+QGroundControl can be downloaded from its [website](http://qgroundcontrol.com/downloads).
 
 <aside class="tip">
 Developers are advised to use the latest daily build instead of the stable release.


### PR DESCRIPTION
- Changed ".org" to ".com" on "http://qgroundcontrol.org/downloads"
