### PR TITLE
Update Aero naming in line with Intel branding

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -6,7 +6,7 @@ This guide describes how to work inside the PX4 system architecture. It enables 
 
 * Get an [overview of the system](setup/config_initial.md)
 * Access and modify the [PX4 Flight Stack](concept/flight_stack.md) and [PX4 Middleware](concept/middleware.md)
-* Deploy PX4 on Intel [Aero](flight_controller/intel_aero.md), Qualcomm [Snapdragon Flight](flight_controller/snapdragon_flight.md), [Pixhawk](flight_controller/pixhawk.md), [Pixfalcon](flight_controller/pixfalcon.md) and many more autopilots.
+* Deploy PX4 on [Intel® Aero Ready to Fly Drone](flight_controller/intel_aero.md), [Qualcomm Snapdragon Flight](flight_controller/snapdragon_flight.md), [Pixhawk](flight_controller/pixhawk.md), [Pixfalcon](flight_controller/pixfalcon.md) and many more autopilots.
 
 ## Contributing
 

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -40,7 +40,7 @@
   * [Land Detector](tutorials/land_detector.md)
 * [Autopilot Hardware](flight_controller/README.md)
   * [Crazyflie 2.0](flight_controller/crazyflie2.md)
-  * [Intel Aero](flight_controller/intel_aero.md)
+  * [Intel® Aero Ready to Fly Drone](flight_controller/intel_aero.md)
   * [Pixfalcon](flight_controller/pixfalcon.md)
   * [Pixhawk](flight_controller/pixhawk.md)
   * [Pixracer](flight_controller/pixracer.md)

--- a/en/flight_controller/intel_aero.md
+++ b/en/flight_controller/intel_aero.md
@@ -1,10 +1,10 @@
-# Intel Aero RTF
+# Intel® Aero Ready to Fly Drone
 
