### PR TITLE
Compilation fix.

### DIFF
--- a/build_scripts/ubuntu_sim_ros_gazebo.sh
+++ b/build_scripts/ubuntu_sim_ros_gazebo.sh
@@ -46,6 +46,8 @@ pip install pyserial
 # optional python tools
 pip install pyulog
 
+sudo apt-get install ant openjdk-8-jdk openjdk-8-jre -y
+
 
 # Install FastRTPS 1.5.0 and FastCDR-1.0.7
 fastrtps_dir=$HOME/eProsima_FastRTPS-1.5.0-Linux


### PR DESCRIPTION
"make posix_sitl_default gazebo" not possible without java.

```
/usr/local/bin/fastrtpsgen: 15: exec: java: not found
/usr/local/bin/fastrtpsgen: 7: /usr/local/bin/fastrtpsgen: java: not found
[17/129] Building CXX object src/modul...Files/modules__logger.dir/logger.cpp.o
ninja: build stopped: subcommand failed.
Makefile:159: recipe for target 'posix_sitl_default' failed
make: *** [posix_sitl_default] Error 1
```