### PR TITLE
ROS: MAVROS Offboard control example: update SET MODE flag

### DIFF
--- a/kr/ros/mavros_offboard.md
+++ b/kr/ros/mavros_offboard.md
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
         if( current_state.mode != "OFFBOARD" &&
             (ros::Time::now() - last_request > ros::Duration(5.0))){
             if( set_mode_client.call(offb_set_mode) &&
-                offb_set_mode.response.success){
+                offb_set_mode.response.mode_sent){
                 ROS_INFO("Offboard enabled");
             }
             last_request = ros::Time::now();

--- a/zh/ros/mavros_offboard.md
+++ b/zh/ros/mavros_offboard.md
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
             if( !current_state.armed &&
                 (ros::Time::now() - last_request > ros::Duration(5.0))){
                 if( arming_client.call(arm_cmd) &&
-                    arm_cmd.response.success){
+                    arm_cmd.response.mode_sent){
                     ROS_INFO("Vehicle armed");
                 }
                 last_request = ros::Time::now();


### PR DESCRIPTION
This PR:
1. Changes some descriptions so it becomes more clear and updates them
2. Updates the `SET_MODE` cmd flag from `success` to `mode_sent`, according to https://github.com/mavlink/mavros/commit/599c5887ad2aadc124d7e1354f3a1597402118da.

So it becomes definite, this PR should probably wait for new MAVROS release on ROS buildfarm (as this change is only on current `master`).