### PR TITLE
Change all use off old-style aside markup to use richquotes plugin

### DIFF
--- a/advanced-configurations.md
+++ b/advanced-configurations.md
@@ -61,9 +61,8 @@ param import /fs/microsd/vtol_param_backup
 
 There is also a C and a separate C++ API which can be used to access parameter values.
 
-<aside class="todo">
-Discuss param C / C++ API.
-</aside>
+> **Todo** Discuss param C / C++ API.
+
 
 <div class="host-code"></div>
 

--- a/advanced-debug-values.md
+++ b/advanced-debug-values.md
@@ -38,9 +38,7 @@ dbg.value = position[0];
 orb_publish(ORB_ID(debug_key_value), pub_dbg, &dbg);
 ```
 
-<aside class="caution">
-Multiple debug messages must have enough time between their respective publishings for Mavlink to process them. This means that either the code must wait between publishing multiple debug messages, or alternate the messages on each function call iteration.
-</aside>
+> **Caution** Multiple debug messages must have enough time between their respective publishings for Mavlink to process them. This means that either the code must wait between publishing multiple debug messages, or alternate the messages on each function call iteration.
 
 The result in QGroundControl then looks like this on the real-time plot:
 

--- a/advanced-drivers.md
+++ b/advanced-drivers.md
@@ -2,9 +2,8 @@
 
 The PX4 codebase uses a lightweight, unified driver abstraction layer: [DriverFramework](https://github.com/px4/DriverFramework). New drivers for POSIX and [QuRT](https://en.wikipedia.org/wiki/Qualcomm_Hexagon) are written against this framework.
 
-<aside class="todo">
-Legacy drivers for NuttX are based on the [Device](https://github.com/PX4/Firmware/tree/master/src/drivers/device) framework and will be ported to DriverFramework.
-</aside>
+> **Todo** Legacy drivers for NuttX are based on the [Device](https://github.com/PX4/Firmware/tree/master/src/drivers/device) framework and will be ported to DriverFramework.
+
 
 ## Core Architecture
 

--- a/advanced-faq.md
+++ b/advanced-faq.md
@@ -5,9 +5,8 @@
 
 ### Flash Overflow
 
-<aside class="tip">
-Use the FMUv4 architecture to obtain double the flash. The first available board from this generation is the [Pixracer](http://dev.px4.io/hardware-pixracer.html).
-</aside>
+> **Tip** Use the FMUv4 architecture to obtain double the flash. The first available board from this generation is the [Pixracer](http://dev.px4.io/hardware-pixracer.html).
+
 
 The amount of code that can be loaded onto a board is limited by the amount of flash memory it has. When adding additional modules or code its possible that the addition exceeds the flash memory. This will result in a "flash overflow". The upstream version will always build, but depending on what a developer adds it might overflow locally.
 

--- a/advanced-snapdragon.md
+++ b/advanced-snapdragon.md
@@ -40,7 +40,7 @@ For this step the Flight_BSP zip file from Intrynsic is required. It can be obta
 
 ### Upgrading/replacing the Linux image
 
-<aside class="caution">Flashing the Linux image will erase everything on the Snapdragon. Back up your work before you perform this step!</aside>
+> **Caution** Flashing the Linux image will erase everything on the Snapdragon. Back up your work before you perform this step!
 
 Make sure the board can be found using adb:
 
@@ -74,7 +74,7 @@ It is normal that the partitions `recovery`, `update`, and `factory` will fail.
 
 Part of the PX4 stack is running on the ADSP (the DSP side of the Snapdragon 8074). The underlying operating system QURT needs to be updated separately.
 
-<aside class="caution">If anything goes wrong during the ADSP firmware update, your Snapdragon can get bricked! Follow the steps below carefully which should prevent bricking in most cases.</aside>
+> **Caution** If anything goes wrong during the ADSP firmware update, your Snapdragon can get bricked! Follow the steps below carefully which should prevent bricking in most cases.
 
 First of all, if you're not already on BSP 3.1.1, [upgrade the Linux image](#upgradingreplacing-the-linux-image)!
 
@@ -154,7 +154,7 @@ The APIs to set up and use the UART are described in [dspal](https://github.com/
 
 ## Wifi-settings
 
-<aside class="todo">These are notes for advanced developers.</aside>
+> **Todo** These are notes for advanced developers.
 
 Connect to the Linux shell (see [console instructions](advanced-system-console.html#snapdragon-flight-wiring-the-console)).
 

--- a/advanced-system-startup.md
+++ b/advanced-system-startup.md
@@ -10,9 +10,7 @@ The remaining files are part of the general startup logic, and the first execute
 
 A failure of a driver of software component can lead to an aborted boot.
 
-<aside class="tip">
-An incomplete boot often materializes as missing parameters in the ground control stations, because the non-started applications did not initialize their parameters.
-</aside>
+> **Tip** An incomplete boot often materializes as missing parameters in the ground control stations, because the non-started applications did not initialize their parameters.
 
 The right approach to debug the boot sequence is to connect the [system console](advanced-system-console.md) and power-cycle the board. The resulting boot log has detailed information about the boot sequence and should contain hints why the boot aborted.
 
@@ -30,9 +28,7 @@ In most cases customizing the default boot is the better approach, which is docu
 
 The best way to customize the system startup is to introduce a [new airframe configuration](airframes-adding-a-new-frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
 
-<aside class="caution">
-The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
-</aside>
+> **Caution** The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
 
 There are three main hooks. Note that the root folder of the microsd card is identified by the path `/fs/microsd`.
 

--- a/advanced-uorb.md
+++ b/advanced-uorb.md
@@ -43,9 +43,7 @@ the same process as it's later published.
 
 ## Listing Topics and Listening in
 
-<aside class="note">
-The 'listener' command is only available on Pixracer (FMUv4) and Linux / OS X.
-</aside>
+> **Note** The 'listener' command is only available on Pixracer (FMUv4) and Linux / OS X.
 
 To list all topics, list the file handles:
 

--- a/airframes-adding-a-new-frame.md
+++ b/airframes-adding-a-new-frame.md
@@ -77,9 +77,7 @@ IMPORTANT REMARK: If you want to reverse a channel, never do this neither on you
 
 A typical configuration file is below. 
 
-<aside class="note">
-The plugs of the servos / motors go in the order of the mixers in this file.
-</aside>
+> **Note** The plugs of the servos / motors go in the order of the mixers in this file.
 
 So MAIN1 would be the left aileron, MAIN2 the right aileron, MAIN3 is empty (note the Z: zero mixer) and MAIN4 is throttle (to keep throttle on output 4 for common fixed wing configurations).
 

--- a/airframes-motor-map.md
+++ b/airframes-motor-map.md
@@ -2,9 +2,7 @@
 
 The motor maps below indicate which `MAIN` output connects to which motor. It also indicates the turn direction of the propeller.
 
-<aside class="tip">
-The turn direction of a 3-phase motor can be reversed by flipping any two of the three connected wires.
-</aside>
+> **Tip** The turn direction of a 3-phase motor can be reversed by flipping any two of the three connected wires.
 
 ## Quadrotor X Layout
 
@@ -30,6 +28,4 @@ The turn direction of a 3-phase motor can be reversed by flipping any two of the
 
 ![Octorotor Plus Layout](images/motor_map/octorotor_plus_assignment.png)
 
-<aside class="todo">
-Tricopters and coaxial hexacopters are supported as well, but we have no graphics yet.
-</aside>
+> **Todo** Tricopters and coaxial hexacopters are supported as well, but we have no graphics yet.

--- a/airframes-plane-wing-z-84.md
+++ b/airframes-plane-wing-z-84.md
@@ -2,9 +2,7 @@
 
 ## Parts List
 
-<aside class="note">
-Ensure to order the PNF version which includes motor, propeller and electronic speed controller. The kit version requires these to be purchased individually.
-</aside>
+> **Note** Ensure to order the PNF version which includes motor, propeller and electronic speed controller. The kit version requires these to be purchased individually.
 
   * Zeta Science Wing-Wing Z-84 *PNF* ([Hobbyking Store](http://hobbyking.com/hobbyking/store/RC_PRODUCT_SEARCH.asp?strSearch=z-84))
   * 1800 mAh 2S LiPo

--- a/airframes-vtol-testing.md
+++ b/airframes-vtol-testing.md
@@ -15,15 +15,11 @@ There are currently 3 ways of commanding the VTOL to transition:
 
 When a transition is commanded (by either of the methods above), the VTOL enters the transition phase. If the VTOL receives a new transition command back to the old state during an ongoing transition it will switch back instantly. This is a safety feature to abort the transition when necessary. After the transition has been completed, the VTOL will be in the new state and a commanded transition into the reverse direction will take place normally.
 
-<aside class="note">
-Make sure the AUX1 channel is assigned to an RC switch and that airspeed is working properly.
-</aside>
+> **Note** Make sure the AUX1 channel is assigned to an RC switch and that airspeed is working properly.
 
 ## On the bench
 
-<aside class="caution">
-Remove all props! To test transition functionality properly, the vehicle needs to be armed.
-</aside>
+> **Caution** Remove all props! To test transition functionality properly, the vehicle needs to be armed.
 
 By default, starting in multirotor mode:
 
@@ -40,9 +36,7 @@ By default, starting in multirotor mode:
 
 ## In flight
 
-<aside class="tip">
-Before testing transitions in flight, make sure the VTOL flies stable in multirotor mode. In general, if something doesn't go as planned, transition to multirotor mode and let it recover (it does a good job when it's properly tuned).
-</aside>
+> **Tip** Before testing transitions in flight, make sure the VTOL flies stable in multirotor mode. In general, if something doesn't go as planned, transition to multirotor mode and let it recover (it does a good job when it's properly tuned).
 
 In-flight transition requires at least the following parameters to match your airframe and piloting skills:
 

--- a/airframes-vtol.md
+++ b/airframes-vtol.md
@@ -8,9 +8,8 @@ The [PX4 Flight Stack](concept-flight-stack.md) supports virtually all VTOL conf
 
 The VTOL codebase is the same codebase as for all other airframes and just adds additional control logic, in particular for transitions.
 
-<aside class="note">
-All these VTOL configurations have been actively test-flown and are ready to use. Ensure to have an airspeed sensor attached to the system as its used by the autopilot when its safe to perform the transition.
-</aside>
+> **Note** All these VTOL configurations have been actively test-flown and are ready to use. Ensure to have an airspeed sensor attached to the system as its used by the autopilot when its safe to perform the transition.
+
 
 ## Key Configuration Parameters
 

--- a/book.json
+++ b/book.json
@@ -7,5 +7,14 @@
         "mermaid",
         "-mermaid-2"
     ],
-    "pluginsConfig": {}
+    "pluginsConfig":
+    {
+        "richquotes":
+        {
+            "star": {
+                "tip": "hint",
+                "todo": "caution"
+            }
+        }
+    }
 }

--- a/hardware-pixracer.md
+++ b/hardware-pixracer.md
@@ -42,9 +42,8 @@ The Pixracer is designed to use a separate avionics power supply. This is necess
 
 One of the main features of the board is its ability to use Wifi for flashing new firmware, system setup and in-flight telemetry. This frees it of the need of any desktop system.
 
-<aside class="todo">
-Setup and telemetry are already available, firmware upgrade is already supported by the default bootloader but not yet enabled
-</aside>
+> **Todo** Setup and telemetry are already available, firmware upgrade is already supported by the default bootloader but not yet enabled
 
-  * [ESP8266 Documentation and Flash Instructions](https://pixhawk.org/peripherals/8266)
-  * [Custom ESP8266 MAVLink firmware](https://github.com/dogmaphobic/mavesp8266)
+
+* [ESP8266 Documentation and Flash Instructions](https://pixhawk.org/peripherals/8266)
+* [Custom ESP8266 MAVLink firmware](https://github.com/dogmaphobic/mavesp8266)

--- a/hardware-rpi.md
+++ b/hardware-rpi.md
@@ -95,9 +95,7 @@ sudo /etc/init.d/avahi-daemon restart
 And that's it. You should be able to access your Pi directly by its hostname from any computer on the network.
 
 
-<aside class="tip">
-You might have to add .local to the hostname to discover it.
-</aside>
+> **Tip** You might have to add .local to the hostname to discover it.
 
 ### Configuring a SSH Public-Key
 

--- a/hardware-snapdragon.md
+++ b/hardware-snapdragon.md
@@ -57,9 +57,7 @@ Details on wiring can be found below.
 
 ## Pinouts
 
-<aside class="warning">
-Although the Snapdragon uses DF13 connectors, the pinout is different from Pixhawk.
-</aside>
+> **Warning** Although the Snapdragon uses DF13 connectors, the pinout is different from Pixhawk.
 
 Detailed pinout information can be found here: [Qualcomm Developer Network](https://developer.qualcomm.com/hardware/snapdragon-flight/board-pin-outs).
 

--- a/qgroundcontrol-intro.md
+++ b/qgroundcontrol-intro.md
@@ -27,9 +27,7 @@ Switch to the setup tab. Scroll the menu on the left all the way to the bottom a
 
 QGroundControl can be downloaded from its [website](http://qgroundcontrol.com/downloads).
 
-<aside class="tip">
-Developers are advised to use the latest daily build instead of the stable release.
-</aside>
+> **Tip** Developers are advised to use the latest daily build instead of the stable release.
 
 ## Building from source
 

--- a/ros-mavros-installation.md
+++ b/ros-mavros-installation.md
@@ -57,6 +57,5 @@ $ rosdep install --from-paths src --ignore-src --rosdistro indigo -y
     # finally - build
 $ catkin build
 ```
