### PR TITLE
Require installation of xxd (via vim) on archlinux

### DIFF
--- a/en/setup/dev_env_linux_boutique.md
+++ b/en/setup/dev_env_linux_boutique.md
@@ -62,7 +62,7 @@ sudo yum install glibc.i686 ncurses-libs.i686
 Ensure you have the multilib repository enabled.
 
 ```sh
-sudo pacman -S base-devel lib32-glibc git-core python-pyserial zip
+sudo pacman -S base-devel lib32-glibc git-core python-pyserial zip vim
 ```
 
 Install [yaourt](https://wiki.archlinux.org/index.php/Yaourt#Installation), the package manager for the [Arch User Repository (AUR)](https://wiki.archlinux.org/index.php/Arch_User_Repository).


### PR DESCRIPTION
Since https://github.com/PX4/Firmware/pull/7873 the build system requires xxd.
On archlinux vim has to be installed, otherwise xxd is absent and the build fails.