### PR TITLE
AT command correction

### DIFF
--- a/en/sik-radio.md
+++ b/en/sik-radio.md
@@ -63,9 +63,7 @@ Then set the net ID, write settings and reboot radio:
 
 ```
 ATS3=55
-AT
-&
-W
+AT&W
 ATZ
 ```
 


### PR DESCRIPTION
As stupid as it might sound, I had to check the SiK Firmware to check how to save the configuration. 

```
AT
&
W
```

to  

```
AT&W
```