### PR TITLE
starting-installing-mac: path needed for opencv

### DIFF
--- a/starting-installing-mac.md
+++ b/starting-installing-mac.md
@@ -23,7 +23,8 @@ brew update
 brew install git bash-completion genromfs kconfig-frontends gcc-arm-none-eabi
 brew install astyle cmake ninja
 # simulation tools
-brew install ant graphviz sdformat3 eigen opencv
+brew install ant graphviz sdformat3 eigen
+brew install homebrew/science/opencv
 ```
 
 We need to get an older version of protobuf (`< 3.0.0`).


### PR DESCRIPTION
The path is needed for opencv to distinguish it from the opencv3
package.
