### PR TITLE
Adds build instructions to each flight controller page

### DIFF
--- a/en/flight_controller/pixfalcon.md
+++ b/en/flight_controller/pixfalcon.md
@@ -30,3 +30,7 @@ Pixfalcon is binary-compatible derivative of the [Pixhawk](../flight_controller/
   * 2x UART (one for Telemetry / OSD, no flow control)
   * 8x PWM with manual override
   * S.BUS / PPM input
+
+## Build Instructions
+
+`make px4fmu-v2_default upload`

--- a/en/flight_controller/pixhawk.md
+++ b/en/flight_controller/pixhawk.md
@@ -40,3 +40,7 @@
 ## Pinouts and Schematics
 
 The board is documented in detailed on the [Pixhawk project](https://pixhawk.org/modules/pixhawk) website.
+
+## Build Instructions
+
+`make px4fmu-v2_default upload`

--- a/en/flight_controller/pixhawk3_pro.md
+++ b/en/flight_controller/pixhawk3_pro.md
@@ -26,3 +26,6 @@ and additional features, designed by [Drotek](https://drotek.com) and PX4.
   * S.BUS / Spektrum / SUMD / PPM input
   * JST GH user-friendly connectors: same connectors and pinouts as Pixracer
 
+## Build Instructions
+
+`make px4fmu-v4pro_default upload`

--- a/en/flight_controller/pixracer.md
+++ b/en/flight_controller/pixracer.md
@@ -47,3 +47,7 @@ One of the main features of the board is its ability to use Wifi for flashing ne
 
 * [ESP8266 Documentation and Flash Instructions](https://pixhawk.org/peripherals/8266)
 * [Custom ESP8266 MAVLink firmware](https://github.com/dogmaphobic/mavesp8266)
+
+## Build Instructions
+
+`make px4fmu-v4_default upload`


### PR DESCRIPTION
This commit adds the build instructions for each of the Pixhawk series flight controller boards, so that the pages are consistent with the Pixhawk 2 page, which had the build instructions.

This will help the users to know what build instruction needs to be run to compile the firmware for a particular flight controller.