### PR TITLE
Add travis for link checking on master. Use compatible redirect plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: ruby
+rvm:
+- 2.2.2
+
+install:
+- npm install gitbook-cli -g
+- gitbook install
+- gitbook build
+- gem install html-proofer
+
+script: 
+
+- htmlproofer ./_book
+
+# branch whitelist
+branches:
+  only:
+  - master      # test the master branch
+
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true   # speeds up installation of html-proofer

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ install:
 
 script: 
 
-- htmlproofer ./_book
+- htmlproofer ./_book --empty-alt-ignore true --check-external-hash true
+
 
 # branch whitelist
 branches:

--- a/book.json
+++ b/book.json
@@ -8,7 +8,7 @@
         "-mermaid-2",
         "language-picker",
         "custom-favicon",
-        "bulk-redirect",
+        "bulk-redirect@git+https://github.com/Dronecode/gitbook-plugin-bulk-redirect.git",
         "toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git",
         "validate-links",
         "-stub-out-blocks@git+https://github.com/hamishwillee/gitbook-plugin-stub-out-blocks.git",


### PR DESCRIPTION
Enables link checking on travis. This version only runs on master. Does not run on PRS or block, because we currently have too many errors.