### PR TITLE
Fix mini-dm path, add note about nano-dm

### DIFF
--- a/advanced-system-console.md
+++ b/advanced-system-console.md
@@ -9,9 +9,9 @@ There are multiple shells, but only one console: The system console is the locat
   * System console (first shell): Hardware serial port
   * Additional shells: Pixhawk on USB (e.g. lists as /dev/tty.usbmodem1 on Mac OS)
 
-> **Info** 
+> **Info**
 > USB shell: To just run a few quick commands or test an application connecting to the USB
-> shell is sufficient. **To use it, boot the system without the microSD card inserted** 
+> shell is sufficient. **To use it, boot the system without the microSD card inserted**
 > (with the microSD, the mavlink shell can be used instead, see below).
 > The hardware serial console is only needed for boot debugging or when USB should be used
 > for MAVLink to connect a [GCS](qgroundcontrol-intro.md).

--- a/advanced-system-console.md
+++ b/advanced-system-console.md
@@ -124,6 +124,8 @@ With the Snapdragon connected via USB, open the mini-dm to see the output of the
 ${HEXAGON_SDK_ROOT}/tools/debug/mini-dm/Linux_Debug/mini-dm
 ```
 
+Note: Alternatively, especially on Mac, you can also use [nano-dm](https://github.com/kevinmehall/nano-dm).
+
 Run the main app on the linaro side:
 ```
 cd /home/linaro

--- a/advanced-system-console.md
+++ b/advanced-system-console.md
@@ -121,7 +121,7 @@ The interaction with the DSP side (QuRT) is enabled with the `qshell` posix app 
 
 With the Snapdragon connected via USB, open the mini-dm to see the output of the DSP:
 ```
-${HEXAGON_SDK_ROOT}/tools/mini-dm/Linux_Debug/mini-dm
+${HEXAGON_SDK_ROOT}/tools/debug/mini-dm/Linux_Debug/mini-dm
 ```
 
 Run the main app on the linaro side:

--- a/starting-installing-linux.md
+++ b/starting-installing-linux.md
@@ -156,6 +156,8 @@ Messages from the DSP can be viewed using mini-dm.
 ${HEXAGON_SDK_ROOT}/tools/debug/mini-dm/Linux_Debug/mini-dm
 ```
 
+Note: Alternatively, especially on Mac, you can also use [nano-dm](https://github.com/kevinmehall/nano-dm).
+
 ### Raspberry Pi hardware
 Developers working on Raspberry Pi hardware should download the RPi Linux toolchain from below. The installation script will automatically install the cross-compiler toolchain. If you are looking for the *native* Raspberry Pi toolchain to compile directly on the Pi, see [here](http://dev.px4.io/hardware-pi2.html#native-builds-optional)
 

--- a/starting-installing-linux.md
+++ b/starting-installing-linux.md
@@ -153,7 +153,7 @@ Messages from the DSP can be viewed using mini-dm.
 
 
 ```sh
-$HOME/Qualcomm/Hexagon_SDK/3.0/tools/debug/mini-dm/Linux_Debug/mini-dm
+${HEXAGON_SDK_ROOT}/tools/debug/mini-dm/Linux_Debug/mini-dm
 ```
 
 ### Raspberry Pi hardware


### PR DESCRIPTION
The path to mini-dm was wrong (fixes #61).

Also, for Mac, there is an alternative with [nano-dm](https://github.com/kevinmehall/nano-dm).
