### PR TITLE
importing from 'rootfs/eeprom/parameters' failed (-1)

### DIFF
--- a/simulation-debugging.md
+++ b/simulation-debugging.md
@@ -49,7 +49,7 @@ make posix_sitl_lpe gazebo___gdb
 make posix_sitl_lpe gazebo___lldb
 ```
 
-where the last parameter is the `<viewer_model_debugger>`; triplet (using three underscores implies the default 'iris' model).
+where the last parameter is the &lt;viewer\_model\_debugger&gt; triplet (using three underscores implies the default &#39;iris&#39; model).
 This will start the debugger and launch the SITL application. In order to break into the debugger shell and halt the execution, hit ```CTRL-C```:
 
 ```gdb
@@ -66,7 +66,7 @@ libsystem_kernel.dylib`__read_nocancel:
 
 The lldb or gdb shells behave like normal sessions, please refer to the LLDB / GDB documentation.
 
-The last parameter, the `<viewer_model_debugger>`; triplet, is actually passed to make in the build directory, so
+The last parameter, the &lt;viewer\_model\_debugger&gt; triplet, is actually passed to make in the build directory, so
 
 ```sh
 make posix_sitl_lpe jmavsim___gdb
@@ -86,7 +86,7 @@ be obtained with:
 make help
 ```
 
-but for your convenience, a list with just the `<viewer_model_debugger>` triplets
+but for your convenience, a list with just the &lt;viewer\_model\_debugger&gt; triplets
 is printed with the command
 
 ```sh
@@ -96,14 +96,14 @@ make list_vmd_make_targets
 ## Compiler optimization
 
 It is possible to suppress compiler optimization for given executables and/or
-modules (as added by cmake with ```add_executable``` or ```add_library```) when configuring
-for `posix(_sitl)`. This can be handy when it is necessary to step through code
+modules (as added by cmake with `add_executable` or `add_library`) when configuring
+for `posix_sitl_*`. This can be handy when it is necessary to step through code
 with a debugger or print variables that would otherwise be optimized out.
 
 To do so, set the environment variable `PX4_NO_OPTIMIZATION` to be a semi-colon
 separated list of regular expressions that match the targets that need
 to be compiled without optimization. This environment variable is ignored
-when the configuration isn't `posix_sitl_*`.
+when the configuration isn&#39;t `posix_sitl_*`.
 
 For example,
 
@@ -111,7 +111,7 @@ For example,
 export PX4_NO_OPTIMIZATION='px4;^modules__uORB;^modules__systemlib$'
 ```
 
-would suppress optimization of the targets: `platforms__posix__px4_layer`, `modules__systemlib`, `modules__uORB`, `examples__px4_simple_app`, `modules__uORB__uORB_tests` and `px4`.
+would suppress optimization of the targets: platforms\_\_posix\_\_px4\_layer, modules\_\_systemlib, modules\_\_uORB, examples\_\_px4\_simple\_app, modules\_\_uORB\_\_uORB\_tests and px4.
 
 The targets that can be matched with these regular expressions can be
 printed with the command:

--- a/simulation-debugging.md
+++ b/simulation-debugging.md
@@ -6,9 +6,6 @@ As the simulation is running on the host machine, all the desktop development to
 
 The Clang address sanitizer can help to find alignment (bus) errors and other memory faults like segmentation fauls. The command below sets the right compile options.
 
-
-<div class="host-code"></div>
-
 ```sh
 make clean # only required on first address sanitizer run after a normal build
 MEMORY_DEBUG=1 make posix jmavsim
@@ -16,15 +13,11 @@ MEMORY_DEBUG=1 make posix jmavsim
 
 ## Valgrind
 
-<div class="host-code"></div>
-
 ```sh
 brew install valgrind
 ```
 
 or
-
-<div class="host-code"></div>
 
 ```sh
 sudo apt-get install valgrind
@@ -37,8 +30,6 @@ Add instructions how to run Valgrind
 ## Start combinations
 
 SITL can be launched with and without debugger attached and with either jMAVSim or Gazebo as simulation backend. This results in the start options below:
-
-<div class="host-code"></div>
 
 ```sh
 make posix_sitl_default jmavsim
@@ -58,12 +49,10 @@ make posix_sitl_lpe gazebo___gdb
 make posix_sitl_lpe gazebo___lldb
 ```
 
-where the last parameter is the &lt;viewer_model_debugger&gt; triplet (using three underscores implies the default 'iris' model).
+where the last parameter is the `<viewer_model_debugger>`; triplet (using three underscores implies the default 'iris' model).
 This will start the debugger and launch the SITL application. In order to break into the debugger shell and halt the execution, hit ```CTRL-C```:
 
-<div class="host-code"></div>
-
-```bash
+```gdb
 Process 16529 stopped
 * thread #1: tid = 0x114e6d, 0x00007fff90f4430a libsystem_kernel.dylib`__read_nocancel + 10, name = 'px4', queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
     frame #0: 0x00007fff90f4430a libsystem_kernel.dylib`__read_nocancel + 10
