### PR TITLE
/*clarifications and correcting one bug*/

### DIFF
--- a/en/airframes/adding_a_new_frame.md
+++ b/en/airframes/adding_a_new_frame.md
@@ -71,11 +71,11 @@ set PWM_OUT 4
 set PWM_DISARMED 1000
 ```
 
-IMPORTANT REMARK: If you want to reverse a channel, never do this neither on your RC transmitter nor with e.g `RC1_REV`. The channels are only reversed when flying in manual mode, when you switch in an autopilot flight mode, the channels output will still be wrong (it only inverts your RC signal). Thus for a correct channel assignment change either your PWM signals with `PWM_MAIN_REV1` (e.g. for channel one) or change the signs for both output scaling and output range in the corresponding mixer (see below). 
+IMPORTANT REMARK: If you want to reverse a channel, never do this on your RC transmitter or with e.g `RC1_REV`. The channels are only reversed when flying in manual mode, when you switch in an autopilot flight mode, the channels output will still be wrong (it only inverts your RC signal). Thus for a correct channel assignment change either your PWM signals with `PWM_MAIN_REV1` (e.g. for channel one) or change the signs of the output scaling in the corresponding mixer (see below).
 
 ### Mixer file
 
-A typical configuration file is below. 
+A typical configuration file is below. Note that the mixer file contains several blocks of code, each of which refers to one actuator or ESC. So if you have e.g. two servos and one ESC, the mixer file will contain three blocks of code. 
 
 > **Note** The plugs of the servos / motors go in the order of the mixers in this file.
 
@@ -93,11 +93,11 @@ S: 0 1   6500   6500      0 -10000  10000
 Where each number from left to right means:
 
   * M: Indicates two scalers for two inputs
-  * O: Indicates the output scaling (*1 in negative, *1 in positive), offset (zero here), and output range (-1..+1 here).  If you want to invert your PWM signal, the signs for both output scalings and both output range numbers have to be changed. (```O:      -10000  -10000      0 10000  -10000```)
+  * O: Indicates the output scaling (*1 in negative, *1 in positive), offset (zero here), and output range (-1..+1 here).  If you want to invert your PWM signal, the signs of the output scalings has to be changed. (```O:      -10000  -10000      0 -10000  10000```)
   * S: Indicates the first input scaler: It takes input from control group #0 (attitude controls) and the first input (roll). It scales the input * 0.6 and reverts the sign (-0.6 becomes -6000 in scaled units). It applies no offset (0) and outputs to the full range (-1..+1)
   * S: Indicates the second input scaler: It takes input from control group #0 (attitude controls) and the second input (pitch). It scales the input * 0.65 and reverts the sign (-0.65 becomes -6500 in scaled units). It applies no offset (0) and outputs to the full range (-1..+1)
 
-Both scalers are added, which for a flying wing means the control surface takes maximum 60% deflection from roll and 65% deflection from pitch. As it is over-committed with 125% total deflection for maximum pitch and roll, it means the first channel (roll here) has priority over the second channel / scaler (pitch).
+Behind the scenes, both scalers are added, which for a flying wing means the control surface takes maximum 60% deflection from roll and 65% deflection from pitch, i.e., SERVO = (0.60 * roll) + (0.65 * pitch). As it is over-committed with 125% total deflection for maximum pitch and roll, it means the first channel (roll here) has priority over the second channel / scaler (pitch). 
 
 The complete mixer looks like this:
 
@@ -122,21 +122,24 @@ Elevon mixers
 -------------
 Three scalers total (output, roll, pitch).
 
-On the assumption that the two elevon servos are physically reversed, the pitch
-input is inverted between the two servos.
-
 The scaling factor for roll inputs is adjusted to implement differential travel
-for the elevons.
+for the elevons. 
+
+This first block of code is for Servo 0...
 
 M: 2
 O:      10000  10000      0 -10000  10000
 S: 0 0  -6000  -6000      0 -10000  10000
 S: 0 1   6500   6500      0 -10000  10000
 
+And this is for Servo 1...
+
 M: 2
 O:      10000  10000      0 -10000  10000
 S: 0 0  -6000  -6000      0 -10000  10000
 S: 0 1  -6500  -6500      0 -10000  10000
+
+Note that in principle, you could implement left/right wing asymmetric mixing, but in general the two blocks of code will be numerically equal, and just differ by the sign of the third line (S: 0 1), since to roll the plane, the two ailerons must move in OPPOSITE directions. The signs of the second lines (S: 0 0) are indentical, since to pitch the plane, both servos need to move in the SAME direction. 
 
 Output 2
 --------
@@ -161,4 +164,4 @@ S: 0 3      0  20000 -10000 -10000  10000
 
 The airframe meta data is bundled in the .px4 firmware file (which is a zipped JSON file).
 
-> **Note** Ensure to flash the resulting .px4 file in QGroundControl (custom file option) to load the meta data into the application. The new airframe will then be available in the user interface.
+> **Note** Ensure to flash the resulting .px4 file in QGroundControl (custom file option) to load the meta data into the application. The new airframe will then be available in the user interface once you restart QGroundControl.


### PR DESCRIPTION
As best as I can tell, based on directly testing this, only both output scalings need to be changed, and not the output range numbers as well. So the sentence should read "If you want to invert your PWM signal, the sign for both output scalings has to be changed. (O: -10000 -10000 0 -10000 10000)".