-<aside class="note">
-If you are installing mavros on a raspberry pi, you may get an error related to your os, when running "rosdep install ...". Add "--os=OS_NAME:OS_VERSION " to the rosdep command and replace OS_NAME with your OS name and OS_VERSION with your OS version (e.g. --os=debian:jessie).
-</aside>
+
+> **Note** If you are installing mavros on a raspberry pi, you may get an error related to your os, when running "rosdep install ...". Add "--os=OS_NAME:OS_VERSION " to the rosdep command and replace OS_NAME with your OS name and OS_VERSION with your OS version (e.g. --os=debian:jessie).

--- a/ros-mavros-offboard.md
+++ b/ros-mavros-offboard.md
@@ -1,8 +1,6 @@
 # MAVROS offboard control example
 
-<aside class="caution">
-Offboard control is dangerous. If you are operating on a real vehicle be sure to have a way of gaining back manual control in case something goes wrong.
-</aside>
+> **Caution** Offboard control is dangerous. If you are operating on a real vehicle be sure to have a way of gaining back manual control in case something goes wrong.
 
 The following tutorial will run through the basics of offboard control through mavros as applied to an Iris quadcopter simulated in Gazebo. At the end of the tutorial, you should see the same behaviour as in the video below, i.e. a slow takeoff to an altitude of 2 meters.
 
