### PR TITLE
Initial config update section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 This guide describes how to work inside the PX4 system architecture. It enables developers to:
 
-* Get an [overview of the system](en/setup/config_initial.md)
-* Access and modify the [PX4 Flight Stack](en/concept/flight_stack.md) and [PX4 Middleware](en/concept/middleware.md)
+* Get a [minimum developer setup](en/setup/config_initial.md).
+* Access and modify the [PX4 Flight Stack](en/concept/flight_stack.md) and [PX4 Middleware](en/concept/middleware.md).
 * [Build and deploy PX4](en/setup/building_px4.md) on *Intel® Aero Ready to Fly Drone*, *Qualcomm Snapdragon Flight*, *Pixhawk*, *Pixfalcon* and [many more autopilots](https://docs.px4.io/en/flight_controller/).
 
 ## Contributing

--- a/en/README.md
+++ b/en/README.md
@@ -6,8 +6,8 @@
 
 This guide describes how to work inside the PX4 system architecture. It enables developers to:
 
-* Get an [overview of the system](setup/config_initial.md)
-* Access and modify the [PX4 Flight Stack](concept/flight_stack.md) and [PX4 Middleware](concept/middleware.md)
+* Get a [minimum developer setup](setup/config_initial.md).
+* Access and modify the [PX4 Flight Stack](concept/flight_stack.md) and [PX4 Middleware](concept/middleware.md).
 * [Build and deploy PX4](setup/building_px4.md) on *Intel® Aero Ready to Fly Drone*, *Qualcomm Snapdragon Flight*, *Pixhawk*, *Pixfalcon* and [many more autopilots](https://docs.px4.io/en/flight_controller/).
 
 ## Contributing

--- a/en/setup/config_initial.md
+++ b/en/setup/config_initial.md
@@ -1,22 +1,34 @@
-# Initial Configuration
+# Initial Configuration & Setup
 
-Before starting to develop on PX4, the system should be configured initially with a default configuration to ensure the hardware is set up properly and is tested. The video below explains the setup process with [Pixhawk hardware](https://docs.px4.io/en/flight_controller/pixhawk_series.html) and [QGroundControl](../qgc/README.md). A list of supported reference airframes is [here](../airframes/architecture.md).
+Before starting to work on PX4 we recommend that developers obtain the basic equipment described below (or similar), and initially use a "default" configuration for their [airframe](../airframes/airframe_reference.md).
 
-> **Info** [Download the DAILY BUILD of QGroundControl](https://docs.qgroundcontrol.com/en/releases/daily_builds.html) and follow the video instructions below to set up your vehicle. See the [QGroundControl Tutorial](../qgc/README.md) for details on mission planning, flying and parameter setting.
+> **Tip** PX4 can be used with a much wider range of equipment, but new developers will benefit from going with one of the standard setups, and a Taranis RC plus a Note 4 tablet make up for a very inexpensive field kit.
 
-A list of setup options is below the video.
+## Basic Equipment
+
+The equipment below is highly recommended:
+* A Taranis Plus remote control for the safety pilot (or equivalent)
+* A development computer
+  * MacBook Pro or Air with OSX 10.10 or newer
+  * Modern laptop with Ubuntu Linux (14.04 or newer)
+* A ground control station device
+  * Any MacBook or Ubuntu Linux laptop (can be the development computer)
+  * Samsung Note 4 or equivalent / more recent Android tablet
+  * iPad (requires Wifi telemetry adapter)
+* Safety glasses
+* For multicopters - tether for more risky tests
+
+## Vehicle Configuration
+
+Download the [QGroundControl Daily Build](https://docs.qgroundcontrol.com/en/releases/daily_builds.html) for your development platform.
+
+> **Tip** *QGroundControl* for a desktop OS is required for vehicle configuration. The daily build is highly recommended in order to take advantage of the latest features in PX4.
+
+Follow the video instructions below to set up your vehicle. For more detailed/written instructions see the sidebar topics in the [PX4 User Guide > Basic Configuration](https://docs.px4.io/en/config/) section. 
 
 {% youtube %}https://www.youtube.com/watch?v=91VGmdSlbo4&rel=0&vq=hd720{% endyoutube %}
 
-## Radio Control Options
 
-The PX4 flight stack does not mandate a radio control system. It also does not mandate the use of individual switches for selecting flight modes.
 
-### Flying without Radio Control
 
-All radio control setup checks can be disabled by setting the parameter `COM_RC_IN_MODE` to `1`. This will not allow manual flight, but e.g. flying in 
-
-### Single Channel Mode Switch
-
-Instead of using multiple switches, in this mode the system accepts a single channel as mode switch. This is explained in the [legacy wiki](https://pixhawk.org/peripherals/radio-control/opentx/single_channel_mode_switch).
 

--- a/en/setup/config_initial.md
+++ b/en/setup/config_initial.md
@@ -13,7 +13,7 @@ The equipment below is highly recommended:
   * Modern laptop with Ubuntu Linux (14.04 or newer)
 * A ground control station device
   * Any MacBook or Ubuntu Linux laptop (can be the development computer)
-  * Samsung Note 4 or equivalent / more recent Android tablet
+  * Samsung Note 4 or equivalent (any recent Android tablet or phone with a large enough screen to run QGroundControl effectively).
   * iPad (requires Wifi telemetry adapter)
 * Safety glasses
 * For multicopters - tether for more risky tests
@@ -27,8 +27,4 @@ Download the [QGroundControl Daily Build](https://docs.qgroundcontrol.com/en/rel
 Follow the video instructions below to set up your vehicle. For more detailed/written instructions see the sidebar topics in the [PX4 User Guide > Basic Configuration](https://docs.px4.io/en/config/) section. 
 
 {% youtube %}https://www.youtube.com/watch?v=91VGmdSlbo4&rel=0&vq=hd720{% endyoutube %}
-
-
-
-
 


### PR DESCRIPTION
@bkueng The initial config section was linked to as "an overview of the system" (which it isn't) and contained pretty much instructions to set up a standard config for your airframe using QGC daily build.

I updated this so that now it is "Tools you need to work as a developer on PX4" and (as before) "Use QGC to config your airframe in a standard way" - but with links to the user guide. 

It is definitely "more sane" but could use your advice/checking. For example, should we perhaps rename the doc in some way. Comments in line.