### PR TITLE
Fixed download link for ubuntu_sim_nuttx.sh

### DIFF
--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -26,7 +26,7 @@ Then follow the instructions for your development target in the sections below.
 
 To install the development toolchain:
 
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/master/build/scripts/ubuntu_sim_nuttx.sh" target="_blank" download>ubuntu_sim_nuttx.sh</a>.
+1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_nuttx.sh" target="_blank" download>ubuntu_sim_nuttx.sh</a>.
 1. Run the script in a bash shell:
    ```bash
    source ubuntu_sim_nuttx.sh


### PR DESCRIPTION
Bug introduced in commit `b8abbbd` : `update build directory location (build_xy -> build/xy)`
[diff L29](https://github.com/PX4/Devguide/commit/b8abbbd1d2895d9eeb1f805c04f1b374399fe470?diff=unified#diff-190df8a706183ab8ca594f9df1598554L29)