### PR TITLE
Remove references to FMUv1 (deprecated)

### DIFF
--- a/en/software_update/stm32_bootloader.md
+++ b/en/software_update/stm32_bootloader.md
@@ -4,7 +4,6 @@ The code for the PX4 bootloader is available from the Github [Bootloader](https:
 
 ## Supported Boards
 
-  * FMUv1 (PX4FMU, STM32F4)
   * FMUv2 (Pixhawk 1, STM32F4)
   * FMUv3 (Pixhawk 2, STM32F4)
   * FMUv4 (Pixracer 3 and Pixhawk 3 Pro, STM32F4)
@@ -59,11 +58,6 @@ These instructions are for the [J-Link GDB server](https://www.segger.com/jlink-
 [Download the J-Link software](https://www.segger.com/downloads/jlink#) from the Segger website and install it according to their instructions.
 
 #### Run the JLink GDB server
-
-FMUv1:
-```bash
-JLinkGDBServer -select USB=0 -device STM32F405RG -if SWD-DP -speed 20000
-```
 
 AeroFC:
 ```bash

--- a/en/software_update/stm32_bootloader.md
+++ b/en/software_update/stm32_bootloader.md
@@ -59,10 +59,19 @@ These instructions are for the [J-Link GDB server](https://www.segger.com/jlink-
 
 #### Run the JLink GDB server
 
-AeroFC:
+The command below is used to run the server for autopilots that use the STM32F427VI SoC:
+
 ```bash
-JLinkGDBServer -select USB=0 -device STM32F429AI -if SWD-DP -speed 20000
+JLinkGDBServer -select USB=0 -device STM32F427VI -if SWD-DP -speed 20000
 ```
+
+The `--device`/SoC for common targets is:
+
+* **FMUv2, FMUv3, FMUv4, aerofc-v1, mindpx-v2:** STM32F427VI
+* **px4fmu-v4pro:** STM32F469I
+* **px4fmu-v5:** STM32F765II
+* **crazyflie:** STM32F405RG
+
 
 #### Connect GDB
 

--- a/en/software_update/stm32_bootloader.md
+++ b/en/software_update/stm32_bootloader.md
@@ -59,7 +59,7 @@ These instructions are for the [J-Link GDB server](https://www.segger.com/jlink-
 
 #### Run the JLink GDB server
 
-The command below is used to run the server for autopilots that use the STM32F427VI SoC:
+The command below is used to run the server for flight controllers that use the STM32F427VI SoC:
 
 ```bash
 JLinkGDBServer -select USB=0 -device STM32F427VI -if SWD-DP -speed 20000
@@ -68,7 +68,7 @@ JLinkGDBServer -select USB=0 -device STM32F427VI -if SWD-DP -speed 20000
 The `--device`/SoC for common targets is:
 
 * **FMUv2, FMUv3, FMUv4, aerofc-v1, mindpx-v2:** STM32F427VI
-* **px4fmu-v4pro:** STM32F469I
+* **px4fmu-v4pro:** STM32F469II
 * **px4fmu-v5:** STM32F765II
 * **crazyflie:** STM32F405RG
 

--- a/en/test_and_ci/continous_integration.md
+++ b/en/test_and_ci/continous_integration.md
@@ -4,7 +4,7 @@ PX4 builds and testing are spread out over multiple continuous integration servi
 
 ## [Travis-ci](https://travis-ci.org/PX4/Firmware)
 
-Travis-ci is responsible for the official stable/beta/development binaries that are flashable through [QGroundControl](http://qgroundcontrol.com/). It currently uses GCC 4.9.3 included in the docker image [px4io/px4-dev-base](https://hub.docker.com/r/px4io/px4-dev-base/) and compiles px4fmu-{v1, v2, v4}, mindpx-v2, tap-v1 with makefile target qgc_firmware.
+Travis-ci is responsible for the official stable/beta/development binaries that are flashable through [QGroundControl](http://qgroundcontrol.com/). It currently uses GCC 4.9.3 included in the docker image [px4io/px4-dev-base](https://hub.docker.com/r/px4io/px4-dev-base/) and compiles px4fmu-{v2, v4}, mindpx-v2, tap-v1 with makefile target qgc_firmware.
 
 Travis-ci also has a MacOS posix sitl build which includes testing.
 


### PR DESCRIPTION
This removes references to FMUv1 from the Devguide. See https://github.com/PX4/Firmware/issues/7758 for context.