### PR TITLE
Mac: use the latest version of protobuf

### DIFF
--- a/starting-installing-mac.md
+++ b/starting-installing-mac.md
@@ -23,15 +23,8 @@ brew update
 brew install git bash-completion genromfs kconfig-frontends gcc-arm-none-eabi
 brew install astyle cmake ninja
 # simulation tools
-brew install ant graphviz sdformat3 eigen
+brew install ant graphviz sdformat3 eigen protobuf
 brew install homebrew/science/opencv
-```
-
-We need to get an older version of protobuf (`< 3.0.0`).
-
-```sh
-brew tap homebrew/versions
-brew install homebrew/versions/protobuf260
 ```
 
 Then install the required python packages:


### PR DESCRIPTION
Turns out, it is fine to use the latest version, at least if you have
the latest version of gazebo as well.

This depends on https://github.com/PX4/sitl_gazebo/pull/53.