@@ -195,6 +193,4 @@ while(ros::ok()){
 ```
 The rest of the code is pretty self explanatory. We attempt to switch to offboard mode after which we arm the quad to allow it to fly. We space out the service calls by 5 seconds so as to not flood the autopilot with the requests. In the same loop we continue sending the requested pose at the appropriate rate.
 
-<aside class="tip">
-This code has been simplified to the bare minimum for illustration purposes. In larger systems, it is often useful to create a new thread which will be in charge of periodically publishing the setpoint.
-</aside>
+> **Tip** This code has been simplified to the bare minimum for illustration purposes. In larger systems, it is often useful to create a new thread which will be in charge of periodically publishing the setpoint.

--- a/simulation-debugging.md
+++ b/simulation-debugging.md
@@ -23,9 +23,7 @@ or
 sudo apt-get install valgrind
 ```
 
-<aside class="todo">
-Add instructions how to run Valgrind
-</aside>
+> **Todo** Add instructions how to run Valgrind
 
 ## Start combinations
 

--- a/simulation-gazebo-octomap.md
+++ b/simulation-gazebo-octomap.md
@@ -30,9 +30,8 @@ Open ~/catkin_ws/src/rotors_simulator/rotors_gazebo/package.xml and add the foll
 ```
 
 Run the following two lines. 
-<aside class="note">
-The first line changes your default shell editor (which is vim by default) to gedit. This is recommended for users who have little experience with vim, but can otherwise be omitted.
-</aside>
+
+> **Note** The first line changes your default shell editor (which is vim by default) to gedit. This is recommended for users who have little experience with vim, but can otherwise be omitted.
 
 <div class="host-code"></div>
 ```sh

--- a/starting-advanced-configuration.md
+++ b/starting-advanced-configuration.md
@@ -2,9 +2,7 @@
 
 The advanced system configuration is performed through [QGroundControl](qgroundcontrol-intro.md).
 
-<aside class="tip">
-[Download the DAILY BUILD of QGroundControl](http://qgroundcontrol.com/downloads) in regular intervals to stay up to date.
-</aside>
+> **Tip** [Download the DAILY BUILD of QGroundControl](http://qgroundcontrol.com/downloads) in regular intervals to stay up to date.
 
 ## Setting Configuration Parameters
 

--- a/starting-installing-linux-boutique.md
+++ b/starting-installing-linux-boutique.md
@@ -4,9 +4,8 @@
 
 Linux users need to explicitly allow access to the USB bus for JTAG programming adapters.
 
-<aside class="note">
-For Archlinux: replace the group plugdev with uucp in the following commands
-</aside>
+> **Note** For Archlinux: replace the group plugdev with uucp in the following commands
+
 
 Run a simple ls in sudo mode to ensure the commands below succeed:
 
@@ -88,9 +87,9 @@ Then you will also need to install other 32-bit libraries glibc.i686 ncurses-lib
 ```sh
 sudo yum install glibc.i686 ncurses-libs.i686
 ```
-<aside class="note">
-Pulling in ncurses-libs.i686 will pull in most of the other required 32 bit libraries. Centos 7 will install most all the PX4 related devices without the need for any added udev rules. The devices will be accessible to the predefined group ' dialout'. Therefore any references to adding udev rules can be ignored. The only requirement is that your user account is a member of the group 'dial out'
-</aside>
+
+> **Note** Pulling in ncurses-libs.i686 will pull in most of the other required 32 bit libraries. Centos 7 will install most all the PX4 related devices without the need for any added udev rules. The devices will be accessible to the predefined group ' dialout'. Therefore any references to adding udev rules can be ignored. The only requirement is that your user account is a member of the group 'dial out'
+
 
 ### Arch Linux
 
@@ -123,9 +122,7 @@ sudo usermod -a -G uucp $USER
 After that, logging out and logging back in is needed.
 
 
-<aside class="note">
-Log out and log in for changes to take effect! Also remove the device and plug it back in!**
-</aside>
+> **Note** Log out and log in for changes to take effect! Also remove the device and plug it back in!**
 
 ### Toolchain Installation
 

--- a/tutorial-hello-sky.md
+++ b/tutorial-hello-sky.md
@@ -34,9 +34,7 @@ Create a new C file named `px4_simple_app.c` in the `px4_simple_app` folder (it 
 
 Edit it and start with the default header and a main function.
 
-<aside class="tip">
-Note the code style in this file - all contributions to PX4 should adhere to it.
-</aside>
+> **Tip** Note the code style in this file - all contributions to PX4 should adhere to it.
 
 ```C
 /****************************************************************************

--- a/tutorial-integration-testing.md
+++ b/tutorial-integration-testing.md
@@ -28,9 +28,7 @@ rostest px4 mavros_posix_tests_iris.launch gui:=true headless:=false
 
 ### Write a new MAVROS test (Python)
 
-<aside class="note">
-Currently in early stages, more streamlined support for testing (helper classes/methods etc.) to come.
-</aside>
+> **Note** Currently in early stages, more streamlined support for testing (helper classes/methods etc.) to come.
 
 ####1.) Create a new test script
 

--- a/uavcan-bootloader-installation.md
+++ b/uavcan-bootloader-installation.md
@@ -1,8 +1,6 @@
 # UAVCAN Bootloader Installation
 
-<aside class="warning">
-UAVCAN devices typically ship with a bootloader pre-installed. Do not follow the instructions in this section unless you are developing UAVCAN devices.
-</aside>
+> **Warning** UAVCAN devices typically ship with a bootloader pre-installed. Do not follow the instructions in this section unless you are developing UAVCAN devices.
 
 ## Overview
 

--- a/uavcan-node-enumeration.md
+++ b/uavcan-node-enumeration.md
@@ -1,8 +1,6 @@
 # UAVCAN Enumeration and Configuration
 
-<aside class="note">
-Enable UAVCAN as the default motor output bus by ticking the 'Enable UAVCAN' checkbox as shown below. Alternatively the UAVCAN_ENABLE parameter can be set to '3' in the QGroundControl parameter editor. Set it to '2' to enable CAN, but leave motor outputs on PWM.
-</aside>
+> **Note** Enable UAVCAN as the default motor output bus by ticking the 'Enable UAVCAN' checkbox as shown below. Alternatively the UAVCAN_ENABLE parameter can be set to '3' in the QGroundControl parameter editor. Set it to '2' to enable CAN, but leave motor outputs on PWM.
 
 Use [QGroundControl](qgroundcontrol-intro.md) and switch to the Setup view. Select the Power Configuration on the left. Click on the 'start assignment' button.
 


### PR DESCRIPTION
This changes all files to use the [richquotes syntax](https://www.npmjs.com/package/gitbook-plugin-richquotes). Even though richquotes currently have a bug #92 , this makes it easier for quote markup to show up, as it renders as quote by default. 