### PR TITLE
Add plugin to enable favicon for docs

### DIFF
--- a/book.json
+++ b/book.json
@@ -8,7 +8,8 @@
         "-mermaid-2",
         "github",
         "language-picker",
-        "language-redirect@git+https://github.com/hamishwillee/gitbook-plugin-language-redirect.git"
+        "language-redirect@git+https://github.com/hamishwillee/gitbook-plugin-language-redirect.git",
+        "custom-favicon"
     ],
     "pluginsConfig":
     {
@@ -26,7 +27,8 @@
         },
         "github": {
             "url": "https://github.com/PX4/Devguide"
-        }
+        },
+        "favicon": "favicon.ico"
 
 
     }


### PR DESCRIPTION
The favicon.ico file is already present (not very high res - we probably should get a better one). All this does is use the [custom-favicon](https://www.npmjs.com/package/gitbook-plugin-custom-favicon) plugin to ensure it is displayed (basically it copies a specified file to replace the default theme favicon in the output).