### PR TITLE
preliminary pass at fixing the interfacing with ROS page of the dev guide

### DIFF
--- a/simulation-ros-interface.md
+++ b/simulation-ros-interface.md
@@ -23,18 +23,15 @@ roslaunch mavros px4.launch fcu_url:="udp://:14540@127.0.0.1:14557"
 
 ## Installing Gazebo for ROS
 
-The Gazebo ROS SITL simulation is known to work with Gazebo6 (Gazebo7 did NOT work) which can be installed via:
+The Gazebo ROS SITL simulation is known to work with both Gazebo 6 and Gazebo 7, which can be installed via:
 
 ```sh
-sudo apt-get install ros-indigo-gazebo6-ros
+sudo apt-get install ros-$(ROS_DISTRO)-gazebo7-ros-pkgs    //Recommended
 ```
-
-If other sensor models such as lasers are desired, the Gazebo plugins will also be needed:
-
+or
 ```sh
-sudo apt-get install ros-indigo-gazebo6-plugins
+sudo apt-get install ros-$(ROS_DISTRO)-gazebo6-ros-pkgs
 ```
-
 
 ## Launching Gazebo with ROS wrappers
 
@@ -49,7 +46,7 @@ To run SITL wrapped in ROS the ROS environment needs to be updated, then launch 
 
 ```sh
 cd <Firmware_clone>
-make posix_sitl_default
+make posix_sitl_default gazebo
 source ~/catkin_ws/devel/setup.bash
 source Tools/setup_gazebo.bash $(pwd) build_posix_sitl_default
 export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$(pwd)
@@ -97,7 +94,7 @@ Now in a new terminal make sure you will be able to insert the Iris model throug
 
 ```sh
 cd <Firmware_clone>
-source integrationtests/setup_gazebo_ros.bash $(pwd)
+source Tools/setup_gazebo.bash $(pwd) $(pwd)/build_posix_sitl_default
 ```
 
 Now start Gazebo like you would when working with ROS and insert the Iris quadcopter model. Once the Iris is loaded it will automatically connect to the px4 app.


### PR DESCRIPTION
Fixed obsolete instructions, specifically:
1. Installing Gazebo for ROS, both gazebo 6 and 7 work, and updated package install instructions to be more in line with the official Gazebo ROS installation guide

2. What's happening behind the scenes, fixed obsolete source bash file that has been moved and changed

Signed-off-by: Eric Fang <efang@andrew.cmu.edu>