### PR TITLE
rename mavlink messaging and add overview link + stream rate

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -46,7 +46,7 @@
       * [Camera and optical flow](advanced-snapdragon_camera.md)
 * Middleware and Architecture
   * [uORB Messaging](advanced-uorb.md)
-  * [Custom MAVLink Message](custom-mavlink-message.md)
+  * [MAVLink Messaging](mavlink-messaging.md)
   * [Daemons](architecture-daemon.md)
   * [Driver Framework](advanced-drivers.md)
 * Airframes

--- a/mavlink-messaging.md
+++ b/mavlink-messaging.md
@@ -1,4 +1,6 @@
-# Create Custom MAVLink Messages
+# MAVLink Messaging
+An overview of all messages can be found [here](http://mavlink.org/messages/common).
+## Create Custom MAVLink Messages
 This tutorial assumes you have a [custom uORB](advanced-uorb.md) `ca_trajectory`
 message in `msg/ca_trajectory.msg` and a custom mavlink
 `ca_trajectory` message in
@@ -6,7 +8,7 @@ message in `msg/ca_trajectory.msg` and a custom mavlink
 [here](http://qgroundcontrol.org/mavlink/create_new_mavlink_message) how to
 create a custom mavlink message and header).
 
-# Sending Custom MAVLink Messages
+## Sending Custom MAVLink Messages
 This section explains how to use a custom uORB message and send it as a mavlink
 message.
 
@@ -44,7 +46,7 @@ public:
 	{
 		return MAVLINK_MSG_ID_CA_TRAJECTORY_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
-	
+
 private:
 	MavlinkOrbSubscription *_sub;
 	uint64_t _ca_traj_time;
@@ -64,14 +66,14 @@ protected:
 		struct ca_traj_struct_s _ca_trajectory;    //make sure ca_traj_struct_s is the definition of your uorb topic
 
 		if (_sub->update(&_ca_traj_time, &_ca_trajectory)) {
-			mavlink_ca_trajectory_t _msg_ca_trajectory;  //make sure mavlink_ca_trajectory_t is the definition of your custom mavlink message 
-			
+			mavlink_ca_trajectory_t _msg_ca_trajectory;  //make sure mavlink_ca_trajectory_t is the definition of your custom mavlink message
+
 			_msg_ca_trajectory.timestamp = _ca_trajectory.timestamp;
 			_msg_ca_trajectory.time_start_usec = _ca_trajectory.time_start_usec;
 			_msg_ca_trajectory.time_stop_usec  = _ca_trajectory.time_stop_usec;
 			_msg_ca_trajectory.coefficients =_ca_trajectory.coefficients;
 			_msg_ca_trajectory.seq_id = _ca_trajectory.seq_id;
-		
+
 			_mavlink->send_message(MAVLINK_MSG_ID_CA_TRAJECTORY, &_msg_ca_trajectory);
 		}
 	}
@@ -98,7 +100,7 @@ mavlink stream -r 50 -s CA_TRAJECTORY -u 14556
 ```
 
 
-# Receiving Custom MAVLink Messages
+## Receiving Custom MAVLink Messages
 This section explains how to receive a message over mavlink and publish it to
 uORB.
 
@@ -124,7 +126,7 @@ Add an uORB publisher in the `MavlinkReceiver` class in
 orb_advert_t _ca_traj_msg_pub;
 ```
 
-Implement the `handle_message_ca_trajectory_msg` function in [mavlink_receiver.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_receiver.cpp) 
+Implement the `handle_message_ca_trajectory_msg` function in [mavlink_receiver.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_receiver.cpp)
 
 ```C
 void
@@ -165,4 +167,13 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 		...
  	}
 ```
-
+## General
+### Set streaming rate
+Sometimes it is useful to increase the streaming rate of individual topics (e.g. for inspection in QGC). This can be achieved by the following line
+```sh
+mavlink stream -u <port number> -s <mavlink topic name> -r <rate>
+```
+You can get the port number with ```mavlink status``` which will output (amongst others) ```transport protocol: UDP (<port number>)```. An example would be
+```sh
+mavlink stream -u 14556 -s OPTICAL_FLOW_RAD -r 300
+```


### PR DESCRIPTION
I renamed and restructured the mavlink page a bit. Added the link to the overview and added an example of how to change streaming rate