@@ -77,17 +66,13 @@ libsystem_kernel.dylib`__read_nocancel:
 
 The lldb or gdb shells behave like normal sessions, please refer to the LLDB / GDB documentation.
 
-The last parameter, the &lt;viewer_model_debugger&gt; triplet, is actually passed to make in the build directory, so
-
-<div class="host-code"></div>
+The last parameter, the `<viewer_model_debugger>`; triplet, is actually passed to make in the build directory, so
 
 ```sh
 make posix_sitl_lpe jmavsim___gdb
 ```
 
 is equivalent with
-
-<div class="host-code"></div>
 
 ```sh
 make posix_sitl_lpe	# Configure with cmake
@@ -97,16 +82,12 @@ make -C build_posix_sitl_lpe jmavsim___gdb
 A full list of the available make targets in the build directory can
 be obtained with:
 
-<div class="host-code"></div>
-
 ```sh
 make help
 ```
 
-but for your convenience, a list with just the &lt;viewer_model_debugger&gt; triplets
+but for your convenience, a list with just the `<viewer_model_debugger>` triplets
 is printed with the command
-
-<div class="host-code"></div>
 
 ```sh
 make list_vmd_make_targets
@@ -115,28 +96,25 @@ make list_vmd_make_targets
 ## Compiler optimization
 
 It is possible to suppress compiler optimization for given executables and/or
-modules (as added by cmake with add_executable or add_library). This can be
-handy when it is necessary to step through code with a debugger or print
-variables that would otherwise be optimized out.
+modules (as added by cmake with ```add_executable``` or ```add_library```) when configuring
+for `posix(_sitl)`. This can be handy when it is necessary to step through code
+with a debugger or print variables that would otherwise be optimized out.
 
-To do so, set the environment variable PX4_NO_OPTIMIZATION to be a semi-colon
+To do so, set the environment variable `PX4_NO_OPTIMIZATION` to be a semi-colon
 separated list of regular expressions that match the targets that need
-to be compiled without optimization.
+to be compiled without optimization. This environment variable is ignored
+when the configuration isn't `posix_sitl_*`.
 
 For example,
-
-<div class="host-code"></div>
 
 ```sh
 export PX4_NO_OPTIMIZATION='px4;^modules__uORB;^modules__systemlib$'
 ```
 
-would suppress optimization of the targets: platforms__posix__px4_layer, modules__systemlib, modules__uORB, examples__px4_simple_app, modules__uORB__uORB_tests and px4.
+would suppress optimization of the targets: `platforms__posix__px4_layer`, `modules__systemlib`, `modules__uORB`, `examples__px4_simple_app`, `modules__uORB__uORB_tests` and `px4`.
 
 The targets that can be matched with these regular expressions can be
 printed with the command:
-
-<div class="host-code"></div>
 
 ```sh
 make -C build_posix_sitl_* list_cmake_targets

--- a/simulation-debugging.md
+++ b/simulation-debugging.md
@@ -90,7 +90,7 @@ is equivalent with
 <div class="host-code"></div>
 
 ```sh
-cmake posix_sitl_lpe
+make posix_sitl_lpe	# Configure with cmake
 cd build_posix_sitl_lpe
 make jmavsim___gdb
 ```

--- a/simulation-debugging.md
+++ b/simulation-debugging.md
@@ -58,7 +58,7 @@ make posix_sitl_lpe gazebo___gdb
 make posix_sitl_lpe gazebo___lldb
 ```
 
-where the last parameter is the <viewer_model_debugger> triplet (using three underscores implies the default 'iris' model).
+where the last parameter is the &lt;viewer_model_debugger&gt; triplet (using three underscores implies the default 'iris' model).
 This will start the debugger and launch the SITL application. In order to break into the debugger shell and halt the execution, hit ```CTRL-C```:
 
 <div class="host-code"></div>
@@ -77,7 +77,7 @@ libsystem_kernel.dylib`__read_nocancel:
 
 The lldb or gdb shells behave like normal sessions, please refer to the LLDB / GDB documentation.
 
-The last parameter, the <viewer_model_debugger> triplet, is actually passed to make in the build directory, so
+The last parameter, the &lt;viewer_model_debugger&gt; triplet, is actually passed to make in the build directory, so
 
 <div class="host-code"></div>
 
