### PR TITLE
Fix astyle path

### DIFF
--- a/en/contribute/README.md
+++ b/en/contribute/README.md
@@ -19,7 +19,7 @@ PX4 uses [astyle](http://astyle.sourceforge.net/) for code formatting. Valid ver
 * [astyle 2.06](https://sourceforge.net/projects/astyle/files/astyle/astyle%202.06/) (recommended)
 * [astyle 3.0](https://sourceforge.net/projects/astyle/files/astyle/astyle%203.0/)
 
-Once installed, formatting can be checked with `./Tools/check_code_style_all.sh`. The output should be `Format checks passed` on a clean master. If that worked, `make format` can be used in the future to check and format all files automatically.
+Once installed, formatting can be checked with `./Tools/astyle/check_code_style_all.sh`. The output should be `Format checks passed` on a clean master. If that worked, `make format` can be used in the future to check and format all files automatically.
 
 > **Info** There is a known issue resulting in a huge diff with versions 2.05.1 and 2.06 from [PX4](https://github.com/PX4/astyle). In that case, try a clean installed version 2.06 or 3.0 from [sourceforge](http://astyle.sourceforge.net/).
 

--- a/kr/contribute/README.md
+++ b/kr/contribute/README.md
@@ -19,7 +19,7 @@ PX4에서는 코드 포맷에 [astyle](http://astyle.sourceforge.net/)을 사용
 * [astyle 2.06](https://sourceforge.net/projects/astyle/files/astyle/astyle%202.06/) (recommended)
 * [astyle 3.0](https://sourceforge.net/projects/astyle/files/astyle/astyle%203.0/)
 
-일단 설치하면, 포맷은 `./Tools/check_code_style_all.sh`로 체크할 수 있습니다. 출력은 clean master에서 `Format checks passed`로 나와야 합니다. 이것이 제대로 작동했다면 향후에 모든 파일을 자동으로 검사하고 포맷팅하기 위해서 `make format`을 사용할 수 있습니다.
+일단 설치하면, 포맷은 `./Tools/astyle/check_code_style_all.sh`로 체크할 수 있습니다. 출력은 clean master에서 `Format checks passed`로 나와야 합니다. 이것이 제대로 작동했다면 향후에 모든 파일을 자동으로 검사하고 포맷팅하기 위해서 `make format`을 사용할 수 있습니다.
 
 > **Info** [PX4](https://github.com/PX4/astyle)의 버전 2.05.1와 2.06 사이에 차이가 크다는 이슈가 있습니다. 이 경우 [sourceforge](http://astyle.sourceforge.net/)에서 버전 2.06이나 3.0을 설치하세요.
 


### PR DESCRIPTION
Also: With the recommended version of astyle 2.06 from sourceforge, I get a huge diff with `./Tools/astyle/check_code_style_all.sh`. Its so long it overflows the buffer of my terminal and I can only see the diff of `src/lib/micro-CDR/test/AllTest.cpp`, there might be more.