-The Aero RTF is a UAV development platform. Part of this is the [Intel Aero
+The Intel® Aero Ready to Fly Drone is a UAV development platform. Part of this is the [Intel Aero
 Compute Board](https://software.intel.com/en-us/aero/dev-kit), running Linux on
 a Quad-core CPU. The other part is an STM32 microcontroller that is connected
 to it and that runs PX4 on NuttX. These are integrated in the same package on
-the [RTF](https://software.intel.com/en-us/aero/drone-dev-kit), which also includes
+the [Intel® Aero Ready to Fly Drone](https://software.intel.com/en-us/aero/drone-dev-kit), which also includes
 the vision accessory kit.
 
 

--- a/en/log/logging.md
+++ b/en/log/logging.md
@@ -85,7 +85,7 @@ https://github.com/PX4/Firmware/issues/4634.
 The traditional and still fully supported way to do logging is using an SD card
 on the FMU. However there is an alternative, log streaming, which sends the
 same logging data via MAVLink. This method can be used for example in cases
-where the FMU does not have an SD card slot (eg. Intel Aero) or simply to avoid
+where the FMU does not have an SD card slot (e.g. Intel® Aero Ready to Fly Drone) or simply to avoid
 having to deal with SD cards. Both methods can be used independently and at the
 same time.
 

--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -20,8 +20,8 @@ Update the package list and install the following dependencies for all PX4 build
 
 * NuttX based hardware: [Pixhawk](../flight_controller/pixhawk.md), [Pixfalcon](../flight_controller/pixfalcon.md),
   [Pixracer](../flight_controller/pixracer.md), [Crazyflie](../flight_controller/crazyflie2.md),
-  [Intel Aero](../flight_controller/intel_aero.md)
-* Snapdragon Flight hardware: [Snapdragon](../flight_controller/snapdragon_flight.md)
+  [Intel® Aero Ready to Fly Drone](../flight_controller/intel_aero.md)
+* [Qualcomm Snapdragon Flight hardware](../flight_controller/snapdragon_flight.md)
 * Linux-based hardware: [Raspberry Pi 2/3](../flight_controller/raspberry_pi.md), Parrot Bebop
 * Host simulation: [jMAVSim SITL](../simulation/sitl.md) and [Gazebo SITL](../simulation/gazebo.md)
 

--- a/zh/README.md
+++ b/zh/README.md
@@ -13,7 +13,7 @@ translated_sha: 95b39d747851dd01c1fe5d36b24e59ec865e323e
 
 * 了解[系统的概况](setup/config_initial.md)。 
 * 获取和修改[PX4飞行栈](concept/flight_stack.md)和[PX4中间件](concept/middleware.md)。 
-* 在[IntelAero](flight_controller/intel_aero.md)、[高通骁龙飞控](flight_controller/snapdragon_flight.md)、[Pixhawk](flight_controller/pixhawk.md)和[Pixfalcon](flight_controller/pixfalcon.md)以及其他一些自驾仪上部署PX4。
+* 在[Intel® Aero Ready to Fly Drone](flight_controller/intel_aero.md)、[高通骁龙飞控](flight_controller/snapdragon_flight.md)、[Pixhawk](flight_controller/pixhawk.md)和[Pixfalcon](flight_controller/pixfalcon.md)以及其他一些自驾仪上部署PX4。
 
 ## 贡献
 

--- a/zh/SUMMARY.md
+++ b/zh/SUMMARY.md
@@ -39,7 +39,7 @@
   * [AirSim仿真](simulation/airsim.md)
 * [自驾仪硬件](flight_controller/README.md)
   * [Crazyflie 2.0](flight_controller/crazyflie2.md)
-  * [Intel Aero](flight_controller/intel_aero.md)
+  * [Intel® Aero Ready to Fly Drone](flight_controller/intel_aero.md)
   * [Pixfalcon](flight_controller/pixfalcon.md)
   * [Pixhawk](flight_controller/pixhawk.md)
   * [Pixracer](flight_controller/pixracer.md)

--- a/zh/flight_controller/intel_aero.md
+++ b/zh/flight_controller/intel_aero.md
@@ -3,13 +3,13 @@ translated_page: https://github.com/PX4/Devguide/blob/master/en/flight_controlle
 translated_sha: 95b39d747851dd01c1fe5d36b24e59ec865e323e
 ---
 
-# Intel Aero RTF
+# Intel® Aero Ready to Fly Drone
 
-The Aero RTF is a UAV development platform. Part of this is the [Intel Aero
+The Intel® Aero Ready to Fly Drone is a UAV development platform. Part of this is the [Intel Aero
 Compute Board](https://software.intel.com/en-us/aero/dev-kit), running Linux on
 a Quad-core CPU. The other part is an STM32 microcontroller that is connected
 to it and that runs PX4 on NuttX. These are integrated in the same package on
-the [RTF](https://software.intel.com/en-us/aero/drone-dev-kit), which also includes
+the [Intel® Aero Ready to Fly Drone](https://software.intel.com/en-us/aero/drone-dev-kit), which also includes
 the vision accessory kit.
 
 

--- a/zh/log/logging.md
+++ b/zh/log/logging.md
@@ -90,7 +90,7 @@ https://github.com/PX4/Firmware/issues/4634.
 The traditional and still fully supported way to do logging is using an SD card
 on the FMU. However there is an alternative, log streaming, which sends the
 same logging data via MAVLink. This method can be used for example in cases
-where the FMU does not have an SD card slot (eg. Intel Aero) or simply to avoid
+where the FMU does not have an SD card slot (e.g. Intel® Aero Ready to Fly Drone) or simply to avoid
 having to deal with SD cards. Both methods can be used independently and at the
 same time.
 

--- a/zh/setup/dev_env_linux.md
+++ b/zh/setup/dev_env_linux.md
@@ -28,8 +28,8 @@ sudo usermod -a -G dialout $USER
 
 * NuttX based hardware: [Pixhawk](../flight_controller/pixhawk.md), [Pixfalcon](../flight_controller/pixfalcon.md),
   [Pixracer](../flight_controller/pixracer.md), [Crazyflie](../flight_controller/crazyflie2.md),
-  [Intel Aero](../flight_controller/intel_aero.md)
-* Snapdragon Flight hardware: [Snapdragon](../flight_controller/snapdragon_flight.md)
+  [Intel® Aero Ready to Fly Drone](../flight_controller/intel_aero.md)
+* [Qualcomm Snapdragon Flight hardware](../flight_controller/snapdragon_flight.md)
 * Linux-based hardware: [Raspberry Pi 2/3](../flight_controller/raspberry_pi.md)、, Parrot Bebop
 * Host simulation: [jMAVSim SITL](../simulation/sitl.md) and [Gazebo SITL](../simulation/gazebo.md)
 


### PR DESCRIPTION
Intel requested we use proper branding for the aero: 

"For the underlying page title and body copy please again say “Intel® Aero Ready to Fly Drone”  Let’s please not abbreviate it to RTF in title or body copy.