@@ -104,7 +104,7 @@ be obtained with:
 make help
 ```
 
-but for your convenience, a list with just the <viewer_model_debugger> triplets
+but for your convenience, a list with just the &lt;viewer_model_debugger&gt; triplets
 is printed with the command
 
 <div class="host-code"></div>
@@ -133,4 +133,3 @@ export PX4_NO_OPTIMIZATION='px4;^modules__uORB;^modules__systemlib$'
 ```
 
 would suppress optimization of the targets: platforms__posix__px4_layer, modules__systemlib, modules__uORB, examples__px4_simple_app, modules__uORB__uORB_tests and px4.
-```

--- a/simulation-debugging.md
+++ b/simulation-debugging.md
@@ -58,6 +58,7 @@ make posix_sitl_lpe gazebo___gdb
 make posix_sitl_lpe gazebo___lldb
 ```
 
+where the last parameter is the <viewer_model_debugger> triplet (using three underscores implies the default 'iris' model).
 This will start the debugger and launch the SITL application. In order to break into the debugger shell and halt the execution, hit ```CTRL-C```:
 
 <div class="host-code"></div>
@@ -75,3 +76,61 @@ libsystem_kernel.dylib`__read_nocancel:
 ```
 
 The lldb or gdb shells behave like normal sessions, please refer to the LLDB / GDB documentation.
+
+The last parameter, the <viewer_model_debugger> triplet, is actually passed to make in the build directory, so
+
+<div class="host-code"></div>
+
+```sh
+make posix_sitl_lpe jmavsim___gdb
+```
+
+is equivalent with
+
+<div class="host-code"></div>
+
+```sh
+cmake posix_sitl_lpe
+cd build_posix_sitl_lpe
+make jmavsim___gdb
+```
+
+A full list of the available make targets in the build directory can
+be obtained with:
+
+<div class="host-code"></div>
+
+```sh
+make help
+```
+
+but for your convenience, a list with just the <viewer_model_debugger> triplets
+is printed with the command
+
+<div class="host-code"></div>
+
+```sh
+make list_vmd_make_targets
+```
+
+## Compiler optimization
+
+It is possible to suppress compiler optimization for given executables and/or
+modules (as added by cmake with add_executable or add_library). This can be
+handy when it is necessary to step through code with a debugger or print
+variables that would otherwise be optimized out.
+
+To do so, set the environment variable PX4_NO_OPTIMIZATION to be a semi-colon
+separated list of regular expressions that match the targets that need
+to be compiled without optimization.
+
+For example,
+
+<div class="host-code"></div>
+
+```sh
+export PX4_NO_OPTIMIZATION='px4;^modules__uORB;^modules__systemlib$'
+```
+
+would suppress optimization of the targets: platforms__posix__px4_layer, modules__systemlib, modules__uORB, examples__px4_simple_app, modules__uORB__uORB_tests and px4.
+```

--- a/simulation-debugging.md
+++ b/simulation-debugging.md
@@ -91,8 +91,7 @@ is equivalent with
 
 ```sh
 make posix_sitl_lpe	# Configure with cmake
-cd build_posix_sitl_lpe
-make jmavsim___gdb
+make -C build_posix_sitl_lpe jmavsim___gdb
 ```
 
 A full list of the available make targets in the build directory can
@@ -133,3 +132,12 @@ export PX4_NO_OPTIMIZATION='px4;^modules__uORB;^modules__systemlib$'
 ```
 
 would suppress optimization of the targets: platforms__posix__px4_layer, modules__systemlib, modules__uORB, examples__px4_simple_app, modules__uORB__uORB_tests and px4.
+
+The targets that can be matched with these regular expressions can be
+printed with the command:
+
+<div class="host-code"></div>
+
+```sh
+make -C build_posix_sitl_* list_cmake_targets
+```


### PR DESCRIPTION
px4 starting.

