### PR TITLE
Remove the redirect from root

### DIFF
--- a/book.json
+++ b/book.json
@@ -9,8 +9,7 @@
         "github",
         "language-picker",
         "custom-favicon",
-        "bulk-redirect",
-        "redirect-root@git+https://github.com/hamishwillee/gitbook-plugin-redirect-root.git"
+        "bulk-redirect"
     ],
     "pluginsConfig":
     {
@@ -33,10 +32,6 @@
         "bulk-redirect": {
             "basepath": "/",
             "redirectsFile": "redirects.json"
-        },
-
-        "redirect-root": {
-            "url":"https://dev.px4.io/en/"
         }
         
     }


### PR DESCRIPTION
The plugin replaces the root index.html with a redirect. Unfortunately the language switcher uses this file to get the list of languages. Need to remove plugin and revisit.