### PR TITLE
Add per page toc using plugin: page-toc-button

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,6 +3,7 @@
         "youtube",
         "richquotes",
         "anchors",
+        "page-toc-button",
         "mermaid",
         "-mermaid-2"
     ],


### PR DESCRIPTION
This plugin adds a floating button near top right of page that you can click to see the TOC for the page. This is very useful for navigation.

There are a number of plugins that do this job, but this is one of the few that is both attractive and works on gitbook.com.