ERROR [param] importing from 'rootfs/eeprom/parameters' failed (-1)
Command 'param' failed, returned 1
INFO  [dataman] Unknown restart, data manager file 'rootfs/fs/microsd/dataman' size is 11405140 bytes
  BAT_N_CELLS: curr: 0 -> new: 3
  CAL_ACC0_ID: curr: 0 -> new: 1376264
  CAL_ACC0_XOFF: curr: 0.0000 -> new: 0.0100
  CAL_ACC0_XSCALE: curr: 1.0000 -> new: 1.0100
  CAL_ACC0_YOFF: curr: 0.0000 -> new: -0.0100
  CAL_ACC0_YSCALE: curr: 1.0000 -> new: 1.0100
  CAL_ACC0_ZOFF: curr: 0.0000 -> new: 0.0100
  CAL_ACC0_ZSCALE: curr: 1.0000 -> new: 1.0100
  CAL_ACC1_ID: curr: 0 -> new: 1310728
  CAL_ACC1_XOFF: curr: 0.0000 -> new: 0.0100
  CAL_GYRO0_ID: curr: 0 -> new: 2293768
  CAL_GYRO0_XOFF: curr: 0.0000 -> new: 0.0100
  CAL_MAG0_ID: curr: 0 -> new: 196616
  CAL_MAG0_XOFF: curr: 0.0000 -> new: 0.0100
  COM_DISARM_LAND: curr: 0 -> new: 3
  COM_OBL_ACT: curr: 0 -> new: 2
  COM_OF_LOSS_T: curr: 0.0000 -> new: 5.0000
  COM_RC_IN_MODE: curr: 0 -> new: 1
  EKF2_ANGERR_INIT: curr: 0.1000 -> new: 0.0100
  EKF2_GBIAS_INIT: curr: 0.1000 -> new: 0.0100
  EKF2_MAG_TYPE: curr: 0 -> new: 1
  MC_PITCH_P: curr: 6.5000 -> new: 6.0000
  MC_PITCHRATE_P: curr: 0.1500 -> new: 0.2000
  MC_ROLL_P: curr: 6.5000 -> new: 6.0000
  MC_ROLLRATE_P: curr: 0.1500 -> new: 0.2000
  MPC_HOLD_MAX_Z: curr: 0.6000 -> new: 2.0000
  MPC_Z_VEL_I: curr: 0.0200 -> new: 0.1500
  MPC_Z_VEL_P: curr: 0.2000 -> new: 0.6000
  NAV_ACC_RAD: curr: 10.0000 -> new: 2.0000
  NAV_DLL_ACT: curr: 0 -> new: 2
  RTL_DESCEND_ALT: curr: 30.0000 -> new: 5.0000
  RTL_LAND_DELAY: curr: -1.0000 -> new: 5.0000
  RTL_RETURN_ALT: curr: 60.0000 -> new: 30.0000
  SENS_BOARD_X_OFF: curr: 0.0000 -> new: 0.0000
  SYS_AUTOSTART: curr: 0 -> new: 4010
INFO  [platforms__posix__drivers__ledsim] LED::init
INFO  [platforms__posix__drivers__ledsim] LED::init
INFO  [simulator] Waiting for initial data on UDP port 14560. Please start the flight simulator to proceed..
Buildfile: /root/src/Firmware2/Firmware/Tools/jMAVSim/build.xml

make_dirs:

compile:

create_run_jar:

copy_res:

BUILD SUCCESSFUL
Total time: 0 seconds
Options parsed, starting Sim.
Starting GUI...
3D [dev] 1.6.0-pre12-daily-experimental daily

Exception in thread "main" java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jdt.internal.jarinjarloader.JarRsrcLoader.main(JarRsrcLoader.java:58)
Caused by: java.lang.UnsatisfiedLinkError: Can't load library: /root/src/Firmware2/Firmware/Tools/jMAVSim/out/production/libgluegen-rt.so
	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1827)
	at java.lang.Runtime.load0(Runtime.java:809)
	at java.lang.System.load(System.java:1086)
	at com.jogamp.common.jvm.JNILibLoaderBase.loadLibraryInternal(JNILibLoaderBase.java:596)
	at com.jogamp.common.jvm.JNILibLoaderBase.access$000(JNILibLoaderBase.java:63)
	at com.jogamp.common.jvm.JNILibLoaderBase$DefaultAction.loadLibrary(JNILibLoaderBase.java:95)
	at com.jogamp.common.jvm.JNILibLoaderBase.loadLibrary(JNILibLoaderBase.java:459)
	at com.jogamp.common.os.DynamicLibraryBundle$GlueJNILibLoader.loadLibrary(DynamicLibraryBundle.java:421)
	at com.jogamp.common.os.Platform$1.run(Platform.java:317)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.jogamp.common.os.Platform.<clinit>(Platform.java:287)
	at com.jogamp.opengl.GLProfile.<clinit>(GLProfile.java:146)
	at jogamp.opengl.ThreadingImpl$1.run(ThreadingImpl.java:83)
	at jogamp.opengl.ThreadingImpl$1.run(ThreadingImpl.java:66)
	at java.security.AccessController.doPrivileged(Native Method)
	at jogamp.opengl.ThreadingImpl.<clinit>(ThreadingImpl.java:66)
	at com.jogamp.opengl.Threading.disableSingleThreading(Threading.java:164)
	at javax.media.j3d.JoglPipeline.initialize(JoglPipeline.java:130)
	at javax.media.j3d.Pipeline.createPipeline(Pipeline.java:92)
	at javax.media.j3d.MasterControl.loadLibraries(MasterControl.java:837)
	at javax.media.j3d.VirtualUniverse.<clinit>(VirtualUniverse.java:274)
	at me.drton.jmavsim.Visualizer3D.<init>(Visualizer3D.java:122)
	at me.drton.jmavsim.Simulator.<init>(Simulator.java:147)
	at me.drton.jmavsim.Simulator.main(Simulator.java:645)
	... 5 more

what`s wrong about the process?