### PR TITLE
update the standard plane output channel

### DIFF
--- a/en/airframes/airframe_reference.md
+++ b/en/airframes/airframe_reference.md
@@ -722,14 +722,10 @@ This page lists all supported airframes and types including
    <tr><th>Name</th><th></th></tr>
  </thead>
 <tbody>
-<tr id="plane_standard_plane_multiplex_easystar">
- <td style="vertical-align: top;">Multiplex Easystar</td>
- <td style="vertical-align: top;"><p>Maintainer: Lorenz Meier <lorenz@px4.io></p><p><code>SYS_AUTOSTART</code> = 2100</p><p><b>Specific Outputs:</b><ul><li><b>MAIN1</b>: aileron</li><li><b>MAIN2</b>: elevator</li><li><b>MAIN3</b>: rudder</li><li><b>MAIN4</b>: throttle</li></ul></p></td>
 
-</tr>
 <tr id="plane_standard_plane_standard_aert_plane">
- <td style="vertical-align: top;">Standard AERT Plane</td>
- <td style="vertical-align: top;"><p>Maintainer: Lorenz Meier <lorenz@px4.io></p><p><code>SYS_AUTOSTART</code> = 2101</p><p><b>Specific Outputs:</b><ul><li><b>MAIN1</b>: aileron</li><li><b>MAIN2</b>: elevator</li><li><b>MAIN3</b>: rudder</li><li><b>MAIN4</b>: throttle</li><li><b>MAIN5</b>: flaps</li></ul></p></td>
+ <td style="vertical-align: top;">Multiplex Easystar; Standard AERT Plane</td>
+ <td style="vertical-align: top;"><p>Maintainer: Lorenz Meier <lorenz@px4.io></p><p><code>SYS_AUTOSTART</code> = 2100</p><p><b>Specific Outputs:</b><ul><li><b>MAIN1</b>: aileron</li><li><b>MAIN2</b>: elevator</li><li><b>MAIN3</b>: rudder</li><li><b>MAIN4</b>: throttle</li><li><b>MAIN5</b>: flaps</li></ul></p></td>
 
 </tr>
 <tr id="plane_standard_plane_skywalker_(3dr_aero)">


### PR DESCRIPTION
the latest firmware has deleted  SYS_AUTOSTART id 2101, and changed the throttle channel from MAIN3 to MAIN4.
this guide need to be updated.