### PR TITLE
(typo) roll is controlled by aileron

### DIFF
--- a/concept-mixing.md
+++ b/concept-mixing.md
@@ -23,7 +23,7 @@ graph LR;
 
 PX4 uses control groups (inputs) and output groups. Conceptionally they are very simple: A control group is e.g. `attitude`, for the core flight controls, or `gimbal` for payload. An output group is one physical bus, e.g. the first 8 PWM outputs for servos. Each of these groups has 8 normalized (-1..+1) command ports, which can be mapped and scaled through the mixer. A mixer defines how each of these 8 signals of the controls are connected to the 8 outputs.
 
-For a simple plane control 0 (roll) is connected straight to output 0 (elevator). For a multicopter things are a bit different: control 0 (roll) is connected to all four motors and combined with throttle.
+For a simple plane control 0 (roll) is connected straight to output 0 (aileron). For a multicopter things are a bit different: control 0 (roll) is connected to all four motors and combined with throttle.
 
 #### Control Group #0 (Flight Control)
 


### PR DESCRIPTION
I think here is a typo.
Roll is controlled by aileron rather than elevator.