### PR TITLE
Disable anchors plugin to enable notes, tips etc to display properly

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,7 +2,7 @@
     "plugins": [
         "youtube",
         "richquotes",
-        "anchors",
+        "-anchors",
         "page-toc-button",
         "mermaid",
         "-mermaid-2",


### PR DESCRIPTION
See #92 for reasoning. This will allow notes to display. It will disable the little icon that you can select next to a heading to copy an anchor. 

Note, you can still copy the anchor from the page TOC.