### PR TITLE
Instructions for required python packages

### DIFF
--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -34,6 +34,9 @@ sudo apt-get install python-argparse git-core wget zip \
     python-empy qtcreator cmake build-essential genromfs -y
 # simulation tools
 sudo apt-get install ant protobuf-compiler libeigen3-dev libopencv-dev openjdk-8-jdk openjdk-8-jre clang-3.5 lldb-3.5 -y
+# required python packages
+sudo apt-get install python-pip
+sudo -H pip install pyserial empy pandas jinja2
 ```
 
 ### NuttX based hardware

--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -36,7 +36,7 @@ sudo apt-get install python-argparse git-core wget zip \
 sudo apt-get install ant protobuf-compiler libeigen3-dev libopencv-dev openjdk-8-jdk openjdk-8-jre clang-3.5 lldb-3.5 -y
 # required python packages
 sudo apt-get install python-pip
-sudo -H pip install pyserial empy pandas jinja2
+sudo -H pip install pandas jinja2
 ```
 
 ### NuttX based hardware


### PR DESCRIPTION
New installed Ubuntu doesn't come with these required packages.
It's the same as in [Mac OS instruction](https://dev.px4.io/en/setup/dev_env_mac.html).