### PR TITLE
Add edit on github, create bug report toolbar icons

### DIFF
--- a/book.json
+++ b/book.json
@@ -6,10 +6,10 @@
         "page-toc-button",
         "mermaid",
         "-mermaid-2",
-        "github",
         "language-picker",
         "custom-favicon",
-        "bulk-redirect"
+        "bulk-redirect",
+        "toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git"
     ],
     "pluginsConfig":
     {
@@ -25,13 +25,33 @@
         "language-redirect": {
             "baseurl": "https://dev.px4.io/"
         },
-        "github": {
-            "url": "https://github.com/PX4/Devguide"
-        },
         "favicon": "favicon.ico",
         "bulk-redirect": {
             "basepath": "/",
             "redirectsFile": "redirects.json"
+        },
+        "toolbar": {
+            "buttons":
+            [
+                {
+                    "label": "Bug tracker",
+                    "icon": "fa fa-bug",
+                    "position" : "left",
+                    "url": "https://github.com/PX4/Devguide/issues/new?title=Doc+Bug:+{{title}}&body=DESCRIBE+PROBLEM+WITH+DOCS+HERE%0A%0ABug+Page:+[{{title}}]({{url}})"
+                    
+                },
+                {
+                    "label": "GitHub",
+                    "icon": "fa fa-github",
+                    "url": "https://github.com/PX4/Devguide"
+                },
+                {
+                    "label": "Edit page on github",
+                    "icon": "fa fa-pencil-square-o",
+                    "position" : "left",
+                    "url": "https://github.com/PX4/Devguide/edit/master/{{filepath_lang}}"
+                }
+            ]
         }
         
     }


### PR DESCRIPTION
This adds icons for:
* editing the current page (clicking link takes you to the page on gitbook master
* creating a bug in the associated repo (clicking the link opens a new bug, seeded with the doc title and link)

![image](https://cloud.githubusercontent.com/assets/5368500/25600891/e25120c8-2f2a-11e7-8f35-d5b2b1477d4f.png)

The change uses a modified version of the [toolbar](https://www.npmjs.com/package/gitbook-plugin-toolbar/tutorial) plugin. The modifications were required in order to be able to define a link to the page for editing on github. 

It also removes the github plugin (that formerly added a link to the repo) and we just use the toolbar plugin to create that link. 