### PR TITLE
Fix broken links to AIRSIM resources

### DIFF
--- a/en/simulation/airsim.md
+++ b/en/simulation/airsim.md
@@ -4,17 +4,4 @@ AirSim is a open-source, cross platform simulator for drones, built on Unreal En
 
 The main entry point for the documentation is the [Github AirSim README](https://github.com/Microsoft/AirSim/blob/master/README.md).
 
-## HITL
-
-The instructions for [HITL setup are here](https://github.com/Microsoft/AirSim/blob/master/docs/prereq.md).
-
-The walkthrough video below shows the setup for HITL with Pixhawk in more detail.
-
-{% youtube %}
-https://youtu.be/HNWdYrtw3f0
-{% endyoutube %}
-
-## SITL
-
-The instructions for [SITL setup are here](https://github.com/Microsoft/AirSim/blob/master/docs/sitl.md).
-
+The main entry point for documentation on working with PX4 is [PX4 Setup for AirSim](https://github.com/Microsoft/AirSim/blob/master/docs/px4_setup.md) (covering both HITL and SITL).


### PR DESCRIPTION
Fix up links to point to new AirSim docs for working with PX4. Old docs went AWOL in https://github.com/Microsoft/AirSim/commit/6d8726e72c29146b02c9f339f3bf33d580d8c7cc#diff-e3e2a9bfd88566b05001b02a3f51d286