### PR TITLE
Remove LNDMC_POS_UPTHR and LNDMC_MAN_DWNTHR param from doc

### DIFF
--- a/en/tutorials/land_detector.md
+++ b/en/tutorials/land_detector.md
@@ -10,12 +10,10 @@ By default the land detector does detect landing, but does not auto-disarm. If t
 
 The complete set of parameters is available in the *QGroundControl* parameter editor under the `LNDMC` prefix. The key parameters that might differ per airframe are these:
 
-
 * [MPC_THR_HOVER](../advanced/parameter_reference.md#MPC_THR_HOVER) - the hover throttle of the system \(in percent, default is 50%\). It is important to set this correctly as it does not only make the altitude control more accurate, but also ensures correct land detection. A racer or a big camera drone without payload mounted might need a much lower setting \(e.g. 35%\).
-* [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - the overall minimum throttle of the system. This should be set to enable a controlled descend.
+* [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - the overall minimum throttle of the system. This should be set to enable a controlled descent.
 * [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - this is a scaling factor to define the range between min and hover throttle that gets accepted as landed. Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is: `0.1 + (0.5 - 0.1) * 0.2 = 0.18`.
 
-The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
 
 ### Landdetector states
 

--- a/en/tutorials/land_detector.md
+++ b/en/tutorials/land_detector.md
@@ -13,7 +13,7 @@ The complete set of parameters is available in the *QGroundControl* parameter ed
 
 * [MPC_THR_HOVER](../advanced/parameter_reference.md#MPC_THR_HOVER) - the hover throttle of the system \(in percent, default is 50%\). It is important to set this correctly as it does not only make the altitude control more accurate, but also ensures correct land detection. A racer or a big camera drone without payload mounted might need a much lower setting \(e.g. 35%\).
 * [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - the overall minimum throttle of the system. This should be set to enable a controlled descend.
-* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - this is a scaling factor to define the range between min and hover throttle that gets accepted as landed. Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is the min throttle plus \(0.5 - 0.1\) \* 0.2 = 0.08, so a total throttle of 0.18.
+* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - this is a scaling factor to define the range between min and hover throttle that gets accepted as landed. Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is: `0.1 + (0.5 - 0.1) * 0.2 = 0.18`.
 
 The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
 

--- a/en/tutorials/land_detector.md
+++ b/en/tutorials/land_detector.md
@@ -4,45 +4,49 @@ The land detector is a dynamic vehicle model representing key vehicle states suc
 
 ## Configuring Auto-Disarming
 
-By default the land detector does detect landing, but does not auto-disarm. If the hysteresis parameter `COM_DISARM_LAND` is set to a non-zero value the system will auto-disarm after N seconds \(the value it is set to\).
+By default the land detector does detect landing, but does not auto-disarm. If the hysteresis parameter [COM_DISARM_LAND](../advanced/parameter_reference.md#COM_DISARM_LAND) is set to a non-zero value the system will auto-disarm after N seconds \(the value it is set to\).
 
 ## Multicopter Land Detector Configuration
 
-The complete set of parameters is available in the QGroundControl parameter editor under the `LNDMC` prefix. The key parameters that might differ per airframe are these:
+The complete set of parameters is available in the *QGroundControl* parameter editor under the `LNDMC` prefix. The key parameters that might differ per airframe are these:
 
-* `LNDMC_MAN_DWNTHR` - the threshold \(in percent, default is 15%\) for how much manual throttle is allowed to be considering the state as landed. Systems with very high thrust-to-weight ratios like racers might need a lower setting here \(e.g. 8%\).
-* `MPC_THR_HOVER` - the hover throttle of the system \(in percent, default is 50%\). It is important to set this correctly as it does not only make the altitude control more accurate, but also ensures correct land detection. A racer or a big camera drone without payload mounted might need a much lower setting \(e.g. 35%\).
-* `MPC_THR_MIN` - the overall minimum throttle of the system. This should be set to enable a controlled descend.
-* `LNDMC_THR_RANGE` - this is a scaling factor to define the range between min and hover throttle that gets accepted as landed. Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is the min throttle plus \(0.5 - 0.1\) \* 0.2 = 0.08, so a total throttle of 0.18.
-* `LNDMC_POS_UPTHR` - throttle level to trigger takeoff \(in percent, default is 65%\). If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
+
+* [MPC_THR_HOVER](../advanced/parameter_reference.md#MPC_THR_HOVER) - the hover throttle of the system \(in percent, default is 50%\). It is important to set this correctly as it does not only make the altitude control more accurate, but also ensures correct land detection. A racer or a big camera drone without payload mounted might need a much lower setting \(e.g. 35%\).
+* [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - the overall minimum throttle of the system. This should be set to enable a controlled descend.
+* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - this is a scaling factor to define the range between min and hover throttle that gets accepted as landed. Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is the min throttle plus \(0.5 - 0.1\) \* 0.2 = 0.08, so a total throttle of 0.18.
+
+The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
 
 ### Landdetector states
 
-In order to detect landing, the multicopter first has to
- go through three different states, where each state contains the conditions from the previous states plus tighter constraints. If a condition cannot be reached because of missing sensors, then the condition is true by default. For instance, 
- in acro mode and no sensor is active except of the gyro sensor, then the detection solely relies on thrust output and time. 
+In order to detect landing, the multicopter first has to go through three different states, where each state contains the conditions from the previous states plus tighter constraints. 
+If a condition cannot be reached because of missing sensors, then the condition is true by default. 
+For instance, in Acro mode and no sensor is active except of the gyro sensor, then the detection solely relies on thrust output and time. 
  
- In order to proceed to the next state, each condition has to be true for some predefined time. If one condition fails, the landdetector drops out of the current state immediately. 
+In order to proceed to the next state, each condition has to be true for some predefined time. 
+If one condition fails, the landdetector drops out of the current state immediately. 
 
 1. Ground contact
 
 This state is reached if following conditions are true for 0.35 seconds:
 
-- no vertical movement (`LNDMC_Z_VEL_MAX`)
-- no horizontal movement (`LNDMC_XY_VEL_MAX`)
+- no vertical movement ([LNDMC_Z_VEL_MAX](../advanced/parameter_reference.md#LNDMC_Z_VEL_MAX))
+- no horizontal movement ([LNDMC_XY_VEL_MAX](../advanced/parameter_reference.md#LNDMC_XY_VEL_MAX))
 - low thrust `(0.3 * MPC_THR_MIN + LNDMC_THR_RANGE* (MPC_THR_HOVER-MPC_THR_MIN))` or velocity setpoint is 0.9 of land speed but vehicle has no vertical movement.
 
-If the vehicle is in position or velocity control and ground contact was detected, the position controller will set the thrust vector along the body x-y-axis to zero. 
+If the vehicle is in position or velocity control and ground contact was detected, 
+the position controller will set the thrust vector along the body x-y-axis to zero. 
 
 2. Maybe landed
 
 This state is reached if following conditions are true for 0.25 seconds:
 
 - all conditions of ground contact are true
-- is not rotating (`LNDMC_ROT_MAX`)
+- is not rotating ([LNDMC_ROT_MAX](../advanced/parameter_reference.md#LNDMC_ROT_MAX))
 - has low thrust `(LNDMC_THR_RANGE * MPC_THR_MIN + LNDMC_THR_RANGE* (MPC_THR_HOVER-MPC_THR_MIN))`; 
 
-If the vehicle only has knowledge of thrust and angular rate, in order to proceed to the next state the vehicle has to have low thrust and no rotation for 8.0 seconds. 
+If the vehicle only has knowledge of thrust and angular rate, 
+in order to proceed to the next state the vehicle has to have low thrust and no rotation for 8.0 seconds. 
 
 If the vehicle is in position or velocity control and maybe landed was detected, the position controller will set the thrust vector to zero. 
 
@@ -57,8 +61,8 @@ This state is reached if following conditions are true for 0.3 seconds:
 
 The complete set of parameters is available under the `LNDFW` prefix. These two user parameters are sometimes worth tuning:
 
-* `LNDFW_AIRSPD_MAX` - the maximum airspeed allowed for the system still to be considered landed. The default of 8 m/s is a reliable tradeoff between airspeed sensing accuracy and triggering fast enough. Better airspeed sensors should allow lower values of this parameter.
-* `LNDFW_VELI_MAX` - the maximum velocity for the system to be still considered landed. This parameter can be adjusted to ensure a sooner or later land detection on throwing the airframe for hand-launches.
+* [LNDFW_AIRSPD_MAX](../advanced/parameter_reference.md#LNDFW_AIRSPD_MAX) - the maximum airspeed allowed for the system still to be considered landed. The default of 8 m/s is a reliable tradeoff between airspeed sensing accuracy and triggering fast enough. Better airspeed sensors should allow lower values of this parameter.
+* [LNDFW_VELI_MAX](../advanced/parameter_reference.md#LNDFW_VELI_MAX) - the maximum velocity for the system to be still considered landed. This parameter can be adjusted to ensure a sooner or later land detection on throwing the airframe for hand-launches.
 
 
 

--- a/kr/advanced/parameter_reference.md
+++ b/kr/advanced/parameter_reference.md
@@ -1,11 +1,10 @@
-# 파라미터 참조
-
-> **Note** **이 목록은 소스코드에서 자동으로 생성되며** 가장 최근 파라미터 문서를 포함합니다.
+# Parameter Reference
+> **Note** **This list is auto-generated from the source code** and contains the most recent parameter documentation.
 
 ## Attitude EKF estimator
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/examples/attitude_estimator_ekf*.
+The module where these parameters are defined is: *examples/attitude_estimator_ekf*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -95,7 +94,7 @@
 ## Attitude Q estimator
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/attitude_estimator_q*.
+The module where these parameters are defined is: *modules/attitude_estimator_q*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -150,11 +149,11 @@
  <td style="vertical-align: top;"><p>External heading usage mode (from Motion capture/Vision)
 Set to 1 to use heading estimate from vision.
 Set to 2 to use heading from motion capture</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> None</li>
+<li><strong>0:</strong> None</li> 
 
-<li><strong>1:</strong> Vision</li>
+<li><strong>1:</strong> Vision</li> 
 
-<li><strong>2:</strong> Motion Capture</li>
+<li><strong>2:</strong> Motion Capture</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 2 </td>
@@ -188,7 +187,7 @@ velocity</p>    </td>
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_SCALE_IO">BAT_V_SCALE_IO</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Scaling factor for battery voltage sensor on PX4IO</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Scaling factor for battery voltage sensor on PX4IO</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1 > 100000 </td>
  <td style="vertical-align: top;">10000 </td>
@@ -196,7 +195,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_CNT_V_VOLT">BAT_CNT_V_VOLT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Scaling from ADC counts to volt on the ADC input (battery voltage)</p><p><strong>Comment:</strong> This is not the battery voltage, but the intermediate ADC voltage. A value of -1 signifies that the board defaults are used, which is highly recommended.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Scaling from ADC counts to volt on the ADC input (battery voltage)</p><p><strong>Comment:</strong> This is not the battery voltage, but the intermediate ADC voltage. A value of -1 signifies that the board defaults are used, which is highly recommended.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -204,7 +203,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_CNT_V_CURR">BAT_CNT_V_CURR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Scaling from ADC counts to volt on the ADC input (battery current)</p><p><strong>Comment:</strong> This is not the battery current, but the intermediate ADC voltage. A value of -1 signifies that the board defaults are used, which is highly recommended.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Scaling from ADC counts to volt on the ADC input (battery current)</p><p><strong>Comment:</strong> This is not the battery current, but the intermediate ADC voltage. A value of -1 signifies that the board defaults are used, which is highly recommended.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -212,7 +211,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_OFFS_CURR">BAT_V_OFFS_CURR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Offset in volt as seen by the ADC input of the current sensor</p><p><strong>Comment:</strong> This offset will be subtracted before calculating the battery current based on the voltage.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Offset in volt as seen by the ADC input of the current sensor</p><p><strong>Comment:</strong> This offset will be subtracted before calculating the battery current based on the voltage.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
@@ -220,7 +219,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_DIV">BAT_V_DIV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Battery voltage divider (V divider)</p><p><strong>Comment:</strong> This is the divider from battery voltage to 3.3V ADC voltage. If using e.g. Mauch power modules the value from the datasheet can be applied straight here. A value of -1 means to use the board default.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Battery voltage divider (V divider)</p><p><strong>Comment:</strong> This is the divider from battery voltage to 3.3V ADC voltage. If using e.g. Mauch power modules the value from the datasheet can be applied straight here. A value of -1 means to use the board default.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -228,7 +227,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_A_PER_V">BAT_A_PER_V</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Battery current per volt (A/V)</p><p><strong>Comment:</strong> The voltage seen by the 3.3V ADC multiplied by this factor will determine the battery current. A value of -1 means to use the board default.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Battery current per volt (A/V)</p><p><strong>Comment:</strong> The voltage seen by the 3.3V ADC multiplied by this factor will determine the battery current. A value of -1 means to use the board default.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -237,11 +236,11 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_SOURCE">BAT_SOURCE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Battery monitoring source</p><p><strong>Comment:</strong> This parameter controls the source of battery data. The value 'Power Module' means that measurements are expected to come from a power module. If the value is set to 'External' then the system expects to receive mavlink battery status messages.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Power Module</li>
+<li><strong>0:</strong> Power Module</li> 
 
-<li><strong>1:</strong> External</li>
+<li><strong>1:</strong> External</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -250,7 +249,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_EMPTY">BAT_V_EMPTY</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Empty cell voltage (5C load)</p><p><strong>Comment:</strong> Defines the voltage where a single cell of the battery is considered empty. The voltage should be chosen before the steep dropoff to 2.8V. A typical lithium battery can only be discharged down to 10% before it drops off to a voltage level damaging the cells.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">(0.01)</td>
  <td style="vertical-align: top;">3.4 </td>
@@ -259,7 +258,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_CHARGED">BAT_V_CHARGED</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Full cell voltage (5C load)</p><p><strong>Comment:</strong> Defines the voltage where a single cell of the battery is considered full under a mild load. This will never be the nominal voltage of 4.2V</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">(0.01)</td>
  <td style="vertical-align: top;">4.05 </td>
@@ -268,7 +267,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_LOW_THR">BAT_LOW_THR</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Low threshold</p><p><strong>Comment:</strong> Sets the threshold when the battery will be reported as low. This has to be higher than the critical threshold.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0.12 > 0.4 (0.01)</td>
  <td style="vertical-align: top;">0.15 </td>
@@ -277,7 +276,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_CRIT_THR">BAT_CRIT_THR</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Critical threshold</p><p><strong>Comment:</strong> Sets the threshold when the battery will be reported as critically low. This has to be lower than the low threshold. This threshold commonly will trigger RTL.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0.05 > 0.1 (0.01)</td>
  <td style="vertical-align: top;">0.07 </td>
@@ -286,7 +285,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_EMERGEN_THR">BAT_EMERGEN_THR</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Emergency threshold</p><p><strong>Comment:</strong> Sets the threshold when the battery will be reported as dangerously low. This has to be lower than the critical threshold. This threshold commonly will trigger landing.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0.03 > 0.07 (0.01)</td>
  <td style="vertical-align: top;">0.05 </td>
@@ -295,7 +294,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_LOAD_DROP">BAT_V_LOAD_DROP</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Voltage drop per cell on full throttle</p><p><strong>Comment:</strong> This implicitely defines the internal resistance to maximum current ratio and assumes linearity. A good value to use is the difference between the 5C and 20-25C load. Not used if BAT_R_INTERNAL is set.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0.07 > 0.5 (0.01)</td>
  <td style="vertical-align: top;">0.3 </td>
@@ -304,7 +303,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_R_INTERNAL">BAT_R_INTERNAL</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Explicitly defines the per cell internal resistance</p><p><strong>Comment:</strong> If non-negative, then this will be used in place of BAT_V_LOAD_DROP for all calculations.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 0.2 </td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -313,40 +312,40 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_N_CELLS">BAT_N_CELLS</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Number of cells</p><p><strong>Comment:</strong> Defines the number of cells the attached battery consists of.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unconfigured</li>
+<li><strong>0:</strong> Unconfigured</li> 
 
-<li><strong>2:</strong> 2S Battery</li>
+<li><strong>2:</strong> 2S Battery</li> 
 
-<li><strong>3:</strong> 3S Battery</li>
+<li><strong>3:</strong> 3S Battery</li> 
 
-<li><strong>4:</strong> 4S Battery</li>
+<li><strong>4:</strong> 4S Battery</li> 
 
-<li><strong>5:</strong> 5S Battery</li>
+<li><strong>5:</strong> 5S Battery</li> 
 
-<li><strong>6:</strong> 6S Battery</li>
+<li><strong>6:</strong> 6S Battery</li> 
 
-<li><strong>7:</strong> 7S Battery</li>
+<li><strong>7:</strong> 7S Battery</li> 
 
-<li><strong>8:</strong> 8S Battery</li>
+<li><strong>8:</strong> 8S Battery</li> 
 
-<li><strong>9:</strong> 9S Battery</li>
+<li><strong>9:</strong> 9S Battery</li> 
 
-<li><strong>10:</strong> 10S Battery</li>
+<li><strong>10:</strong> 10S Battery</li> 
 
-<li><strong>11:</strong> 11S Battery</li>
+<li><strong>11:</strong> 11S Battery</li> 
 
-<li><strong>12:</strong> 12S Battery</li>
+<li><strong>12:</strong> 12S Battery</li> 
 
-<li><strong>13:</strong> 13S Battery</li>
+<li><strong>13:</strong> 13S Battery</li> 
 
-<li><strong>14:</strong> 14S Battery</li>
+<li><strong>14:</strong> 14S Battery</li> 
 
-<li><strong>15:</strong> 15S Battery</li>
+<li><strong>15:</strong> 15S Battery</li> 
 
-<li><strong>16:</strong> 16S Battery</li>
+<li><strong>16:</strong> 16S Battery</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -355,7 +354,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_CAPACITY">BAT_CAPACITY</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Battery capacity</p><p><strong>Comment:</strong> Defines the capacity of the attached battery.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 100000 (50)</td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -363,10 +362,35 @@ velocity</p>    </td>
 </tr>
 </tbody></table>
 
+## Camera Control
+
+
+The module where these parameters are defined is: *modules/camera_feedback*.
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAM_FBACK_MODE">CAM_FBACK_MODE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Camera feedback mode</p><p><strong>Comment:</strong> Sets the camera feedback mode.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> Feedback on trigger</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+</tbody></table>
+
 ## Camera trigger
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/drivers/camera_trigger*.
+The module where these parameters are defined is: *drivers/camera_trigger*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -377,13 +401,13 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="TRIG_INTERFACE">TRIG_INTERFACE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Camera trigger Interface</p><p><strong>Comment:</strong> Selects the trigger interface</p> <strong>Values:</strong><ul>
-<li><strong>1:</strong> GPIO</li>
+<li><strong>1:</strong> GPIO</li> 
 
-<li><strong>2:</strong> Seagull MAP2 (over PWM)</li>
+<li><strong>2:</strong> Seagull MAP2 (over PWM)</li> 
 
-<li><strong>3:</strong> MAVLink (forward via MAV_CMD_IMAGE_START_CAPTURE)</li>
+<li><strong>3:</strong> MAVLink (forward via MAV_CMD_IMAGE_START_CAPTURE)</li> 
 
-<li><strong>4:</strong> Generic PWM (IR trigger, servo)</li>
+<li><strong>4:</strong> Generic PWM (IR trigger, servo)</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
  </td>
@@ -401,9 +425,9 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="TRIG_POLARITY">TRIG_POLARITY</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Camera trigger polarity</p><p><strong>Comment:</strong> This parameter sets the polarity of the trigger (0 = active low, 1 = active high )</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Active low</li>
+<li><strong>0:</strong> Active low</li> 
 
-<li><strong>1:</strong> Active high</li>
+<li><strong>1:</strong> Active high</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 1 </td>
@@ -420,15 +444,15 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="TRIG_MODE">TRIG_MODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Camera trigger mode</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disable</li>
+<li><strong>0:</strong> Disable</li> 
 
-<li><strong>1:</strong> On individual commands</li>
+<li><strong>1:</strong> Time based, on command</li> 
 
-<li><strong>2:</strong> Time based, always on</li>
+<li><strong>2:</strong> Time based, always on</li> 
 
-<li><strong>3:</strong> Distance based, always on</li>
+<li><strong>3:</strong> Distance based, always on</li> 
 
-<li><strong>4:</strong> Distance, mission controlled</li>
+<li><strong>4:</strong> Distance based, on command (Survey mode)</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
  </td>
@@ -456,7 +480,7 @@ velocity</p>    </td>
 ## Circuit Breaker
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/systemlib*.
+The module where these parameters are defined is: *modules/systemlib*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -536,12 +560,20 @@ velocity</p>    </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CBRK_VELPOSERR">CBRK_VELPOSERR</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Circuit breaker for position error check</p><p><strong>Comment:</strong> Setting this parameter to 201607 will disable the position and velocity accuracy checks in the commander. WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 201607 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
 </tbody></table>
 
 ## Commander
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/commander*.
+The module where these parameters are defined is: *modules/commander*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -592,6 +624,13 @@ velocity</p>    </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="COM_RC_STICK_OV">COM_RC_STICK_OV</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>RC stick override threshold</p><p><strong>Comment:</strong> If an RC stick is moved more than by this amount the system will interpret this as override request by the pilot.</p>    </td>
+ <td style="vertical-align: top;">5 > 40 (0.05)</td>
+ <td style="vertical-align: top;">12.0 </td>
+ <td style="vertical-align: top;">%</td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="COM_HOME_H_T">COM_HOME_H_T</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Home set horizontal threshold</p><p><strong>Comment:</strong> The home position will be set if the estimated positioning accuracy is below the threshold.</p>    </td>
  <td style="vertical-align: top;">2 > 15 (0.5)</td>
@@ -608,11 +647,11 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_RC_IN_MODE">COM_RC_IN_MODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>RC control input mode</p><p><strong>Comment:</strong> The default value of 0 requires a valid RC transmitter setup. Setting this to 1 allows joystick control and disables RC input handling and the associated checks. A value of 2 will generate RC control data from manual input received via MAVLink instead of directly forwarding the manual input data.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> RC Transmitter</li>
+<li><strong>0:</strong> RC Transmitter</li> 
 
-<li><strong>1:</strong> Joystick/No RC Checks</li>
+<li><strong>1:</strong> Joystick/No RC Checks</li> 
 
-<li><strong>2:</strong> Virtual RC by Joystick</li>
+<li><strong>2:</strong> Virtual RC by Joystick</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 2 </td>
@@ -643,9 +682,9 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_ARM_SWISBTN">COM_ARM_SWISBTN</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Arm switch is only a button</p><p><strong>Comment:</strong> The default uses the arm switch as real switch. If parameter set button gets handled like stick arming.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Arm switch is a switch that stays on when armed</li>
+<li><strong>0:</strong> Arm switch is a switch that stays on when armed</li> 
 
-<li><strong>1:</strong> Arm switch is a button that only triggers arming and disarming</li>
+<li><strong>1:</strong> Arm switch is a button that only triggers arming and disarming</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 1 </td>
@@ -655,13 +694,13 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_LOW_BAT_ACT">COM_LOW_BAT_ACT</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Battery failsafe mode</p><p><strong>Comment:</strong> Action the system takes on low battery. Defaults to off</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Warning</li>
+<li><strong>0:</strong> Warning</li> 
 
-<li><strong>1:</strong> Return to land</li>
+<li><strong>1:</strong> Return to land</li> 
 
-<li><strong>2:</strong> Land at current position</li>
+<li><strong>2:</strong> Land at current position</li> 
 
-<li><strong>3:</strong> Return to land at critically low level, land at current position if reaching dangerously low levels</li>
+<li><strong>3:</strong> Return to land at critically low level, land at current position if reaching dangerously low levels</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">(1)</td>
@@ -675,6 +714,222 @@ See COM_OBL_ACT and COM_OBL_RC_ACT to configure action</p>    </td>
  <td style="vertical-align: top;">0 > 60 (1)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">second</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE1">COM_FLTMODE1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>First flightmode slot (1000-1160)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE2">COM_FLTMODE2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Second flightmode slot (1160-1320)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE3">COM_FLTMODE3</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Third flightmode slot (1320-1480)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE4">COM_FLTMODE4</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Fourth flightmode slot (1480-1640)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE5">COM_FLTMODE5</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Fifth flightmode slot (1640-1800)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE6">COM_FLTMODE6</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Sixth flightmode slot (1800-2000)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_ARM_EKF_POS">COM_ARM_EKF_POS</strong> (FLOAT)</td>
@@ -728,9 +983,16 @@ See COM_OBL_ACT and COM_OBL_RC_ACT to configure action</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_ARM_IMU_GYR">COM_ARM_IMU_GYR</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Maximum rate gyro inconsistency between IMU units that will allow arming</p>    </td>
- <td style="vertical-align: top;">0.02 > 0.2 (0.01)</td>
- <td style="vertical-align: top;">0.15 </td>
+ <td style="vertical-align: top;">0.02 > 0.3 (0.01)</td>
+ <td style="vertical-align: top;">0.25 </td>
  <td style="vertical-align: top;">rad/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_ARM_MAG">COM_ARM_MAG</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum magnetic field inconsistency between units that will allow arming</p>    </td>
+ <td style="vertical-align: top;">0.05 > 0.5 (0.05)</td>
+ <td style="vertical-align: top;">0.15 </td>
+ <td style="vertical-align: top;">Gauss</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_RC_OVERRIDE">COM_RC_OVERRIDE</strong> (INT32)</td>
@@ -746,12 +1008,56 @@ See COM_OBL_ACT and COM_OBL_RC_ACT to configure action</p>    </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_ARM_AUTH">COM_ARM_AUTH</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Arm authorization parameters, this uint32_t will be splitted between starting from the LSB:
+- 8bits to authorizer system id
+- 16bits to authentication method parameter, this will be used to store a timeout for the first 2 methods but can be used to another parameter for other new authentication methods.
+- 7bits to authentication method
+- one arm = 0
+- two step arm = 1
+* the MSB bit is not used to avoid problems in the conversion between int and uint</p><p><strong>Comment:</strong> Default value: (10 << 0 | 1000 << 8 | 0 << 24) = 256010 - authorizer system id = 10 - authentication method parameter = 10000msec of timeout - authentication method = during arm</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">256010 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_POS_FS_DELAY">COM_POS_FS_DELAY</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Loss of position failsafe activation delay</p><p><strong>Comment:</strong> This sets number of seconds that the position checks need to be failed before the failsafe will activate. The default value has been optimised for rotary wing applications. For fixed wing applications, a larger value between 5 and 10 should be used.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;">sec</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_POS_FS_PROB">COM_POS_FS_PROB</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Loss of position probation delay at takeoff</p><p><strong>Comment:</strong> The probation delay is the number of seconds that the EKF innovation checks need to pass for the position to be declared good after it has been declared bad. The probation delay will be reset to this parameter value when takeoff is detected. After takeoff, if position checks are passing, the probation delay will reduce by one second for every lapsed second of valid position down to a minimum of 1 second. If position checks are failing, the probation delay will increase by COM_POS_FS_GAIN seconds for every lapsed second up to a maximum of 100 seconds. The default value has been optimised for rotary wing applications. For fixed wing applications, a value of 1 should be used.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">30 </td>
+ <td style="vertical-align: top;">sec</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_POS_FS_GAIN">COM_POS_FS_GAIN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Loss of position probation gain factor</p><p><strong>Comment:</strong> This sets the rate that the loss of position probation time grows when position checks are failing. The default value has been optimised for rotary wing applications. For fixed wing applications a value of 0 should be used.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">10 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLIGHT_UUID">COM_FLIGHT_UUID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Next flight UUID</p><p><strong>Comment:</strong> This number is incremented automatically after every flight on disarming in order to remember the next flight UUID. The first flight is 0.</p>    </td>
+ <td style="vertical-align: top;">0 > ? </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
 </tbody></table>
 
 ## Data Link Loss
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -834,7 +1140,7 @@ See COM_OBL_ACT and COM_OBL_RC_ACT to configure action</p>    </td>
 ## EKF2
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/ekf2*.
+The module where these parameters are defined is: *modules/ekf2*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -845,72 +1151,80 @@ See COM_OBL_ACT and COM_OBL_RC_ACT to configure action</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_MIN_OBS_DT">EKF2_MIN_OBS_DT</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Minimum time of arrival delta between non-IMU observations before data is downsampled.
-Baro and Magnetometer data will be averaged before downsampling, other data will be point sampled resulting in loss of information</p>    </td>
+Baro and Magnetometer data will be averaged before downsampling, other data will be point sampled resulting in loss of information</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">10 > 50 </td>
  <td style="vertical-align: top;">20 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_MAG_DELAY">EKF2_MAG_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Magnetometer measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_BARO_DELAY">EKF2_BARO_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Barometer measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Barometer measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_GPS_DELAY">EKF2_GPS_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>GPS measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>GPS measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
- <td style="vertical-align: top;">200 </td>
+ <td style="vertical-align: top;">110 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_OF_DELAY">EKF2_OF_DELAY</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Optical flow measurement delay relative to IMU measurements
-Assumes measurement is timestamped at trailing edge of integration period</p>    </td>
+Assumes measurement is timestamped at trailing edge of integration period</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">5 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_RNG_DELAY">EKF2_RNG_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Range finder measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Range finder measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">5 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_ASP_DELAY">EKF2_ASP_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Airspeed measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Airspeed measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
- <td style="vertical-align: top;">200 </td>
+ <td style="vertical-align: top;">100 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_EV_DELAY">EKF2_EV_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Vision Position Estimator delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Vision Position Estimator delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">175 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_GPS_CHECK">EKF2_GPS_CHECK</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Integer bitmask controlling GPS checks</p><p><strong>Comment:</strong> Set bits to 1 to enable checks. Checks enabled by the following bit positions 0 : Minimum required sat count set by EKF2_REQ_NSATS 1 : Minimum required GDoP set by EKF2_REQ_GDOP 2 : Maximum allowed horizontal position error set by EKF2_REQ_EPH 3 : Maximum allowed vertical position error set by EKF2_REQ_EPV 4 : Maximum allowed speed error set by EKF2_REQ_SACC 5 : Maximum allowed horizontal position rate set by EKF2_REQ_HDRIFT. This check can only be used if the vehicle is stationary during alignment. 6 : Maximum allowed vertical position rate set by EKF2_REQ_VDRIFT. This check can only be used if the vehicle is stationary during alignment. 7 : Maximum allowed horizontal speed set by EKF2_REQ_HDRIFT. This check can only be used if the vehicle is stationary during alignment. 8 : Maximum allowed vertical velocity discrepancy set by EKF2_REQ_VDRIFT</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> Min sat count (EKF2_REQ_NSATS)</li>
-  <li><strong>1:</strong> Min GDoP (EKF2_REQ_GDOP)</li>
-  <li><strong>2:</strong> Max horizontal position error (EKF2_REQ_EPH)</li>
-  <li><strong>3:</strong> Max vertical position error (EKF2_REQ_EPV)</li>
-  <li><strong>4:</strong> Max speed error (EKF2_REQ_SACC)</li>
-  <li><strong>5:</strong> Max horizontal position rate (EKF2_REQ_HDRIFT)</li>
-  <li><strong>6:</strong> Max vertical position rate (EKF2_REQ_VDRIFT)</li>
-  <li><strong>7:</strong> Max horizontal speed (EKF2_REQ_HDRIFT)</li>
-  <li><strong>8:</strong> Max vertical velocity discrepancy (EKF2_REQ_VDRIFT)</li>
+ <td style="vertical-align: top;"><p>Integer bitmask controlling GPS checks</p><p><strong>Comment:</strong> Set bits to 1 to enable checks. Checks enabled by the following bit positions 0 : Minimum required sat count set by EKF2_REQ_NSATS 1 : Minimum required GDoP set by EKF2_REQ_GDOP 2 : Maximum allowed horizontal position error set by EKF2_REQ_EPH 3 : Maximum allowed vertical position error set by EKF2_REQ_EPV 4 : Maximum allowed speed error set by EKF2_REQ_SACC 5 : Maximum allowed horizontal position rate set by EKF2_REQ_HDRIFT. This check can only be used if the vehicle is stationary during alignment. 6 : Maximum allowed vertical position rate set by EKF2_REQ_VDRIFT. This check can only be used if the vehicle is stationary during alignment. 7 : Maximum allowed horizontal speed set by EKF2_REQ_HDRIFT. This check can only be used if the vehicle is stationary during alignment. 8 : Maximum allowed vertical velocity discrepancy set by EKF2_REQ_VDRIFT</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> Min sat count (EKF2_REQ_NSATS)</li> 
+  <li><strong>1:</strong> Min GDoP (EKF2_REQ_GDOP)</li> 
+  <li><strong>2:</strong> Max horizontal position error (EKF2_REQ_EPH)</li> 
+  <li><strong>3:</strong> Max vertical position error (EKF2_REQ_EPV)</li> 
+  <li><strong>4:</strong> Max speed error (EKF2_REQ_SACC)</li> 
+  <li><strong>5:</strong> Max horizontal position rate (EKF2_REQ_HDRIFT)</li> 
+  <li><strong>6:</strong> Max vertical position rate (EKF2_REQ_VDRIFT)</li> 
+  <li><strong>7:</strong> Max horizontal speed (EKF2_REQ_HDRIFT)</li> 
+  <li><strong>8:</strong> Max vertical velocity discrepancy (EKF2_REQ_VDRIFT)</li> 
 </ul>
   </td>
  <td style="vertical-align: top;">0 > 511 </td>
@@ -1094,30 +1408,48 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_DECL_TYPE">EKF2_DECL_TYPE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Integer bitmask controlling handling of magnetic declination</p><p><strong>Comment:</strong> Set bits in the following positions to enable functions. 0 : Set to true to use the declination from the geo_lookup library when the GPS position becomes available, set to false to always use the EKF2_MAG_DECL value. 1 : Set to true to save the EKF2_MAG_DECL parameter to the value returned by the EKF when the vehicle disarms. 2 : Set to true to always use the declination as an observation when 3-axis magnetometer fusion is being used.</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> use geo_lookup declination</li>
-  <li><strong>1:</strong> save EKF2_MAG_DECL on disarm</li>
-  <li><strong>2:</strong> use declination as an observation</li>
+ <td style="vertical-align: top;"><p>Integer bitmask controlling handling of magnetic declination</p><p><strong>Comment:</strong> Set bits in the following positions to enable functions. 0 : Set to true to use the declination from the geo_lookup library when the GPS position becomes available, set to false to always use the EKF2_MAG_DECL value. 1 : Set to true to save the EKF2_MAG_DECL parameter to the value returned by the EKF when the vehicle disarms. 2 : Set to true to always use the declination as an observation when 3-axis magnetometer fusion is being used.</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> use geo_lookup declination</li> 
+  <li><strong>1:</strong> save EKF2_MAG_DECL on disarm</li> 
+  <li><strong>2:</strong> use declination as an observation</li> 
 </ul>
-  </td>
+ <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 7 </td>
  <td style="vertical-align: top;">7 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_MAG_TYPE">EKF2_MAG_TYPE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Type of magnetometer fusion</p><p><strong>Comment:</strong> Integer controlling the type of magnetometer fusion used - magnetic heading or 3-axis magnetometer. If set to automatic: heading fusion on-ground and 3-axis fusion in-flight</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Automatic</li>
+ <td style="vertical-align: top;"><p>Type of magnetometer fusion</p><p><strong>Comment:</strong> Integer controlling the type of magnetometer fusion used - magnetic heading or 3-axis magnetometer. If set to automatic: heading fusion on-ground and 3-axis fusion in-flight with fallback to heading fusion if there is insufficient motion to make yaw or mag biases observable.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Automatic</li> 
 
-<li><strong>1:</strong> Magnetic heading</li>
+<li><strong>1:</strong> Magnetic heading</li> 
 
-<li><strong>2:</strong> 3-axis fusion</li>
+<li><strong>2:</strong> 3-axis fusion</li> 
 
-<li><strong>3:</strong> None</li>
+<li><strong>3:</strong> None</li> 
 </ul>
-   </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAG_ACCLIM">EKF2_MAG_ACCLIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Horizontal acceleration threshold used by automatic selection of magnetometer fusion method.
+This parameter is used when the magnetometer fusion method is set automatically (EKF2_MAG_TYPE = 0). If the filtered horizontal acceleration is greater than this parameter value, then the EKF will use 3-axis magnetomer fusion</p>    </td>
+ <td style="vertical-align: top;">0.0 > 5.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;">m/s**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAG_YAWLIM">EKF2_MAG_YAWLIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw rate threshold used by automatic selection of magnetometer fusion method.
+This parameter is used when the magnetometer fusion method is set automatically (EKF2_MAG_TYPE = 0). If the filtered yaw rate is greater than this parameter value, then the EKF will use 3-axis magnetomer fusion</p>    </td>
+ <td style="vertical-align: top;">0.0 > 0.5 </td>
+ <td style="vertical-align: top;">0.25 </td>
+ <td style="vertical-align: top;">rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_BARO_GATE">EKF2_BARO_GATE</strong> (FLOAT)</td>
@@ -1148,37 +1480,33 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
  <td style="vertical-align: top;">SD</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="EKF2_REC_RPL">EKF2_REC_RPL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Replay mode</p><p><strong>Comment:</strong> A value of 1 indicates that the ekf2 module will publish replay messages for logging.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="EKF2_AID_MASK">EKF2_AID_MASK</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Integer bitmask controlling data fusion and aiding methods</p><p><strong>Comment:</strong> Set bits in the following positions to enable: 0 : Set to true to use GPS data if available 1 : Set to true to use optical flow data if available 2 : Set to true to inhibit IMU bias estimation 3 : Set to true to enable vision position fusion 4 : Set to true to enable vision yaw fusion</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> use GPS</li>
-  <li><strong>1:</strong> use optical flow</li>
-  <li><strong>2:</strong> inhibit IMU bias estimation</li>
-  <li><strong>3:</strong> vision position fusion</li>
-  <li><strong>4:</strong> vision yaw fusion</li>
+ <td style="vertical-align: top;"><p>Integer bitmask controlling data fusion and aiding methods</p><p><strong>Comment:</strong> Set bits in the following positions to enable: 0 : Set to true to use GPS data if available 1 : Set to true to use optical flow data if available 2 : Set to true to inhibit IMU bias estimation 3 : Set to true to enable vision position fusion 4 : Set to true to enable vision yaw fusion 5 : Set to true to enable multi-rotor drag specific force fusion</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> use GPS</li> 
+  <li><strong>1:</strong> use optical flow</li> 
+  <li><strong>2:</strong> inhibit IMU bias estimation</li> 
+  <li><strong>3:</strong> vision position fusion</li> 
+  <li><strong>4:</strong> vision yaw fusion</li> 
+  <li><strong>5:</strong> multi-rotor drag fusion</li> 
 </ul>
-  </td>
- <td style="vertical-align: top;">0 > 28 </td>
+ <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 63 </td>
  <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_HGT_MODE">EKF2_HGT_MODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Determines the primary source of height data used by the EKF</p><p><strong>Comment:</strong> The range sensor option should only be used when for operation over a flat surface as the local NED origin will move up and down with ground level.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Barometric pressure</li>
+<li><strong>0:</strong> Barometric pressure</li> 
 
-<li><strong>1:</strong> GPS</li>
+<li><strong>1:</strong> GPS</li> 
 
-<li><strong>2:</strong> Range sensor</li>
+<li><strong>2:</strong> Range sensor</li> 
 
-<li><strong>3:</strong> Vision</li>
+<li><strong>3:</strong> Vision</li> 
 </ul>
-   </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
@@ -1189,6 +1517,13 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
  <td style="vertical-align: top;">0.01 > ? </td>
  <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_SFE">EKF2_RNG_SFE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Range finder range dependant noise scaler</p><p><strong>Comment:</strong> Specifies the increase in range finder noise with range.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 0.2 </td>
+ <td style="vertical-align: top;">0.05 </td>
+ <td style="vertical-align: top;">m/m</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_RNG_GATE">EKF2_RNG_GATE</strong> (FLOAT)</td>
@@ -1224,13 +1559,6 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
  <td style="vertical-align: top;">1.0 > ? </td>
  <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;">SD</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="EKF2_MIN_EV">EKF2_MIN_EV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum valid range for the vision estimate</p>    </td>
- <td style="vertical-align: top;">0.01 > ? </td>
- <td style="vertical-align: top;">0.01 </td>
- <td style="vertical-align: top;">m</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_OF_N_MIN">EKF2_OF_N_MIN</strong> (FLOAT)</td>
@@ -1417,21 +1745,24 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_GBIAS_INIT">EKF2_GBIAS_INIT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>1-sigma IMU gyro switch-on bias</p>    </td>
+ <td style="vertical-align: top;"><p>1-sigma IMU gyro switch-on bias</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0.0 > 0.2 </td>
  <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;">rad/sec</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_ABIAS_INIT">EKF2_ABIAS_INIT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>1-sigma IMU accelerometer switch-on bias</p>    </td>
+ <td style="vertical-align: top;"><p>1-sigma IMU accelerometer switch-on bias</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0.0 > 0.5 </td>
  <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;">m/s/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_ANGERR_INIT">EKF2_ANGERR_INIT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>1-sigma tilt angle uncertainty after gravity vector alignment</p>    </td>
+ <td style="vertical-align: top;"><p>1-sigma tilt angle uncertainty after gravity vector alignment</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0.0 > 0.5 </td>
  <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;">rad</td>
@@ -1443,12 +1774,194 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">rad</td>
 </tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGBIAS_X">EKF2_MAGBIAS_X</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Learned value of magnetometer X axis bias.
+This is the amount of X-axis magnetometer bias learned by the EKF and saved from the last flight. It must be set to zero if the ground based magnetometer calibration is repeated</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">mGauss</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGBIAS_Y">EKF2_MAGBIAS_Y</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Learned value of magnetometer Y axis bias.
+This is the amount of Y-axis magnetometer bias learned by the EKF and saved from the last flight. It must be set to zero if the ground based magnetometer calibration is repeated</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">mGauss</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGBIAS_Z">EKF2_MAGBIAS_Z</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Learned value of magnetometer Z axis bias.
+This is the amount of Z-axis magnetometer bias learned by the EKF and saved from the last flight. It must be set to zero if the ground based magnetometer calibration is repeated</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">mGauss</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGBIAS_ID">EKF2_MAGBIAS_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of Magnetometer the learned bias is for</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGB_VREF">EKF2_MAGB_VREF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>State variance assumed for magnetometer bias storage.
+This is a reference variance used to calculate the fraction of learned magnetometer bias that will be used to update the stored value. Smaller values will make the stored bias data adjust more slowly from flight to flight. Larger values will make it adjust faster</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">2.5E-7 </td>
+ <td style="vertical-align: top;">mGauss**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGB_K">EKF2_MAGB_K</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum fraction of learned mag bias saved at each disarm.
+Smaller values make the saved mag bias learn slower from flight to flight. Larger values make it learn faster. Must be > 0.0 and <= 1.0</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.2 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_AID">EKF2_RNG_AID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Range sensor aid</p><p><strong>Comment:</strong> If this parameter is enabled then the estimator will make use of the range finder measurements to estimate it's height even if range sensor is not the primary height source. It will only do so if conditions for range measurement fusion are met.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Range aid disabled</li> 
+
+<li><strong>1:</strong> Range aid enabled</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_A_VMAX">EKF2_RNG_A_VMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity allowed for range aid mode</p><p><strong>Comment:</strong> If the vehicle horizontal speed exceeds this value then the estimator will not fuse range measurements to estimate it's height. This only applies when range aid mode is activated (EKF2_RNG_AID = enabled).</p>    </td>
+ <td style="vertical-align: top;">0.1 > 2 </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_A_HMAX">EKF2_RNG_A_HMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum absolute altitude (height above ground level) allowed for range aid mode</p><p><strong>Comment:</strong> If the vehicle absolute altitude exceeds this value then the estimator will not fuse range measurements to estimate it's height. This only applies when range aid mode is activated (EKF2_RNG_AID = enabled).</p>    </td>
+ <td style="vertical-align: top;">1.0 > 10.0 </td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_A_IGATE">EKF2_RNG_A_IGATE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gate size used for innovation consistency checks for range aid fusion</p><p><strong>Comment:</strong> A lower value means HAGL needs to be more stable in order to use range finder for height estimation in range aid mode</p>    </td>
+ <td style="vertical-align: top;">0.1 > 5.0 </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">SD</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_DRAG_NOISE">EKF2_DRAG_NOISE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Specific drag force observation noise variance used by the multi-rotor specific drag force model.
+Increasing it makes the multi-rotor wind estimates adjust more slowly</p>    </td>
+ <td style="vertical-align: top;">0.5 > 10.0 </td>
+ <td style="vertical-align: top;">2.5 </td>
+ <td style="vertical-align: top;">(m/sec**2)**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_BCOEF_X">EKF2_BCOEF_X</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>X-axis ballistic coefficient used by the multi-rotor specific drag force model.
+This should be adjusted to minimise variance of the X-axis drag specific force innovation sequence</p>    </td>
+ <td style="vertical-align: top;">1.0 > 100.0 </td>
+ <td style="vertical-align: top;">25.0 </td>
+ <td style="vertical-align: top;">kg/m**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_BCOEF_Y">EKF2_BCOEF_Y</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Y-axis ballistic coefficient used by the multi-rotor specific drag force model.
+This should be adjusted to minimise variance of the Y-axis drag specific force innovation sequence</p>    </td>
+ <td style="vertical-align: top;">1.0 > 100.0 </td>
+ <td style="vertical-align: top;">25.0 </td>
+ <td style="vertical-align: top;">kg/m**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ASPD_MAX">EKF2_ASPD_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Upper limit on airspeed along individual axes used to correct baro for position error effects</p>    </td>
+ <td style="vertical-align: top;">5.0 > 50.0 </td>
+ <td style="vertical-align: top;">20.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_PCOEF_XP">EKF2_PCOEF_XP</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Static pressure position error coefficient for the positive X axis
+This is the ratio of static pressure error to dynamic pressure generated by a positive wind relative velocity along the X body axis.
+If the baro height estimate rises during forward flight, then this will be a negative number</p>    </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_PCOEF_XN">EKF2_PCOEF_XN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Static pressure position error coefficient for the negative X axis.
+This is the ratio of static pressure error to dynamic pressure generated by a negative wind relative velocity along the X body axis.
+If the baro height estimate rises during backwards flight, then this will be a negative number</p>    </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_PCOEF_Y">EKF2_PCOEF_Y</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pressure position error coefficient for the Y axis.
+This is the ratio of static pressure error to dynamic pressure generated by a wind relative velocity along the Y body axis.
+If the baro height estimate rises during sideways flight, then this will be a negative number</p>    </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_PCOEF_Z">EKF2_PCOEF_Z</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Static pressure position error coefficient for the Z axis.
+This is the ratio of static pressure error to dynamic pressure generated by a wind relative velocity along the Z body axis</p>    </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ABL_LIM">EKF2_ABL_LIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer bias learning limit. The ekf delta velocity bias states will be limited to within a range equivalent to +- of this value</p>    </td>
+ <td style="vertical-align: top;">0.0 > 0.8 </td>
+ <td style="vertical-align: top;">0.4 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ABL_ACCLIM">EKF2_ABL_ACCLIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum IMU accel magnitude that allows IMU bias learning.
+If the magnitude of the IMU accelerometer vector exceeds this value, the EKF delta velocity state estimation will be inhibited.
+This reduces the adverse effect of high manoeuvre accelerations and IMU nonlinerity and scale factor errors on the delta velocity bias estimates</p>    </td>
+ <td style="vertical-align: top;">20.0 > 200.0 </td>
+ <td style="vertical-align: top;">25.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ABL_GYRLIM">EKF2_ABL_GYRLIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum IMU gyro angular rate magnitude that allows IMU bias learning.
+If the magnitude of the IMU angular rate vector exceeds this value, the EKF delta velocity state estimation will be inhibited.
+This reduces the adverse effect of rapid rotation rates and associated errors on the delta velocity bias estimates</p>    </td>
+ <td style="vertical-align: top;">2.0 > 20.0 </td>
+ <td style="vertical-align: top;">3.0 </td>
+ <td style="vertical-align: top;">rad/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ABL_TAU">EKF2_ABL_TAU</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Time constant used by acceleration and angular rate magnitude checks used to inhibit delta velocity bias learning.
+The vector magnitude of angular rate and acceleration used to check if learning should be inhibited has a peak hold filter applied to it with an exponential decay.
+This parameter controls the time constant of the decay</p>    </td>
+ <td style="vertical-align: top;">0.1 > 1.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;">s</td>
+</tr>
 </tbody></table>
 
 ## FW Attitude Control
-
-
-이 파라미터가 정의되어 있는 모듈 : *src/modules/fw_att_control*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -1458,182 +1971,208 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_R_TC">FW_R_TC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Attitude Roll Time Constant</p><p><strong>Comment:</strong> This defines the latency between a roll step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    </td>
+ <td style="vertical-align: top;"><p>Attitude Roll Time Constant</p><p><strong>Comment:</strong> This defines the latency between a roll step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.4 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.4 </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_P_TC">FW_P_TC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Attitude Pitch Time Constant</p><p><strong>Comment:</strong> This defines the latency between a pitch step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    </td>
+ <td style="vertical-align: top;"><p>Attitude pitch time constant</p><p><strong>Comment:</strong> This defines the latency between a pitch step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.2 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.4 </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PR_P">FW_PR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate proportional gain</p><p><strong>Comment:</strong> This defines how much the elevator input will be commanded depending on the current body angular rate error.</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch rate proportional gain</p><p><strong>Comment:</strong> This defines how much the elevator input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
  <td style="vertical-align: top;">0.08 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PR_I">FW_PR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 0.5 (0.005)</td>
  <td style="vertical-align: top;">0.02 </td>
  <td style="vertical-align: top;">%/rad</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_P_RMAX_POS">FW_P_RMAX_POS</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum positive / up pitch rate</p><p><strong>Comment:</strong> This limits the maximum pitch up angular rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum positive / up pitch rate</p><p><strong>Comment:</strong> This limits the maximum pitch up angular rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">60.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_P_RMAX_NEG">FW_P_RMAX_NEG</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum negative / down pitch rate</p><p><strong>Comment:</strong> This limits the maximum pitch down up angular rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum negative / down pitch rate</p><p><strong>Comment:</strong> This limits the maximum pitch down up angular rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">60.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PR_IMAX">FW_PR_IMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.4 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RR_P">FW_RR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate proportional Gain</p><p><strong>Comment:</strong> This defines how much the aileron input will be commanded depending on the current body angular rate error.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll rate proportional Gain</p><p><strong>Comment:</strong> This defines how much the aileron input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
  <td style="vertical-align: top;">0.05 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RR_I">FW_RR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate integrator Gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll rate integrator Gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 0.2 (0.005)</td>
  <td style="vertical-align: top;">0.01 </td>
  <td style="vertical-align: top;">%/rad</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RR_IMAX">FW_RR_IMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll Integrator Anti-Windup</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll integrator anti-windup</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_R_RMAX">FW_R_RMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum Roll Rate</p><p><strong>Comment:</strong> This limits the maximum roll rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum roll rate</p><p><strong>Comment:</strong> This limits the maximum roll rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">70.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YR_P">FW_YR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate proportional gain</p><p><strong>Comment:</strong> This defines how much the rudder input will be commanded depending on the current body angular rate error.</p>    </td>
+ <td style="vertical-align: top;"><p>Yaw rate proportional gain</p><p><strong>Comment:</strong> This defines how much the rudder input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
  <td style="vertical-align: top;">0.05 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YR_I">FW_YR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    </td>
+ <td style="vertical-align: top;"><p>Yaw rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 50.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">%/rad</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YR_IMAX">FW_YR_IMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    </td>
+ <td style="vertical-align: top;"><p>Yaw rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_Y_RMAX">FW_Y_RMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum Yaw Rate</p><p><strong>Comment:</strong> This limits the maximum yaw rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum yaw rate</p><p><strong>Comment:</strong> This limits the maximum yaw rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RLL_TO_YAW_FF">FW_RLL_TO_YAW_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll control to yaw control feedforward gain</p><p><strong>Comment:</strong> This gain can be used to counteract the "adverse yaw" effect for fixed wings. When the plane enters a roll it will tend to yaw the nose out of the turn. This gain enables the use of a yaw actuator (rudder, airbrakes, ...) to counteract this effect.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll control to yaw control feedforward gain</p><p><strong>Comment:</strong> This gain can be used to counteract the "adverse yaw" effect for fixed wings. When the plane enters a roll it will tend to yaw the nose out of the turn. This gain enables the use of a yaw actuator (rudder, airbrakes, ...) to counteract this effect.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_W_EN">FW_W_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable wheel steering controller</p>    </td>
+ <td style="vertical-align: top;"><p>Enable wheel steering controller</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_WR_P">FW_WR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Wheel steering rate proportional gain</p><p><strong>Comment:</strong> This defines how much the wheel steering input will be commanded depending on the current body angular rate error.</p>    </td>
+ <td style="vertical-align: top;"><p>Wheel steering rate proportional gain</p><p><strong>Comment:</strong> This defines how much the wheel steering input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
  <td style="vertical-align: top;">0.5 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_WR_I">FW_WR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Wheel steering rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    </td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 0.5 (0.005)</td>
  <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;">%/rad</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_WR_IMAX">FW_WR_IMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Wheel steering rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    </td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_W_RMAX">FW_W_RMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum wheel steering rate</p><p><strong>Comment:</strong> This limits the maximum wheel steering rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum wheel steering rate</p><p><strong>Comment:</strong> This limits the maximum wheel steering rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RR_FF">FW_RR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output. Use this to obtain a tigher response of the controller without introducing noise amplification.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output. Use this to obtain a tigher response of the controller without introducing noise amplification.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
  <td style="vertical-align: top;">0.5 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PR_FF">FW_PR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
  <td style="vertical-align: top;">0.5 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YR_FF">FW_YR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    </td>
+ <td style="vertical-align: top;"><p>Yaw rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
  <td style="vertical-align: top;">0.3 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_WR_FF">FW_WR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Wheel steering rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    </td>
+ <td style="vertical-align: top;"><p>Wheel steering rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
  <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YCO_VMIN">FW_YCO_VMIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal speed for yaw coordination</p><p><strong>Comment:</strong> For airspeeds above this value, the yaw rate is calculated for a coordinated turn. Set to a very high value to disable.</p>    </td>
+ <td style="vertical-align: top;"><p>Minimal speed for yaw coordination</p><p><strong>Comment:</strong> For airspeeds above this value, the yaw rate is calculated for a coordinated turn. Set to a very high value to disable.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1000.0 (0.5)</td>
  <td style="vertical-align: top;">1000.0 </td>
  <td style="vertical-align: top;">m/s</td>
@@ -1641,133 +2180,150 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YCO_METHOD">FW_YCO_METHOD</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Method used for yaw coordination</p><p><strong>Comment:</strong> The param value sets the method used to calculate the yaw rate 0: open-loop zero lateral acceleration based on kinematic constraints 1: closed-loop: try to reduce lateral acceleration to 0 by measuring the acceleration</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> open-loop</li>
+<li><strong>0:</strong> open-loop</li> 
 
-<li><strong>1:</strong> closed-loop</li>
+<li><strong>1:</strong> closed-loop</li> 
 </ul>
-   </td>
+   <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RSP_OFF">FW_RSP_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll Setpoint Offset</p><p><strong>Comment:</strong> An airframe specific offset of the roll setpoint in degrees, the value is added to the roll setpoint and should correspond to the typical cruise speed of the airframe.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll setpoint offset</p><p><strong>Comment:</strong> An airframe specific offset of the roll setpoint in degrees, the value is added to the roll setpoint and should correspond to the typical cruise speed of the airframe.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">-90.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PSP_OFF">FW_PSP_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch Setpoint Offset</p><p><strong>Comment:</strong> An airframe specific offset of the pitch setpoint in degrees, the value is added to the pitch setpoint and should correspond to the typical cruise speed of the airframe.</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch setpoint offset</p><p><strong>Comment:</strong> An airframe specific offset of the pitch setpoint in degrees, the value is added to the pitch setpoint and should correspond to the typical cruise speed of the airframe.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">-90.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_R_MAX">FW_MAN_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max Manual Roll</p><p><strong>Comment:</strong> Max roll for manual control in attitude stabilized mode</p>    </td>
+ <td style="vertical-align: top;"><p>Max manual roll</p><p><strong>Comment:</strong> Max roll for manual control in attitude stabilized mode</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">45.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_P_MAX">FW_MAN_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max Manual Pitch</p><p><strong>Comment:</strong> Max pitch for manual control in attitude stabilized mode</p>    </td>
+ <td style="vertical-align: top;"><p>Max manual pitch</p><p><strong>Comment:</strong> Max pitch for manual control in attitude stabilized mode</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">45.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_FLAPS_SCL">FW_FLAPS_SCL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Scale factor for flaps</p>    </td>
+ <td style="vertical-align: top;"><p>Scale factor for flaps</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_FLAPERON_SCL">FW_FLAPERON_SCL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Scale factor for flaperons</p>    </td>
+ <td style="vertical-align: top;"><p>Scale factor for flaperons</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_ARSP_MODE">FW_ARSP_MODE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Airspeed mode</p><p><strong>Comment:</strong> The param value sets the method used to publish the control state airspeed. For small wings or VTOL without airspeed sensor this parameter can be used to enable flying without an airspeed reading</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> use measured airspeed</li>
-
-<li><strong>1:</strong> use vehicle ground velocity as airspeed</li>
-
-<li><strong>2:</strong> declare airspeed invalid</li>
-</ul>
-   </td>
- <td style="vertical-align: top;">0 > 2 </td>
+ <td style="vertical-align: top;"><p>Disable airspeed sensor</p><p><strong>Comment:</strong> For small wings or VTOL without airspeed sensor this parameter can be used to enable flying without an airspeed reading</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_R_SC">FW_MAN_R_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual roll scale</p><p><strong>Comment:</strong> Scale factor applied to the desired roll actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    </td>
+ <td style="vertical-align: top;"><p>Manual roll scale</p><p><strong>Comment:</strong> Scale factor applied to the desired roll actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_P_SC">FW_MAN_P_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual pitch scale</p><p><strong>Comment:</strong> Scale factor applied to the desired pitch actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    </td>
+ <td style="vertical-align: top;"><p>Manual pitch scale</p><p><strong>Comment:</strong> Scale factor applied to the desired pitch actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_Y_SC">FW_MAN_Y_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual yaw scale</p><p><strong>Comment:</strong> Scale factor applied to the desired yaw actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    </td>
+ <td style="vertical-align: top;"><p>Manual yaw scale</p><p><strong>Comment:</strong> Scale factor applied to the desired yaw actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_BAT_SCALE_EN">FW_BAT_SCALE_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Whether to scale throttle by battery power level</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The fixed wing should constantly behave as if it was fully charged with reduced max thrust at lower battery percentages. i.e. if cruise speed is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    </td>
+ <td style="vertical-align: top;"><p>Whether to scale throttle by battery power level</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The fixed wing should constantly behave as if it was fully charged with reduced max thrust at lower battery percentages. i.e. if cruise speed is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_ACRO_X_MAX">FW_ACRO_X_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Acro body x max rate</p><p><strong>Comment:</strong> This is the rate the controller is trying to achieve if the user applies full roll stick input in acro mode.</p>    </td>
+ <td style="vertical-align: top;"><p>Acro body x max rate</p><p><strong>Comment:</strong> This is the rate the controller is trying to achieve if the user applies full roll stick input in acro mode.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">45 > 720 </td>
  <td style="vertical-align: top;">90 </td>
  <td style="vertical-align: top;">degrees</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_ACRO_Y_MAX">FW_ACRO_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Acro body y max rate</p><p><strong>Comment:</strong> This is the body y rate the controller is trying to achieve if the user applies full pitch stick input in acro mode.</p>    </td>
+ <td style="vertical-align: top;"><p>Acro body y max rate</p><p><strong>Comment:</strong> This is the body y rate the controller is trying to achieve if the user applies full pitch stick input in acro mode.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">45 > 720 </td>
  <td style="vertical-align: top;">90 </td>
  <td style="vertical-align: top;">degrees</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_ACRO_Z_MAX">FW_ACRO_Z_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Acro body z max rate</p><p><strong>Comment:</strong> This is the body z rate the controller is trying to achieve if the user applies full yaw stick input in acro mode.</p>    </td>
+ <td style="vertical-align: top;"><p>Acro body z max rate</p><p><strong>Comment:</strong> This is the body z rate the controller is trying to achieve if the user applies full yaw stick input in acro mode.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">10 > 180 </td>
  <td style="vertical-align: top;">45 </td>
  <td style="vertical-align: top;">degrees</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RATT_TH">FW_RATT_TH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Threshold for Rattitude mode</p><p><strong>Comment:</strong> Manual input needed in order to override attitude control rate setpoints and instead pass manual stick inputs as rate setpoints</p>    </td>
+ <td style="vertical-align: top;"><p>Threshold for Rattitude mode</p><p><strong>Comment:</strong> Manual input needed in order to override attitude control rate setpoints and instead pass manual stick inputs as rate setpoints</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.8 </td>
  <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_TC">GND_WR_TC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Attitude Wheel Time Constant</p><p><strong>Comment:</strong> This defines the latency between a steering step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.4 > 1.0 (0.05)</td>
+ <td style="vertical-align: top;">0.4 </td>
+ <td style="vertical-align: top;">s</td>
 </tr>
 </tbody></table>
 
 ## FW L1 Control
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/fw_pos_control_l1*.
+The module where these parameters are defined is: *modules/fw_pos_control_l1*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -1889,7 +2445,8 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_LND_HHDIST">FW_LND_HHDIST</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Landing heading hold horizontal distance</p>    </td>
+ <td style="vertical-align: top;"><p>Landing heading hold horizontal distance.
+Set to 0 to disable heading hold</p>    </td>
  <td style="vertical-align: top;">0 > 30.0 (0.5)</td>
  <td style="vertical-align: top;">15.0 </td>
  <td style="vertical-align: top;">m</td>
@@ -1927,7 +2484,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 ## FW Launch detection
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/lib/launchdetection*.
+The module where these parameters are defined is: *lib/launchdetection*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -1982,7 +2539,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_AIRSPD_MIN">FW_AIRSPD_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum Airspeed</p><p><strong>Comment:</strong> If the airspeed falls below this value, the TECS controller will try to increase airspeed more aggressively.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Minimum Airspeed</p><p><strong>Comment:</strong> If the airspeed falls below this value, the TECS controller will try to increase airspeed more aggressively.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
  <td style="vertical-align: top;">10.0 </td>
@@ -1990,15 +2547,23 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_AIRSPD_MAX">FW_AIRSPD_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum Airspeed</p><p><strong>Comment:</strong> If the airspeed is above this value, the TECS controller will try to decrease airspeed more aggressively.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Maximum Airspeed</p><p><strong>Comment:</strong> If the airspeed is above this value, the TECS controller will try to decrease airspeed more aggressively.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
  <td style="vertical-align: top;">20.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="FW_AIRSPD_TRIM">FW_AIRSPD_TRIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Cruise Airspeed</p><p><strong>Comment:</strong> The fixed wing controller tries to fly at this airspeed.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
+ <td style="vertical-align: top;">15.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="FW_T_CLMB_MAX">FW_T_CLMB_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum climb rate</p><p><strong>Comment:</strong> This is the best climb rate that the aircraft can achieve with the throttle set to THR_MAX and the airspeed set to the default value. For electric aircraft make sure this number can be achieved towards the end of flight when the battery voltage has reduced. The setting of this parameter can be checked by commanding a positive altitude change of 100m in loiter, RTL or guided mode. If the throttle required to climb is close to THR_MAX and the aircraft is maintaining airspeed, then this parameter is set correctly. If the airspeed starts to reduce, then the parameter is set to high, and if the throttle demand required to climb and maintain speed is noticeably less than FW_THR_MAX, then either FW_T_CLMB_MAX should be increased or FW_THR_MAX reduced.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Maximum climb rate</p><p><strong>Comment:</strong> This is the best climb rate that the aircraft can achieve with the throttle set to THR_MAX and the airspeed set to the default value. For electric aircraft make sure this number can be achieved towards the end of flight when the battery voltage has reduced. The setting of this parameter can be checked by commanding a positive altitude change of 100m in loiter, RTL or guided mode. If the throttle required to climb is close to THR_MAX and the aircraft is maintaining airspeed, then this parameter is set correctly. If the airspeed starts to reduce, then the parameter is set to high, and if the throttle demand required to climb and maintain speed is noticeably less than FW_THR_MAX, then either FW_T_CLMB_MAX should be increased or FW_THR_MAX reduced.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 15.0 (0.5)</td>
  <td style="vertical-align: top;">5.0 </td>
@@ -2006,7 +2571,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SINK_MIN">FW_T_SINK_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum descent rate</p><p><strong>Comment:</strong> This is the sink rate of the aircraft with the throttle set to THR_MIN and flown at the same airspeed as used to measure FW_T_CLMB_MAX.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Minimum descent rate</p><p><strong>Comment:</strong> This is the sink rate of the aircraft with the throttle set to THR_MIN and flown at the same airspeed as used to measure FW_T_CLMB_MAX.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 5.0 (0.5)</td>
  <td style="vertical-align: top;">2.0 </td>
@@ -2014,7 +2579,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SINK_MAX">FW_T_SINK_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum descent rate</p><p><strong>Comment:</strong> This sets the maximum descent rate that the controller will use. If this value is too large, the aircraft can over-speed on descent. This should be set to a value that can be achieved without exceeding the lower pitch angle limit and without over-speeding the aircraft.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Maximum descent rate</p><p><strong>Comment:</strong> This sets the maximum descent rate that the controller will use. If this value is too large, the aircraft can over-speed on descent. This should be set to a value that can be achieved without exceeding the lower pitch angle limit and without over-speeding the aircraft.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">2.0 > 15.0 (0.5)</td>
  <td style="vertical-align: top;">5.0 </td>
@@ -2022,7 +2587,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_TIME_CONST">FW_T_TIME_CONST</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TECS time constant</p><p><strong>Comment:</strong> This is the time constant of the TECS control algorithm (in seconds). Smaller values make it faster to respond, larger values make it slower to respond.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>TECS time constant</p><p><strong>Comment:</strong> This is the time constant of the TECS control algorithm (in seconds). Smaller values make it faster to respond, larger values make it slower to respond.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">5.0 </td>
@@ -2030,7 +2595,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_THRO_CONST">FW_T_THRO_CONST</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TECS Throttle time constant</p><p><strong>Comment:</strong> This is the time constant of the TECS throttle control algorithm (in seconds). Smaller values make it faster to respond, larger values make it slower to respond.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>TECS Throttle time constant</p><p><strong>Comment:</strong> This is the time constant of the TECS throttle control algorithm (in seconds). Smaller values make it faster to respond, larger values make it slower to respond.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">8.0 </td>
@@ -2038,7 +2603,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_THR_DAMP">FW_T_THR_DAMP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Throttle damping factor</p><p><strong>Comment:</strong> This is the damping gain for the throttle demand loop. Increase to add damping to correct for oscillations in speed and height.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Throttle damping factor</p><p><strong>Comment:</strong> This is the damping gain for the throttle demand loop. Increase to add damping to correct for oscillations in speed and height.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (0.1)</td>
  <td style="vertical-align: top;">0.5 </td>
@@ -2046,7 +2611,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_INTEG_GAIN">FW_T_INTEG_GAIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integrator gain</p><p><strong>Comment:</strong> This is the integrator gain on the control loop. Increasing this gain increases the speed at which speed and height offsets are trimmed out, but reduces damping and increases overshoot.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Integrator gain</p><p><strong>Comment:</strong> This is the integrator gain on the control loop. Increasing this gain increases the speed at which speed and height offsets are trimmed out, but reduces damping and increases overshoot.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (0.05)</td>
  <td style="vertical-align: top;">0.1 </td>
@@ -2054,7 +2619,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_VERT_ACC">FW_T_VERT_ACC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical acceleration</p><p><strong>Comment:</strong> This is the maximum vertical acceleration (in m/s/s) either up or down that the controller will use to correct speed or height errors. The default value of 7 m/s/s (equivalent to +- 0.7 g) allows for reasonably aggressive pitch changes if required to recover from under-speed conditions.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Maximum vertical acceleration</p><p><strong>Comment:</strong> This is the maximum vertical acceleration (in m/s/s) either up or down that the controller will use to correct speed or height errors. The default value of 7 m/s/s (equivalent to +- 0.7 g) allows for reasonably aggressive pitch changes if required to recover from under-speed conditions.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">7.0 </td>
@@ -2062,7 +2627,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_HGT_OMEGA">FW_T_HGT_OMEGA</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Complementary filter "omega" parameter for height</p><p><strong>Comment:</strong> This is the cross-over frequency (in radians/second) of the complementary filter used to fuse vertical acceleration and barometric height to obtain an estimate of height rate and height. Increasing this frequency weights the solution more towards use of the barometer, whilst reducing it weights the solution more towards use of the accelerometer data.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Complementary filter "omega" parameter for height</p><p><strong>Comment:</strong> This is the cross-over frequency (in radians/second) of the complementary filter used to fuse vertical acceleration and barometric height to obtain an estimate of height rate and height. Increasing this frequency weights the solution more towards use of the barometer, whilst reducing it weights the solution more towards use of the accelerometer data.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">3.0 </td>
@@ -2070,7 +2635,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SPD_OMEGA">FW_T_SPD_OMEGA</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Complementary filter "omega" parameter for speed</p><p><strong>Comment:</strong> This is the cross-over frequency (in radians/second) of the complementary filter used to fuse longitudinal acceleration and airspeed to obtain an improved airspeed estimate. Increasing this frequency weights the solution more towards use of the airspeed sensor, whilst reducing it weights the solution more towards use of the accelerometer data.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Complementary filter "omega" parameter for speed</p><p><strong>Comment:</strong> This is the cross-over frequency (in radians/second) of the complementary filter used to fuse longitudinal acceleration and airspeed to obtain an improved airspeed estimate. Increasing this frequency weights the solution more towards use of the airspeed sensor, whilst reducing it weights the solution more towards use of the accelerometer data.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">2.0 </td>
@@ -2078,7 +2643,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_RLL2THR">FW_T_RLL2THR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll -> Throttle feedforward</p><p><strong>Comment:</strong> Increasing this gain turn increases the amount of throttle that will be used to compensate for the additional drag created by turning. Ideally this should be set to  approximately 10 x the extra sink rate in m/s created by a 45 degree bank turn. Increase this gain if the aircraft initially loses energy in turns and reduce if the aircraft initially gains energy in turns. Efficient high aspect-ratio aircraft (eg powered sailplanes) can use a lower value, whereas inefficient low aspect-ratio models (eg delta wings) can use a higher value.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Roll -> Throttle feedforward</p><p><strong>Comment:</strong> Increasing this gain turn increases the amount of throttle that will be used to compensate for the additional drag created by turning. Ideally this should be set to  approximately 10 x the extra sink rate in m/s created by a 45 degree bank turn. Increase this gain if the aircraft initially loses energy in turns and reduce if the aircraft initially gains energy in turns. Efficient high aspect-ratio aircraft (eg powered sailplanes) can use a lower value, whereas inefficient low aspect-ratio models (eg delta wings) can use a higher value.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 20.0 (0.5)</td>
  <td style="vertical-align: top;">15.0 </td>
@@ -2086,7 +2651,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SPDWEIGHT">FW_T_SPDWEIGHT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Speed <--> Altitude priority</p><p><strong>Comment:</strong> This parameter adjusts the amount of weighting that the pitch control applies to speed vs height errors. Setting it to 0.0 will cause the pitch control to control height and ignore speed errors. This will normally improve height accuracy but give larger airspeed errors. Setting it to 2.0 will cause the pitch control loop to control speed and ignore height errors. This will normally reduce airspeed errors, but give larger height errors. The default value of 1.0 allows the pitch control to simultaneously control height and speed. Note to Glider Pilots - set this parameter to 2.0 (The glider will adjust its pitch angle to maintain airspeed, ignoring changes in height).</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Speed <--> Altitude priority</p><p><strong>Comment:</strong> This parameter adjusts the amount of weighting that the pitch control applies to speed vs height errors. Setting it to 0.0 will cause the pitch control to control height and ignore speed errors. This will normally improve height accuracy but give larger airspeed errors. Setting it to 2.0 will cause the pitch control loop to control speed and ignore height errors. This will normally reduce airspeed errors, but give larger height errors. The default value of 1.0 allows the pitch control to simultaneously control height and speed. Note to Glider Pilots - set this parameter to 2.0 (The glider will adjust its pitch angle to maintain airspeed, ignoring changes in height).</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (1.0)</td>
  <td style="vertical-align: top;">1.0 </td>
@@ -2094,7 +2659,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_PTCH_DAMP">FW_T_PTCH_DAMP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch damping factor</p><p><strong>Comment:</strong> This is the damping gain for the pitch demand loop. Increase to add damping to correct for oscillations in height. The default value of 0.0 will work well provided the pitch to servo controller has been tuned properly.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Pitch damping factor</p><p><strong>Comment:</strong> This is the damping gain for the pitch demand loop. Increase to add damping to correct for oscillations in height. The default value of 0.0 will work well provided the pitch to servo controller has been tuned properly.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (0.1)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -2102,7 +2667,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_HRATE_P">FW_T_HRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Height rate proportional factor</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Height rate proportional factor</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.05 </td>
@@ -2110,7 +2675,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_HRATE_FF">FW_T_HRATE_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Height rate feed forward</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Height rate feed forward</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.8 </td>
@@ -2118,18 +2683,26 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SRATE_P">FW_T_SRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Speed rate P factor</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Speed rate P factor</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (0.01)</td>
  <td style="vertical-align: top;">0.02 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="FW_AIRSPD_TRIM">FW_AIRSPD_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Cruise Airspeed</p><p><strong>Comment:</strong> The fixed wing controller tries to fly at this airspeed.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_TRIM">GND_SPEED_TRIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Trim ground speed</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
- <td style="vertical-align: top;">15.0 </td>
+ <td style="vertical-align: top;">3.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_MAX">GND_SPEED_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum ground speed</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
+ <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 </tbody></table>
@@ -2137,7 +2710,7 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 ## Follow target
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2177,10 +2750,207 @@ but also ignore less noise</p>    </td>
 </tr>
 </tbody></table>
 
+## GND Attitude Control
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_P">GND_WR_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate proportional gain</p><p><strong>Comment:</strong> This defines how much the wheel steering input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">%/rad/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_I">GND_WR_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.00 > 0.5 (0.005)</td>
+ <td style="vertical-align: top;">0.00 </td>
+ <td style="vertical-align: top;">%/rad</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_D">GND_WR_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator gain</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.00 > 30 (0.005)</td>
+ <td style="vertical-align: top;">0.00 </td>
+ <td style="vertical-align: top;">%/rad</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_IMAX">GND_WR_IMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_W_RMAX">GND_W_RMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum wheel steering rate</p><p><strong>Comment:</strong> This limits the maximum wheel steering rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
+ <td style="vertical-align: top;">90.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_FF">GND_WR_FF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">%/rad/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_MAN_Y_SC">GND_MAN_Y_SC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Manual yaw scale</p><p><strong>Comment:</strong> Scale factor applied to the desired yaw actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? (0.01)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_GSPD_SP_TRIM">GND_GSPD_SP_TRIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Groundspeed speed trim</p><p><strong>Comment:</strong> This allows to scale the turning radius depending on the speed.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? (0.1)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_BAT_SCALE_EN">GND_BAT_SCALE_EN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Whether to scale throttle by battery power level</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The fixed wing should constantly behave as if it was fully charged with reduced max thrust at lower battery percentages. i.e. if cruise speed is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SP_CTRL_MODE">GND_SP_CTRL_MODE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Control mode for speed</p><p><strong>Comment:</strong> This allows the user to choose between closed loop gps speed or open loop cruise throttle speed</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> open loop control</li> 
+
+<li><strong>1:</strong> close the loop with gps speed</li> 
+</ul>
+   <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_P">GND_SPEED_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed proportional gain</p><p><strong>Comment:</strong> This is the proportional gain for the speed closed loop controller</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.005 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">2.0 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_I">GND_SPEED_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed Integral gain</p><p><strong>Comment:</strong> This is the integral gain for the speed closed loop controller</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.00 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_D">GND_SPEED_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed proportional gain</p><p><strong>Comment:</strong> This is the derivative gain for the speed closed loop controller</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.00 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_IMAX">GND_SPEED_IMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed integral maximum value</p><p><strong>Comment:</strong> This is the maxim value the integral can reach to prevent wind-up.</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.005 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_THR_SC">GND_SPEED_THR_SC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed to throttle scaler</p><p><strong>Comment:</strong> This is a gain to map the speed control output to the throttle linearly.</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.005 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+</tbody></table>
+
+## GND POS Control
+
+
+The module where these parameters are defined is: *modules/gnd_pos_control*.
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_L1_DIST">GND_L1_DIST</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>L1 distance</p><p><strong>Comment:</strong> This is the waypoint radius</p>    </td>
+ <td style="vertical-align: top;">0.0 > 100.0 (0.1)</td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_L1_PERIOD">GND_L1_PERIOD</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>L1 period</p><p><strong>Comment:</strong> This is the L1 distance and defines the tracking point ahead of the rover it's following. Using values around 2-5 for a traxxas stampede. Shorten slowly during tuning until response is sharp without oscillation.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 50.0 (0.5)</td>
+ <td style="vertical-align: top;">10.0 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_L1_DAMPING">GND_L1_DAMPING</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>L1 damping</p><p><strong>Comment:</strong> Damping factor for L1 control.</p>    </td>
+ <td style="vertical-align: top;">0.6 > 0.9 (0.05)</td>
+ <td style="vertical-align: top;">0.75 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_THR_CRUISE">GND_THR_CRUISE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Cruise throttle</p><p><strong>Comment:</strong> This is the throttle setting required to achieve the desired cruise speed. 10% is ok for a traxxas stampede vxl with ESC set to training mode</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_THR_MAX">GND_THR_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Throttle limit max</p><p><strong>Comment:</strong> This is the maximum throttle % that can be used by the controller. For a Traxxas stampede vxl with the ESC set to training, 30 % is enough</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.3 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_THR_MIN">GND_THR_MIN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Throttle limit min</p><p><strong>Comment:</strong> This is the minimum throttle % that can be used by the controller. Set to 0 for rover</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_THR_IDLE">GND_THR_IDLE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Idle throttle</p><p><strong>Comment:</strong> This is the minimum throttle while on the ground, it should be 0 for a rover</p>    </td>
+ <td style="vertical-align: top;">0.0 > 0.4 (0.01)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+</tbody></table>
+
 ## GPS
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/drivers/gps*.
+The module where these parameters are defined is: *drivers/gps*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2191,13 +2961,32 @@ but also ignore less noise</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="GPS_DUMP_COMM">GPS_DUMP_COMM</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Dump GPS communication to a file</p><p><strong>Comment:</strong> If this is set to 1, all GPS communication data will be published via uORB, and written to the log file as gps_dump message.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disable</li>
+<li><strong>0:</strong> Disable</li> 
 
-<li><strong>1:</strong> Enable</li>
+<li><strong>1:</strong> Enable</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GPS_UBX_DYNMODEL">GPS_UBX_DYNMODEL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>u-blox GPS dynamic platform model</p><p><strong>Comment:</strong> u-blox receivers support different dynamic platform models to adjust the navigation engine to the expected application environment.</p> <strong>Values:</strong><ul>
+<li><strong>2:</strong> stationary</li> 
+
+<li><strong>4:</strong> automotive</li> 
+
+<li><strong>6:</strong> airborne with <1g acceleration</li> 
+
+<li><strong>7:</strong> airborne with <2g acceleration</li> 
+
+<li><strong>8:</strong> airborne with <4g acceleration</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 9 </td>
+ <td style="vertical-align: top;">7 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -2205,7 +2994,7 @@ but also ignore less noise</p>    </td>
 ## GPS Failure Navigation
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2215,30 +3004,30 @@ but also ignore less noise</p>    </td>
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_GPSF_LT">NAV_GPSF_LT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Loiter time</p><p><strong>Comment:</strong> The amount of time in seconds the system should do open loop loiter and wait for gps recovery before it goes into flight termination.</p>    </td>
+ <td style="vertical-align: top;"><p>Loiter time</p><p><strong>Comment:</strong> The time in seconds the system should do open loop loiter and wait for GPS recovery before it goes into flight termination. Set to 0 to disable.</p>    </td>
  <td style="vertical-align: top;">0.0 > 3600.0 (1)</td>
- <td style="vertical-align: top;">30.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_GPSF_R">NAV_GPSF_R</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Open loop loiter roll</p><p><strong>Comment:</strong> Roll in degrees during the open loop loiter</p>    </td>
+ <td style="vertical-align: top;"><p>Fixed bank angle</p><p><strong>Comment:</strong> Roll in degrees during the loiter</p>    </td>
  <td style="vertical-align: top;">0.0 > 30.0 (0.5)</td>
  <td style="vertical-align: top;">15.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_GPSF_P">NAV_GPSF_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Open loop loiter pitch</p><p><strong>Comment:</strong> Pitch in degrees during the open loop loiter</p>    </td>
+ <td style="vertical-align: top;"><p>Fixed pitch angle</p><p><strong>Comment:</strong> Pitch in degrees during the open loop loiter</p>    </td>
  <td style="vertical-align: top;">-30.0 > 30.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_GPSF_TR">NAV_GPSF_TR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Open loop loiter thrust</p><p><strong>Comment:</strong> Thrust value which is set during the open loop loiter</p>    </td>
+ <td style="vertical-align: top;"><p>Thrust</p><p><strong>Comment:</strong> Thrust value which is set during the open loop loiter</p>    </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
- <td style="vertical-align: top;">0.7 </td>
+ <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 </tbody></table>
@@ -2246,7 +3035,7 @@ but also ignore less noise</p>    </td>
 ## Geofence
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2257,15 +3046,15 @@ but also ignore less noise</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="GF_ACTION">GF_ACTION</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Geofence violation action</p><p><strong>Comment:</strong> Note: Setting this value to 4 enables flight termination, which will kill the vehicle on violation of the fence. Due to the inherent danger of this, this function is disabled using a software circuit breaker, which needs to be reset to 0 to really shut down the system.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> None</li>
+<li><strong>0:</strong> None</li> 
 
-<li><strong>1:</strong> Warning</li>
+<li><strong>1:</strong> Warning</li> 
 
-<li><strong>2:</strong> Loiter</li>
+<li><strong>2:</strong> Loiter</li> 
 
-<li><strong>3:</strong> Return to Land</li>
+<li><strong>3:</strong> Return to Land</li> 
 
-<li><strong>4:</strong> Flight terminate</li>
+<li><strong>4:</strong> Flight terminate</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 4 </td>
@@ -2275,9 +3064,9 @@ but also ignore less noise</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="GF_ALTMODE">GF_ALTMODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Geofence altitude mode</p><p><strong>Comment:</strong> Select which altitude reference should be used 0 = WGS84, 1 = AMSL</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> WGS84</li>
+<li><strong>0:</strong> WGS84</li> 
 
-<li><strong>1:</strong> AMSL</li>
+<li><strong>1:</strong> AMSL</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 1 </td>
@@ -2287,9 +3076,9 @@ but also ignore less noise</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="GF_SOURCE">GF_SOURCE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Geofence source</p><p><strong>Comment:</strong> Select which position source should be used. Selecting GPS instead of global position makes sure that there is no dependence on the position estimator 0 = global position, 1 = GPS</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> GPOS</li>
+<li><strong>0:</strong> GPOS</li> 
 
-<li><strong>1:</strong> GPS</li>
+<li><strong>1:</strong> GPS</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 1 </td>
@@ -2322,7 +3111,7 @@ but also ignore less noise</p>    </td>
 ## Iridium SBD
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/drivers/iridiumsbd*.
+The module where these parameters are defined is: *drivers/iridiumsbd*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2342,7 +3131,7 @@ but also ignore less noise</p>    </td>
 ## Land Detector
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/land_detector*.
+The module where these parameters are defined is: *modules/land_detector*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2361,7 +3150,7 @@ but also ignore less noise</p>    </td>
  <td style="vertical-align: top;"><strong id="LNDMC_XY_VEL_MAX">LNDMC_XY_VEL_MAX</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Multicopter max horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity allowed in the landed state (m/s)</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.50 </td>
+ <td style="vertical-align: top;">1.5 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
@@ -2391,20 +3180,6 @@ but also ignore less noise</p>    </td>
  <td style="vertical-align: top;">0.02 > 5 </td>
  <td style="vertical-align: top;">0.3 </td>
  <td style="vertical-align: top;">s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="LNDMC_MAN_DWNTHR">LNDMC_MAN_DWNTHR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual flight stick down threshold for landing</p><p><strong>Comment:</strong> When controlling manually the throttle stick value (0 to 1) has to be bellow this threshold in order to pass the check for landing. So if set to 1 it's allowed to land with any stick position.</p>    </td>
- <td style="vertical-align: top;">0 > 1 </td>
- <td style="vertical-align: top;">0.15 </td>
- <td style="vertical-align: top;">norm</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="LNDMC_POS_UPTHR">LNDMC_POS_UPTHR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual position flight stick up threshold for taking off</p><p><strong>Comment:</strong> When controlling manually in position mode the throttle stick value (0 to 1) has to get above this threshold after arming in order to take off.</p>    </td>
- <td style="vertical-align: top;">0 > 1 </td>
- <td style="vertical-align: top;">0.65 </td>
- <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="LNDFW_VEL_XY_MAX">LNDFW_VEL_XY_MAX</strong> (FLOAT)</td>
@@ -2450,9 +3225,9 @@ but also ignore less noise</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="LNDMC_ALT_MAX">LNDMC_ALT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum altitude that can be reached prior to subconditions</p>    </td>
- <td style="vertical-align: top;">10 > 150 </td>
- <td style="vertical-align: top;">100.0 </td>
+ <td style="vertical-align: top;"><p>Maximum altitude for multicopters</p><p><strong>Comment:</strong> The system will obey this limit as a hard altitude limit. This setting will be consolidated with the GF_MAX_VER_DIST parameter. A negative value indicates no altitude limitation.</p>    </td>
+ <td style="vertical-align: top;">-1 > 10000 </td>
+ <td style="vertical-align: top;">-1.0 </td>
  <td style="vertical-align: top;">m</td>
 </tr>
 </tbody></table>
@@ -2460,7 +3235,7 @@ but also ignore less noise</p>    </td>
 ## Local Position Estimator
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/local_position_estimator*.
+The module where these parameters are defined is: *modules/local_position_estimator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2732,14 +3507,14 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="LPE_FUSION">LPE_FUSION</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Integer bitmask controlling data fusion</p><p><strong>Comment:</strong> Set bits in the following positions to enable: 0 : Set to true to fuse GPS data if available, also requires GPS for altitude init 1 : Set to true to fuse optical flow data if available 2 : Set to true to fuse vision position 3 : Set to true to fuse vision yaw 4 : Set to true to fuse land detector 5 : Set to true to publish AGL as local position down component 6 : Set to true to enable flow gyro compensation 7 : Set to true to enable baro fusion default (145 - GPS only)</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> fuse GPS, requires GPS for alt. init</li>
-  <li><strong>1:</strong> fuse optical flow</li>
-  <li><strong>2:</strong> fuse vision position</li>
-  <li><strong>3:</strong> fuse vision yaw</li>
-  <li><strong>4:</strong> fuse land detector</li>
-  <li><strong>5:</strong> pub agl as lpos down</li>
-  <li><strong>6:</strong> flow gyro compensation</li>
-  <li><strong>7:</strong> fuse baro</li>
+ <td style="vertical-align: top;"><p>Integer bitmask controlling data fusion</p><p><strong>Comment:</strong> Set bits in the following positions to enable: 0 : Set to true to fuse GPS data if available, also requires GPS for altitude init 1 : Set to true to fuse optical flow data if available 2 : Set to true to fuse vision position 3 : Set to true to fuse vision yaw 4 : Set to true to fuse land detector 5 : Set to true to publish AGL as local position down component 6 : Set to true to enable flow gyro compensation 7 : Set to true to enable baro fusion default (145 - GPS only)</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> fuse GPS, requires GPS for alt. init</li> 
+  <li><strong>1:</strong> fuse optical flow</li> 
+  <li><strong>2:</strong> fuse vision position</li> 
+  <li><strong>3:</strong> fuse vision yaw</li> 
+  <li><strong>4:</strong> fuse land detector</li> 
+  <li><strong>5:</strong> pub agl as lpos down</li> 
+  <li><strong>6:</strong> flow gyro compensation</li> 
+  <li><strong>7:</strong> fuse baro</li> 
 </ul>
   </td>
  <td style="vertical-align: top;">0 > 255 </td>
@@ -2751,7 +3526,7 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 ## MAVLink
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/mavlink*.
+The module where these parameters are defined is: *modules/mavlink*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2761,14 +3536,16 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="MAV_SYS_ID">MAV_SYS_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>MAVLink system ID</p>    </td>
+ <td style="vertical-align: top;"><p>MAVLink system ID</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">1 > 250 </td>
  <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MAV_COMP_ID">MAV_COMP_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>MAVLink component ID</p>    </td>
+ <td style="vertical-align: top;"><p>MAVLink component ID</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">1 > 250 </td>
  <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
@@ -2776,11 +3553,11 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 <tr>
  <td style="vertical-align: top;"><strong id="MAV_PROTO_VER">MAV_PROTO_VER</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>MAVLink protocol version</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Default to 1, switch to 2 if GCS sends version 2</li>
+<li><strong>0:</strong> Default to 1, switch to 2 if GCS sends version 2</li> 
 
-<li><strong>1:</strong> Always use version 1</li>
+<li><strong>1:</strong> Always use version 1</li> 
 
-<li><strong>2:</strong> Always use version 2</li>
+<li><strong>2:</strong> Always use version 2</li> 
 </ul>
    </td>
  <td style="vertical-align: top;"></td>
@@ -2818,9 +3595,9 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 <tr>
  <td style="vertical-align: top;"><strong id="MAV_BROADCAST">MAV_BROADCAST</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Broadcast heartbeats on local network</p><p><strong>Comment:</strong> This allows a ground control station to automatically find the drone on the local network.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Never broadcast</li>
+<li><strong>0:</strong> Never broadcast</li> 
 
-<li><strong>1:</strong> Always broadcast</li>
+<li><strong>1:</strong> Always broadcast</li> 
 </ul>
    </td>
  <td style="vertical-align: top;"></td>
@@ -2839,7 +3616,7 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 ## MKBLCTRL Testmode
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/drivers/mkblctrl*.
+The module where these parameters are defined is: *drivers/mkblctrl*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2856,83 +3633,6 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 </tr>
 </tbody></table>
 
-## MPU9x50 Configuration
-
-
-이 파라미터가 정의되어 있는 모듈 : *src/platforms/qurt/fc_addon/mpu_spi*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="MPU_GYRO_LPF_ENM">MPU_GYRO_LPF_ENM</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Low pass filter frequency for Gyro</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> MPU9X50_GYRO_LPF_250HZ</li>
-
-<li><strong>1:</strong> MPU9X50_GYRO_LPF_184HZ</li>
-
-<li><strong>2:</strong> MPU9X50_GYRO_LPF_92HZ</li>
-
-<li><strong>3:</strong> MPU9X50_GYRO_LPF_41HZ</li>
-
-<li><strong>4:</strong> MPU9X50_GYRO_LPF_20HZ</li>
-
-<li><strong>5:</strong> MPU9X50_GYRO_LPF_10HZ</li>
-
-<li><strong>6:</strong> MPU9X50_GYRO_LPF_5HZ</li>
-
-<li><strong>7:</strong> MPU9X50_GYRO_LPF_3600HZ_NOLPF</li>
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">4 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPU_ACC_LPF_ENM">MPU_ACC_LPF_ENM</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Low pass filter frequency for Accelerometer</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> MPU9X50_ACC_LPF_460HZ</li>
-
-<li><strong>1:</strong> MPU9X50_ACC_LPF_184HZ</li>
-
-<li><strong>2:</strong> MPU9X50_ACC_LPF_92HZ</li>
-
-<li><strong>3:</strong> MPU9X50_ACC_LPF_41HZ</li>
-
-<li><strong>4:</strong> MPU9X50_ACC_LPF_20HZ</li>
-
-<li><strong>5:</strong> MPU9X50_ACC_LPF_10HZ</li>
-
-<li><strong>6:</strong> MPU9X50_ACC_LPF_5HZ</li>
-
-<li><strong>7:</strong> MPU9X50_ACC_LPF_460HZ_NOLPF</li>
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">4 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPU_SAMPLE_R_ENM">MPU_SAMPLE_R_ENM</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Sample rate in Hz</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> MPU9x50_SAMPLE_RATE_100HZ</li>
-
-<li><strong>1:</strong> MPU9x50_SAMPLE_RATE_200HZ</li>
-
-<li><strong>2:</strong> MPU9x50_SAMPLE_RATE_500HZ</li>
-
-<li><strong>3:</strong> MPU9x50_SAMPLE_RATE_1000HZ</li>
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-</tbody></table>
-
 ## Mission
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
@@ -2942,128 +3642,8 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_OBL_ACT">COM_OBL_ACT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set offboard loss failsafe mode</p><p><strong>Comment:</strong> The offboard loss failsafe will only be entered after a timeout, set by COM_OF_LOSS_T in seconds.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Land at current position</li>
-
-<li><strong>1:</strong> Loiter</li>
-
-<li><strong>2:</strong> Return to Land</li>
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_OBL_RC_ACT">COM_OBL_RC_ACT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set offboard loss failsafe mode when RC is available</p><p><strong>Comment:</strong> The offboard loss failsafe will only be entered after a timeout, set by COM_OF_LOSS_T in seconds.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Position control</li>
-
-<li><strong>1:</strong> Altitude control</li>
-
-<li><strong>2:</strong> Manual</li>
-
-<li><strong>3:</strong> Return to Land</li>
-
-<li><strong>4:</strong> Land at current position</li>
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_LOITER_RAD">NAV_LOITER_RAD</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Loiter radius (FW only)</p><p><strong>Comment:</strong> Default value of loiter radius for missions, loiter, RTL, etc. (fixedwing only).</p>    <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;">25 > 1000 (0.5)</td>
- <td style="vertical-align: top;">50.0 </td>
- <td style="vertical-align: top;">m</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_ACC_RAD">NAV_ACC_RAD</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Acceptance Radius</p><p><strong>Comment:</strong> Default acceptance radius, overridden by acceptance radius of waypoint if set. For fixed wing the L1 turning distance is used for horizontal acceptance.</p>    <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
- <td style="vertical-align: top;">10.0 </td>
- <td style="vertical-align: top;">m</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_FW_ALT_RAD">NAV_FW_ALT_RAD</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>FW Altitude Acceptance Radius</p><p><strong>Comment:</strong> Acceptance radius for fixedwing altitude.</p>    <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
- <td style="vertical-align: top;">10.0 </td>
- <td style="vertical-align: top;">m</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_MC_ALT_RAD">NAV_MC_ALT_RAD</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>MC Altitude Acceptance Radius</p><p><strong>Comment:</strong> Acceptance radius for multicopter altitude.</p>    <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
- <td style="vertical-align: top;">0.8 </td>
- <td style="vertical-align: top;">m</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_DLL_ACT">NAV_DLL_ACT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set data link loss failsafe mode</p><p><strong>Comment:</strong> The data link loss failsafe will only be entered after a timeout, set by COM_DL_LOSS_T in seconds. Once the timeout occurs the selected action will be executed. Setting this parameter to 4 will enable CASA Outback Challenge rules, which are only recommended to participants of that competition.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li>
-
-<li><strong>1:</strong> Loiter</li>
-
-<li><strong>2:</strong> Return to Land</li>
-
-<li><strong>3:</strong> Land at current position</li>
-
-<li><strong>4:</strong> Data Link Auto Recovery (CASA Outback Challenge rules)</li>
-
-<li><strong>5:</strong> Terminate</li>
-
-<li><strong>6:</strong> Lockdown</li>
-</ul>
-   <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_RCL_ACT">NAV_RCL_ACT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set RC loss failsafe mode</p><p><strong>Comment:</strong> The RC loss failsafe will only be entered after a timeout, set by COM_RC_LOSS_T in seconds. If RC input checks have been disabled by setting the COM_RC_IN_MODE param it will not be triggered. Setting this parameter to 4 will enable CASA Outback Challenge rules, which are only recommended to participants of that competition.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li>
-
-<li><strong>1:</strong> Loiter</li>
-
-<li><strong>2:</strong> Return to Land</li>
-
-<li><strong>3:</strong> Land at current position</li>
-
-<li><strong>4:</strong> RC Auto Recovery (CASA Outback Challenge rules)</li>
-
-<li><strong>5:</strong> Terminate</li>
-
-<li><strong>6:</strong> Lockdown</li>
-</ul>
-   <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_FORCE_VT">NAV_FORCE_VT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Force VTOL mode takeoff and land</p>    <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MIS_TAKEOFF_ALT">MIS_TAKEOFF_ALT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Take-off altitude</p><p><strong>Comment:</strong> This is the minimum altitude the system will take off to.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Take-off altitude</p><p><strong>Comment:</strong> This is the minimum altitude the system will take off to.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0 > 80 (0.5)</td>
  <td style="vertical-align: top;">2.5 </td>
@@ -3071,15 +3651,15 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_LTRMIN_ALT">MIS_LTRMIN_ALT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum Loiter altitude</p><p><strong>Comment:</strong> This is the minimum altitude the system will always obey. The intent is to stay out of ground effect.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Minimum Loiter altitude</p><p><strong>Comment:</strong> This is the minimum altitude the system will always obey. The intent is to stay out of ground effect. set to -1, if there shouldn't be a minimum loiter altitude</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
- <td style="vertical-align: top;">0 > 80 (0.5)</td>
- <td style="vertical-align: top;">1.2 </td>
+ <td style="vertical-align: top;">-1 > 80 (0.5)</td>
+ <td style="vertical-align: top;">-1.0 </td>
  <td style="vertical-align: top;">m</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_ONBOARD_EN">MIS_ONBOARD_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Persistent onboard mission storage</p><p><strong>Comment:</strong> When enabled, missions that have been uploaded by the GCS are stored and reloaded after reboot persistently.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Persistent onboard mission storage</p><p><strong>Comment:</strong> When enabled, missions that have been uploaded by the GCS are stored and reloaded after reboot persistently.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -3087,20 +3667,28 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_DIST_1WP">MIS_DIST_1WP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal horizontal distance from home to first waypoint</p><p><strong>Comment:</strong> Failsafe check to prevent running mission stored from previous flight at a new takeoff location. Set a value of zero or less to disable. The mission will not be started if the current waypoint is more distant than MIS_DIS_1WP from the home position.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Maximal horizontal distance from home to first waypoint</p><p><strong>Comment:</strong> Failsafe check to prevent running mission stored from previous flight at a new takeoff location. Set a value of zero or less to disable. The mission will not be started if the current waypoint is more distant than MIS_DIS_1WP from the home position.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
- <td style="vertical-align: top;">0 > 1000 (0.5)</td>
+ <td style="vertical-align: top;">0 > 10000 (100)</td>
+ <td style="vertical-align: top;">900 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MIS_DIST_WPS">MIS_DIST_WPS</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximal horizontal distance between waypoint</p><p><strong>Comment:</strong> Failsafe check to prevent running missions which are way too big. Set a value of zero or less to disable. The mission will not be started if any distance between two subsequent waypoints is greater than MIS_DIST_WPS.</p>    <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;">0 > 10000 (100)</td>
  <td style="vertical-align: top;">900 </td>
  <td style="vertical-align: top;">m</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_ALTMODE">MIS_ALTMODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Altitude setpoint mode</p><p><strong>Comment:</strong> 0: the system will follow a zero order hold altitude setpoint 1: the system will follow a first order hold altitude setpoint values follow the definition in enum mission_altitude_mode</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Zero Order Hold</li>
+<li><strong>0:</strong> Zero Order Hold</li> 
 
-<li><strong>1:</strong> First Order Hold</li>
+<li><strong>1:</strong> First Order Hold</li> 
 </ul>
-   <p><b>Module:</b> src/modules/navigator</p>
+   <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">1 </td>
@@ -3109,15 +3697,17 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_YAWMODE">MIS_YAWMODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Multirotor only. Yaw setpoint mode</p><p><strong>Comment:</strong> The values are defined in the enum mission_altitude_mode</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Heading as set by waypoint</li>
+<li><strong>0:</strong> Heading as set by waypoint</li> 
 
-<li><strong>1:</strong> Heading towards waypoint</li>
+<li><strong>1:</strong> Heading towards waypoint</li> 
 
-<li><strong>2:</strong> Heading towards home</li>
+<li><strong>2:</strong> Heading towards home</li> 
 
-<li><strong>3:</strong> Heading away from home</li>
+<li><strong>3:</strong> Heading away from home</li> 
+
+<li><strong>4:</strong> Heading towards ROI</li> 
 </ul>
-   <p><b>Module:</b> src/modules/navigator</p>
+   <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0 > 3 </td>
  <td style="vertical-align: top;">1 </td>
@@ -3125,7 +3715,7 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_YAW_TMT">MIS_YAW_TMT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Time in seconds we wait on reaching target heading at a waypoint if it is forced</p><p><strong>Comment:</strong> If set > 0 it will ignore the target heading for normal waypoint acceptance. If the waypoint forces the heading the timeout will matter. For example on VTOL forwards transiton. Mainly useful for VTOLs that have less yaw authority and might not reach target yaw in wind. Disabled by default.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Time in seconds we wait on reaching target heading at a waypoint if it is forced</p><p><strong>Comment:</strong> If set > 0 it will ignore the target heading for normal waypoint acceptance. If the waypoint forces the heading the timeout will matter. For example on VTOL forwards transition. Mainly useful for VTOLs that have less yaw authority and might not reach target yaw in wind. Disabled by default.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">-1 > 20 (1)</td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -3133,23 +3723,118 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_YAW_ERR">MIS_YAW_ERR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max yaw error in degrees needed for waypoint heading acceptance</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Max yaw error in degrees needed for waypoint heading acceptance</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0 > 90 (1)</td>
  <td style="vertical-align: top;">12.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="VT_WV_LND_EN">VT_WV_LND_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Weather-vane mode landings for missions</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><strong id="NAV_LOITER_RAD">NAV_LOITER_RAD</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Loiter radius (FW only)</p><p><strong>Comment:</strong> Default value of loiter radius for missions, loiter, RTL, etc. (fixedwing only).</p>    <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;">25 > 1000 (0.5)</td>
+ <td style="vertical-align: top;">50.0 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_ACC_RAD">NAV_ACC_RAD</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Acceptance Radius</p><p><strong>Comment:</strong> Default acceptance radius, overridden by acceptance radius of waypoint if set. For fixed wing the L1 turning distance is used for horizontal acceptance.</p>    <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
+ <td style="vertical-align: top;">10.0 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_FW_ALT_RAD">NAV_FW_ALT_RAD</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>FW Altitude Acceptance Radius</p><p><strong>Comment:</strong> Acceptance radius for fixedwing altitude.</p>    <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
+ <td style="vertical-align: top;">10.0 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_MC_ALT_RAD">NAV_MC_ALT_RAD</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>MC Altitude Acceptance Radius</p><p><strong>Comment:</strong> Acceptance radius for multicopter altitude.</p>    <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
+ <td style="vertical-align: top;">0.8 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_DLL_ACT">NAV_DLL_ACT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set data link loss failsafe mode</p><p><strong>Comment:</strong> The data link loss failsafe will only be entered after a timeout, set by COM_DL_LOSS_T in seconds. Once the timeout occurs the selected action will be executed. Setting this parameter to 4 will enable CASA Outback Challenge rules, which are only recommended to participants of that competition.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> Loiter</li> 
+
+<li><strong>2:</strong> Return to Land</li> 
+
+<li><strong>3:</strong> Land at current position</li> 
+
+<li><strong>4:</strong> Data Link Auto Recovery (CASA Outback Challenge rules)</li> 
+
+<li><strong>5:</strong> Terminate</li> 
+
+<li><strong>6:</strong> Lockdown</li> 
+</ul>
+   <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="NAV_RCL_ACT">NAV_RCL_ACT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set RC loss failsafe mode</p><p><strong>Comment:</strong> The RC loss failsafe will only be entered after a timeout, set by COM_RC_LOSS_T in seconds. If RC input checks have been disabled by setting the COM_RC_IN_MODE param it will not be triggered. Setting this parameter to 4 will enable CASA Outback Challenge rules, which are only recommended to participants of that competition.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> Loiter</li> 
+
+<li><strong>2:</strong> Return to Land</li> 
+
+<li><strong>3:</strong> Land at current position</li> 
+
+<li><strong>4:</strong> RC Auto Recovery (CASA Outback Challenge rules)</li> 
+
+<li><strong>5:</strong> Terminate</li> 
+
+<li><strong>6:</strong> Lockdown</li> 
+</ul>
+   <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">2 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_TRAFF_AVOID">NAV_TRAFF_AVOID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set traffic avoidance mode</p><p><strong>Comment:</strong> Enabling this will allow the system to respond to transponder data from e.g. ADSB transponders</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> Warn only</li> 
+
+<li><strong>2:</strong> Return to Land</li> 
+
+<li><strong>3:</strong> Land immediately</li> 
+</ul>
+   <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_FORCE_VT">NAV_FORCE_VT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Force VTOL mode takeoff and land</p>    <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="VT_WV_TKO_EN">VT_WV_TKO_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable weather-vane mode takeoff for missions</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Enable weather-vane mode takeoff for missions</p>    <p><b>Module:</b> modules/vtol_att_control</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -3157,7 +3842,64 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="VT_WV_LTR_EN">VT_WV_LTR_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Weather-vane mode for loiter</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Weather-vane mode for loiter</p>    <p><b>Module:</b> modules/vtol_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_WV_LND_EN">VT_WV_LND_EN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Weather-vane mode landings for missions</p>    <p><b>Module:</b> modules/vtol_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_OBL_ACT">COM_OBL_ACT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set offboard loss failsafe mode</p><p><strong>Comment:</strong> The offboard loss failsafe will only be entered after a timeout, set by COM_OF_LOSS_T in seconds.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Land at current position</li> 
+
+<li><strong>1:</strong> Loiter</li> 
+
+<li><strong>2:</strong> Return to Land</li> 
+</ul>
+   <p><b>Module:</b> modules/commander</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_OBL_RC_ACT">COM_OBL_RC_ACT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set offboard loss failsafe mode when RC is available</p><p><strong>Comment:</strong> The offboard loss failsafe will only be entered after a timeout, set by COM_OF_LOSS_T in seconds.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Position control</li> 
+
+<li><strong>1:</strong> Altitude control</li> 
+
+<li><strong>2:</strong> Manual</li> 
+
+<li><strong>3:</strong> Return to Land</li> 
+
+<li><strong>4:</strong> Land at current position</li> 
+
+<li><strong>5:</strong> Loiter</li> 
+</ul>
+   <p><b>Module:</b> modules/commander</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_POSCTL_NAVL">COM_POSCTL_NAVL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Position control navigation loss response</p><p><strong>Comment:</strong> This sets the flight mode that will be used if navigation accuracy is no longer adequte for position control. Navigation accuracy checks can be disabled using the CBRK_VELPOSERR parameter, but doing so will remove protection for all flight modes.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Assume use of remote control after fallback. Switch to ALTCTL if a height estimate is available, else switch to MANUAL.</li> 
+
+<li><strong>1:</strong> Assume no use of remote control after fallback. Switch to DESCEND if a height estimate is available, else switch to TERMINATION.</li> 
+</ul>
+   <p><b>Module:</b> modules/commander</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -3168,7 +3910,7 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 ## Mount
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/drivers/vmount*.
+The module where these parameters are defined is: *drivers/vmount*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -3178,19 +3920,16 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MODE_IN">MNT_MODE_IN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Mount input mode
-RC uses the AUX input channels (see MNT_MAN_* parameters),
-MAVLINK_ROI uses the MAV_CMD_DO_SET_ROI Mavlink message, and MAVLINK_DO_MOUNT the
-MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mount</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> DISABLED</li>
+ <td style="vertical-align: top;"><p>Mount input mode</p><p><strong>Comment:</strong> RC uses the AUX input channels (see MNT_MAN_* parameters), MAVLINK_ROI uses the MAV_CMD_DO_SET_ROI Mavlink message, and MAVLINK_DO_MOUNT the MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mount.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> DISABLED</li> 
 
-<li><strong>0:</strong> AUTO</li>
+<li><strong>0:</strong> AUTO</li> 
 
-<li><strong>1:</strong> RC</li>
+<li><strong>1:</strong> RC</li> 
 
-<li><strong>2:</strong> MAVLINK_ROI</li>
+<li><strong>2:</strong> MAVLINK_ROI</li> 
 
-<li><strong>3:</strong> MAVLINK_DO_MOUNT</li>
+<li><strong>3:</strong> MAVLINK_DO_MOUNT</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
  </td>
@@ -3200,13 +3939,10 @@ MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mo
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MODE_OUT">MNT_MODE_OUT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Mount output mode
-AUX uses the mixer output Control Group #2.
-MAVLINK uses the MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL MavLink messages
-to control a mount (set MNT_MAV_SYSID & MNT_MAV_COMPID)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> AUX</li>
+ <td style="vertical-align: top;"><p>Mount output mode</p><p><strong>Comment:</strong> AUX uses the mixer output Control Group #2. MAVLINK uses the MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL MavLink messages to control a mount (set MNT_MAV_SYSID & MNT_MAV_COMPID)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> AUX</li> 
 
-<li><strong>1:</strong> MAVLINK</li>
+<li><strong>1:</strong> MAVLINK</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 1 </td>
@@ -3215,16 +3951,16 @@ to control a mount (set MNT_MAV_SYSID & MNT_MAV_COMPID)</p> <strong>Values:</str
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MAV_SYSID">MNT_MAV_SYSID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Mavlink System ID (if MNT_MODE_OUT is MAVLINK)</p>    </td>
+ <td style="vertical-align: top;"><p>Mavlink System ID of the mount</p><p><strong>Comment:</strong> If MNT_MODE_OUT is MAVLINK, mount configure/control commands will be sent with this target ID.</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">71 </td>
+ <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MAV_COMPID">MNT_MAV_COMPID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Mavlink Component ID (if MNT_MODE_OUT is MAVLINK)</p>    </td>
+ <td style="vertical-align: top;"><p>Mavlink Component ID of the mount</p><p><strong>Comment:</strong> If MNT_MODE_OUT is MAVLINK, mount configure/control commands will be sent with this component ID.</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">67 </td>
+ <td style="vertical-align: top;">154 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -3246,17 +3982,17 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MAN_ROLL">MNT_MAN_ROLL</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Auxiliary channel to control roll (in AUX input or manual mode)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disable</li>
+<li><strong>0:</strong> Disable</li> 
 
-<li><strong>1:</strong> AUX1</li>
+<li><strong>1:</strong> AUX1</li> 
 
-<li><strong>2:</strong> AUX2</li>
+<li><strong>2:</strong> AUX2</li> 
 
-<li><strong>3:</strong> AUX3</li>
+<li><strong>3:</strong> AUX3</li> 
 
-<li><strong>4:</strong> AUX4</li>
+<li><strong>4:</strong> AUX4</li> 
 
-<li><strong>5:</strong> AUX5</li>
+<li><strong>5:</strong> AUX5</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 5 </td>
@@ -3266,17 +4002,17 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MAN_PITCH">MNT_MAN_PITCH</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Auxiliary channel to control pitch (in AUX input or manual mode)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disable</li>
+<li><strong>0:</strong> Disable</li> 
 
-<li><strong>1:</strong> AUX1</li>
+<li><strong>1:</strong> AUX1</li> 
 
-<li><strong>2:</strong> AUX2</li>
+<li><strong>2:</strong> AUX2</li> 
 
-<li><strong>3:</strong> AUX3</li>
+<li><strong>3:</strong> AUX3</li> 
 
-<li><strong>4:</strong> AUX4</li>
+<li><strong>4:</strong> AUX4</li> 
 
-<li><strong>5:</strong> AUX5</li>
+<li><strong>5:</strong> AUX5</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 5 </td>
@@ -3286,21 +4022,71 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MAN_YAW">MNT_MAN_YAW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Auxiliary channel to control yaw (in AUX input or manual mode)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disable</li>
+<li><strong>0:</strong> Disable</li> 
 
-<li><strong>1:</strong> AUX1</li>
+<li><strong>1:</strong> AUX1</li> 
 
-<li><strong>2:</strong> AUX2</li>
+<li><strong>2:</strong> AUX2</li> 
 
-<li><strong>3:</strong> AUX3</li>
+<li><strong>3:</strong> AUX3</li> 
 
-<li><strong>4:</strong> AUX4</li>
+<li><strong>4:</strong> AUX4</li> 
 
-<li><strong>5:</strong> AUX5</li>
+<li><strong>5:</strong> AUX5</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 5 </td>
  <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_DO_STAB">MNT_DO_STAB</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Stabilize the mount (set to true for servo gimbal, false for passthrough).
+Does not affect MAVLINK_ROI input</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_RANGE_PITCH">MNT_RANGE_PITCH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Range of pitch channel output in degrees (only in AUX output mode)</p>    </td>
+ <td style="vertical-align: top;">1.0 > 720.0 </td>
+ <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_RANGE_ROLL">MNT_RANGE_ROLL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Range of roll channel output in degrees (only in AUX output mode)</p>    </td>
+ <td style="vertical-align: top;">1.0 > 720.0 </td>
+ <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_RANGE_YAW">MNT_RANGE_YAW</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Range of yaw channel output in degrees (only in AUX output mode)</p>    </td>
+ <td style="vertical-align: top;">1.0 > 720.0 </td>
+ <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_OFF_PITCH">MNT_OFF_PITCH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Offset for pitch channel output in degrees</p>    </td>
+ <td style="vertical-align: top;">-360.0 > 360.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_OFF_ROLL">MNT_OFF_ROLL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Offset for roll channel output in degrees</p>    </td>
+ <td style="vertical-align: top;">-360.0 > 360.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_OFF_YAW">MNT_OFF_YAW</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Offset for yaw channel output in degrees</p>    </td>
+ <td style="vertical-align: top;">-360.0 > 360.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -3314,168 +4100,8 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="MP_ROLL_P">MP_ROLL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll P gain</p><p><strong>Comment:</strong> Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">6.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ROLLRATE_P">MP_ROLLRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate P gain</p><p><strong>Comment:</strong> Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ROLLRATE_I">MP_ROLLRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate I gain</p><p><strong>Comment:</strong> Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ROLLRATE_D">MP_ROLLRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate D gain</p><p><strong>Comment:</strong> Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.002 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_PITCH_P">MP_PITCH_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch P gain</p><p><strong>Comment:</strong> Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">6.0 </td>
- <td style="vertical-align: top;">1/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_PITCHRATE_P">MP_PITCHRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate P gain</p><p><strong>Comment:</strong> Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_PITCHRATE_I">MP_PITCHRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate I gain</p><p><strong>Comment:</strong> Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_PITCHRATE_D">MP_PITCHRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate D gain</p><p><strong>Comment:</strong> Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.002 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAW_P">MP_YAW_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw P gain</p><p><strong>Comment:</strong> Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">2.0 </td>
- <td style="vertical-align: top;">1/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAWRATE_P">MP_YAWRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate P gain</p><p><strong>Comment:</strong> Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.3 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAWRATE_I">MP_YAWRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate I gain</p><p><strong>Comment:</strong> Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAWRATE_D">MP_YAWRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate D gain</p><p><strong>Comment:</strong> Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAW_FF">MP_YAW_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw feed forward</p><p><strong>Comment:</strong> Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAWRATE_MAX">MP_YAWRATE_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max yaw rate</p><p><strong>Comment:</strong> Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 360.0 </td>
- <td style="vertical-align: top;">60.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ACRO_R_MAX">MP_ACRO_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro roll rate</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 360.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ACRO_P_MAX">MP_ACRO_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro pitch rate</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 360.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ACRO_Y_MAX">MP_ACRO_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro yaw rate</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">120.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_MAN_R_MAX">MPP_MAN_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual roll</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_MAN_P_MAX">MPP_MAN_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual pitch</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_MAN_Y_MAX">MPP_MAN_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual yaw rate</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">120.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MC_ROLL_TC">MC_ROLL_TC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll time constant</p><p><strong>Comment:</strong> Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll time constant</p><p><strong>Comment:</strong> Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.15 > 0.25 (0.01)</td>
  <td style="vertical-align: top;">0.2 </td>
@@ -3483,7 +4109,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCH_TC">MC_PITCH_TC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch time constant</p><p><strong>Comment:</strong> Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch time constant</p><p><strong>Comment:</strong> Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.15 > 0.25 (0.01)</td>
  <td style="vertical-align: top;">0.2 </td>
@@ -3491,7 +4117,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLL_P">MC_ROLL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll P gain</p><p><strong>Comment:</strong> Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll P gain</p><p><strong>Comment:</strong> Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 8 (0.1)</td>
  <td style="vertical-align: top;">6.5 </td>
@@ -3499,7 +4125,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_P">MC_ROLLRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate P gain</p><p><strong>Comment:</strong> Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate P gain</p><p><strong>Comment:</strong> Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.5 (0.01)</td>
  <td style="vertical-align: top;">0.15 </td>
@@ -3507,7 +4133,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_I">MC_ROLLRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate I gain</p><p><strong>Comment:</strong> Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate I gain</p><p><strong>Comment:</strong> Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.05 </td>
@@ -3515,7 +4141,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_RR_INT_LIM">MC_RR_INT_LIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate integrator limit</p><p><strong>Comment:</strong> Roll rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large roll moment trim changes.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate integrator limit</p><p><strong>Comment:</strong> Roll rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large roll moment trim changes.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.30 </td>
@@ -3523,7 +4149,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_D">MC_ROLLRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate D gain</p><p><strong>Comment:</strong> Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate D gain</p><p><strong>Comment:</strong> Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.01 (0.0005)</td>
  <td style="vertical-align: top;">0.003 </td>
@@ -3531,7 +4157,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_FF">MC_ROLLRATE_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3539,7 +4165,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCH_P">MC_PITCH_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch P gain</p><p><strong>Comment:</strong> Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch P gain</p><p><strong>Comment:</strong> Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 10 (0.1)</td>
  <td style="vertical-align: top;">6.5 </td>
@@ -3547,7 +4173,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_P">MC_PITCHRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate P gain</p><p><strong>Comment:</strong> Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate P gain</p><p><strong>Comment:</strong> Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.6 (0.01)</td>
  <td style="vertical-align: top;">0.15 </td>
@@ -3555,7 +4181,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_I">MC_PITCHRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate I gain</p><p><strong>Comment:</strong> Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate I gain</p><p><strong>Comment:</strong> Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.05 </td>
@@ -3563,7 +4189,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PR_INT_LIM">MC_PR_INT_LIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate integrator limit</p><p><strong>Comment:</strong> Pitch rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large pitch moment trim changes.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate integrator limit</p><p><strong>Comment:</strong> Pitch rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large pitch moment trim changes.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.30 </td>
@@ -3571,7 +4197,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_D">MC_PITCHRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate D gain</p><p><strong>Comment:</strong> Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate D gain</p><p><strong>Comment:</strong> Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.0005)</td>
  <td style="vertical-align: top;">0.003 </td>
@@ -3579,7 +4205,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_FF">MC_PITCHRATE_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3587,7 +4213,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAW_P">MC_YAW_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw P gain</p><p><strong>Comment:</strong> Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw P gain</p><p><strong>Comment:</strong> Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 5 (0.1)</td>
  <td style="vertical-align: top;">2.8 </td>
@@ -3595,7 +4221,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_P">MC_YAWRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate P gain</p><p><strong>Comment:</strong> Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate P gain</p><p><strong>Comment:</strong> Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.6 (0.01)</td>
  <td style="vertical-align: top;">0.2 </td>
@@ -3603,7 +4229,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_I">MC_YAWRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate I gain</p><p><strong>Comment:</strong> Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate I gain</p><p><strong>Comment:</strong> Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.1 </td>
@@ -3611,7 +4237,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YR_INT_LIM">MC_YR_INT_LIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate integrator limit</p><p><strong>Comment:</strong> Yaw rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large yaw moment trim changes.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate integrator limit</p><p><strong>Comment:</strong> Yaw rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large yaw moment trim changes.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.30 </td>
@@ -3619,7 +4245,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_D">MC_YAWRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate D gain</p><p><strong>Comment:</strong> Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate D gain</p><p><strong>Comment:</strong> Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3627,7 +4253,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_FF">MC_YAWRATE_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3635,7 +4261,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAW_FF">MC_YAW_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw feed forward</p><p><strong>Comment:</strong> Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw feed forward</p><p><strong>Comment:</strong> Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.5 </td>
@@ -3643,63 +4269,84 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_MAX">MC_ROLLRATE_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max roll rate</p><p><strong>Comment:</strong> Limit for roll rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max roll rate</p><p><strong>Comment:</strong> Limit for roll rate in manual and auto modes (except acro). Has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation. This is not only limited by the vehicle's properties, but also by the maximum measurement rate of the gyro.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 360.0 (5)</td>
+ <td style="vertical-align: top;">0.0 > 1800.0 (5)</td>
  <td style="vertical-align: top;">220.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_MAX">MC_PITCHRATE_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max pitch rate</p><p><strong>Comment:</strong> Limit for pitch rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max pitch rate</p><p><strong>Comment:</strong> Limit for pitch rate in manual and auto modes (except acro). Has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation. This is not only limited by the vehicle's properties, but also by the maximum measurement rate of the gyro.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 360.0 (5)</td>
+ <td style="vertical-align: top;">0.0 > 1800.0 (5)</td>
  <td style="vertical-align: top;">220.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_MAX">MC_YAWRATE_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max yaw rate</p><p><strong>Comment:</strong> A value of significantly over 120 degrees per second can already lead to mixer saturation.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max yaw rate</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 360.0 (5)</td>
+ <td style="vertical-align: top;">0.0 > 1800.0 (5)</td>
  <td style="vertical-align: top;">200.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRAUTO_MAX">MC_YAWRAUTO_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max yaw rate in auto mode</p><p><strong>Comment:</strong> Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation. A value of significantly over 60 degrees per second can already lead to mixer saturation. A value of 30 degrees / second is recommended to avoid very audible twitches.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max yaw rate in auto mode</p><p><strong>Comment:</strong> Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 120.0 (5)</td>
+ <td style="vertical-align: top;">0.0 > 360.0 (5)</td>
  <td style="vertical-align: top;">45.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ACRO_R_MAX">MC_ACRO_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro roll rate</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max acro roll rate
+default: 2 turns per second</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1000.0 (5)</td>
- <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;">720.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ACRO_P_MAX">MC_ACRO_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro pitch rate</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max acro pitch rate
+default: 2 turns per second</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1000.0 (5)</td>
- <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;">720.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ACRO_Y_MAX">MC_ACRO_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro yaw rate</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max acro yaw rate
+default 1.5 turns per second</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1000.0 (5)</td>
- <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;">540.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="MC_ACRO_EXPO">MC_ACRO_EXPO</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Acro Expo factor
+applied to input of all axis: roll, pitch, yaw</p><p><strong>Comment:</strong> 0 Purely linear input curve 1 Purely cubic input curve</p>    <p><b>Module:</b> modules/mc_att_control</p>
+</td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">0.69 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MC_ACRO_SUPEXPO">MC_ACRO_SUPEXPO</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Acro SuperExpo factor
+applied to input of all axis: roll, pitch, yaw</p><p><strong>Comment:</strong> 0 Pure Expo function 0.7 resonable shape enhancement for intuitive stick feel 0.95 very strong bent input curve only near maxima have effect</p>    <p><b>Module:</b> modules/mc_att_control</p>
+</td>
+ <td style="vertical-align: top;">0 > 0.95 </td>
+ <td style="vertical-align: top;">0.7 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="MC_RATT_TH">MC_RATT_TH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Threshold for Rattitude mode</p><p><strong>Comment:</strong> Manual input needed in order to override attitude control rate setpoints and instead pass manual stick inputs as rate setpoints</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Threshold for Rattitude mode</p><p><strong>Comment:</strong> Manual input needed in order to override attitude control rate setpoints and instead pass manual stick inputs as rate setpoints</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.8 </td>
@@ -3707,7 +4354,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_BAT_SCALE_EN">MC_BAT_SCALE_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Battery power level scaler</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The copter should constantly behave as if it was fully charged with reduced max acceleration at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Battery power level scaler</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The copter should constantly behave as if it was fully charged with reduced max acceleration at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -3715,7 +4362,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_BREAK_P">MC_TPA_BREAK_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA P Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch P gain</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA P Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch P gain</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.1)</td>
  <td style="vertical-align: top;">1.0 </td>
@@ -3723,7 +4370,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_BREAK_I">MC_TPA_BREAK_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA I Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch I gain</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA I Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch I gain</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.1)</td>
  <td style="vertical-align: top;">1.0 </td>
@@ -3731,7 +4378,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_BREAK_D">MC_TPA_BREAK_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA D Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch D gain</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA D Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch D gain</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.1)</td>
  <td style="vertical-align: top;">1.0 </td>
@@ -3739,7 +4386,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_RATE_P">MC_TPA_RATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA Rate P</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch P gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA Rate P</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch P gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3747,7 +4394,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_RATE_I">MC_TPA_RATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA Rate I</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch I gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA Rate I</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch I gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3755,11 +4402,171 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_RATE_D">MC_TPA_RATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA Rate D</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch D gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA Rate D</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch D gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ROLL_P">MP_ROLL_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll P gain</p><p><strong>Comment:</strong> Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">6.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ROLLRATE_P">MP_ROLLRATE_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll rate P gain</p><p><strong>Comment:</strong> Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ROLLRATE_I">MP_ROLLRATE_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll rate I gain</p><p><strong>Comment:</strong> Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ROLLRATE_D">MP_ROLLRATE_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll rate D gain</p><p><strong>Comment:</strong> Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.002 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_PITCH_P">MP_PITCH_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch P gain</p><p><strong>Comment:</strong> Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">6.0 </td>
+ <td style="vertical-align: top;">1/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_PITCHRATE_P">MP_PITCHRATE_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch rate P gain</p><p><strong>Comment:</strong> Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_PITCHRATE_I">MP_PITCHRATE_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch rate I gain</p><p><strong>Comment:</strong> Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_PITCHRATE_D">MP_PITCHRATE_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch rate D gain</p><p><strong>Comment:</strong> Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.002 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAW_P">MP_YAW_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw P gain</p><p><strong>Comment:</strong> Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">2.0 </td>
+ <td style="vertical-align: top;">1/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAWRATE_P">MP_YAWRATE_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw rate P gain</p><p><strong>Comment:</strong> Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.3 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAWRATE_I">MP_YAWRATE_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw rate I gain</p><p><strong>Comment:</strong> Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAWRATE_D">MP_YAWRATE_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw rate D gain</p><p><strong>Comment:</strong> Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAW_FF">MP_YAW_FF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw feed forward</p><p><strong>Comment:</strong> Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAWRATE_MAX">MP_YAWRATE_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max yaw rate</p><p><strong>Comment:</strong> Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 360.0 </td>
+ <td style="vertical-align: top;">60.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ACRO_R_MAX">MP_ACRO_R_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max acro roll rate</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 360.0 </td>
+ <td style="vertical-align: top;">35.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ACRO_P_MAX">MP_ACRO_P_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max acro pitch rate</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 360.0 </td>
+ <td style="vertical-align: top;">35.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ACRO_Y_MAX">MP_ACRO_Y_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max acro yaw rate</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">120.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_MAN_R_MAX">MPP_MAN_R_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max manual roll</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 </td>
+ <td style="vertical-align: top;">35.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_MAN_P_MAX">MPP_MAN_P_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max manual pitch</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 </td>
+ <td style="vertical-align: top;">35.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_MAN_Y_MAX">MPP_MAN_Y_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max manual yaw rate</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">120.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
 </tr>
 </tbody></table>
 
@@ -3772,144 +4579,8 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="MPP_THR_MIN">MPP_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum thrust</p><p><strong>Comment:</strong> Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_THR_MAX">MPP_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum thrust</p><p><strong>Comment:</strong> Limit max allowed thrust.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_P">MPP_Z_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for vertical position error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_VEL_P">MPP_Z_VEL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for vertical velocity error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_VEL_I">MPP_Z_VEL_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integral gain for vertical velocity error</p><p><strong>Comment:</strong> Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.02 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_VEL_D">MPP_Z_VEL_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential gain for vertical velocity error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_VEL_MAX">MPP_Z_VEL_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL).</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">5.0 </td>
- <td style="vertical-align: top;">m/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_FF">MPP_Z_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Vertical velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for altitude control in stabilized modes (ALTCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_P">MPP_XY_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for horizontal position error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_VEL_P">MPP_XY_VEL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for horizontal velocity error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_VEL_I">MPP_XY_VEL_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integral gain for horizontal velocity error</p><p><strong>Comment:</strong> Non-zero value allows to resist wind.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.02 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_VEL_D">MPP_XY_VEL_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.01 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_VEL_MAX">MPP_XY_VEL_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity in AUTO mode and endpoint for position stabilized mode (POSCTRL).</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">5.0 </td>
- <td style="vertical-align: top;">m/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_FF">MPP_XY_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Horizontal velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for position control in position control mode (POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_TILTMAX_AIR">MPP_TILTMAX_AIR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum tilt angle in air</p><p><strong>Comment:</strong> Limits maximum tilt in AUTO and POSCTRL modes during flight.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">45.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_TILTMAX_LND">MPP_TILTMAX_LND</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum tilt during landing</p><p><strong>Comment:</strong> Limits maximum tilt angle on landing.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">15.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_LAND_SPEED">MPP_LAND_SPEED</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Landing descend rate</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;">m/s</td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MPC_THR_MIN">MPC_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum thrust in auto thrust control</p><p><strong>Comment:</strong> It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Minimum thrust in auto thrust control</p><p><strong>Comment:</strong> It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.05 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.12 </td>
@@ -3917,7 +4588,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_THR_HOVER">MPC_THR_HOVER</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Hover thrust</p><p><strong>Comment:</strong> Vertical thrust required to hover. This value is mapped to center stick for manual throttle control. With this value set to the thrust required to hover, transition from manual to ALTCTL mode while hovering will occur with the throttle stick near center, which is then interpreted as (near) zero demand for vertical speed.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Hover thrust</p><p><strong>Comment:</strong> Vertical thrust required to hover. This value is mapped to center stick for manual throttle control. With this value set to the thrust required to hover, transition from manual to ALTCTL mode while hovering will occur with the throttle stick near center, which is then interpreted as (near) zero demand for vertical speed.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.2 > 0.8 (0.01)</td>
  <td style="vertical-align: top;">0.5 </td>
@@ -3925,7 +4596,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_THR_MAX">MPC_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum thrust in auto thrust control</p><p><strong>Comment:</strong> Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum thrust in auto thrust control</p><p><strong>Comment:</strong> Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.95 (0.01)</td>
  <td style="vertical-align: top;">0.9 </td>
@@ -3933,7 +4604,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_MANTHR_MIN">MPC_MANTHR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum manual thrust</p><p><strong>Comment:</strong> Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Minimum manual thrust</p><p><strong>Comment:</strong> Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.08 </td>
@@ -3941,7 +4612,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_MANTHR_MAX">MPC_MANTHR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum manual thrust</p><p><strong>Comment:</strong> Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum manual thrust</p><p><strong>Comment:</strong> Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.9 </td>
@@ -3949,7 +4620,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_P">MPC_Z_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for vertical position error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Proportional gain for vertical position error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.5 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -3957,7 +4628,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_P">MPC_Z_VEL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for vertical velocity error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Proportional gain for vertical velocity error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.1 > 0.4 </td>
  <td style="vertical-align: top;">0.2 </td>
@@ -3965,7 +4636,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_I">MPC_Z_VEL_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integral gain for vertical velocity error</p><p><strong>Comment:</strong> Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Integral gain for vertical velocity error</p><p><strong>Comment:</strong> Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.01 > 0.1 </td>
  <td style="vertical-align: top;">0.02 </td>
@@ -3973,7 +4644,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_D">MPC_Z_VEL_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential gain for vertical velocity error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Differential gain for vertical velocity error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.1 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3981,7 +4652,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_MAX_UP">MPC_Z_VEL_MAX_UP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical ascent velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL, POSCTRL).</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum vertical ascent velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL, POSCTRL).</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.5 > 8.0 </td>
  <td style="vertical-align: top;">3.0 </td>
@@ -3989,23 +4660,15 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_MAX_DN">MPC_Z_VEL_MAX_DN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical descent velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL, POSCTRL).</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum vertical descent velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL, POSCTRL).</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.5 > 4.0 </td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_Z_FF">MPC_Z_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Vertical velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for altitude control in stabilized modes (ALTCTRL, POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_P">MPC_XY_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for horizontal position error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Proportional gain for horizontal position error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 </td>
  <td style="vertical-align: top;">0.95 </td>
@@ -4013,7 +4676,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_VEL_P">MPC_XY_VEL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for horizontal velocity error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Proportional gain for horizontal velocity error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.06 > 0.15 </td>
  <td style="vertical-align: top;">0.09 </td>
@@ -4021,7 +4684,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_VEL_I">MPC_XY_VEL_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integral gain for horizontal velocity error</p><p><strong>Comment:</strong> Non-zero value allows to resist wind.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Integral gain for horizontal velocity error</p><p><strong>Comment:</strong> Non-zero value allows to resist wind.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.1 </td>
  <td style="vertical-align: top;">0.02 </td>
@@ -4029,7 +4692,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_VEL_D">MPC_XY_VEL_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.005 > 0.1 </td>
  <td style="vertical-align: top;">0.01 </td>
@@ -4037,47 +4700,42 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_CRUISE">MPC_XY_CRUISE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Nominal horizontal velocity in mission</p><p><strong>Comment:</strong> Normal horizontal velocity in AUTO modes (includes also RTL / hold / etc.) and endpoint for position stabilized mode (POSCTRL).</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity in mission</p><p><strong>Comment:</strong> Normal horizontal velocity in AUTO modes (includes also RTL / hold / etc.) and endpoint for position stabilized mode (POSCTRL).</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">3.0 > 20.0 (1)</td>
  <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_VEL_MAN_MAX">MPC_VEL_MAN_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Nominal horizontal velocity for manual controlled mode</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><strong id="MPC_CRUISE_90">MPC_CRUISE_90</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Cruise speed when angle prev-current/current-next setpoint
+is 90 degrees. It should be lower than MPC_XY_CRUISE</p><p><strong>Comment:</strong> Applies only in AUTO modes (includes also RTL / hold / etc.)</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">1.0 > ? (1)</td>
+ <td style="vertical-align: top;">3.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_VEL_MANUAL">MPC_VEL_MANUAL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity setpoint for manual controlled mode
+If velocity setpoint larger than MPC_XY_VEL_MAX is set, then
+the setpoint will be capped to MPC_XY_VEL_MAX</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">3.0 > 20.0 (1)</td>
  <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_TARGET_THRE">MPC_TARGET_THRE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Distance Threshold Horizontal Auto</p><p><strong>Comment:</strong> The distance defines at which point the vehicle has to slow down to reach target if no direct passing to the next target is desired</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
-</td>
- <td style="vertical-align: top;">1.0 > 50.0 (1)</td>
- <td style="vertical-align: top;">15.0 </td>
- <td style="vertical-align: top;">m</td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_VEL_MAX">MPC_XY_VEL_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity in AUTO mode. If higher speeds are commanded in a mission they will be capped to this velocity.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity in AUTO mode. If higher speeds are commanded in a mission they will be capped to this velocity.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 20.0 (1)</td>
- <td style="vertical-align: top;">8.0 </td>
+ <td style="vertical-align: top;">12.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_XY_FF">MPC_XY_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Horizontal velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for position control in position control mode (POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MPC_TILTMAX_AIR">MPC_TILTMAX_AIR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum tilt angle in air</p><p><strong>Comment:</strong> Limits maximum tilt in AUTO and POSCTRL modes during flight.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum tilt angle in air</p><p><strong>Comment:</strong> Limits maximum tilt in AUTO and POSCTRL modes during flight.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 90.0 </td>
  <td style="vertical-align: top;">45.0 </td>
@@ -4085,7 +4743,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_TILTMAX_LND">MPC_TILTMAX_LND</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum tilt during landing</p><p><strong>Comment:</strong> Limits maximum tilt angle on landing.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum tilt during landing</p><p><strong>Comment:</strong> Limits maximum tilt angle on landing.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 90.0 </td>
  <td style="vertical-align: top;">12.0 </td>
@@ -4093,15 +4751,15 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_LAND_SPEED">MPC_LAND_SPEED</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Landing descend rate</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Landing descend rate</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
- <td style="vertical-align: top;">0.2 > ? </td>
- <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;">0.6 > ? </td>
+ <td style="vertical-align: top;">0.7 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_TKO_SPEED">MPC_TKO_SPEED</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Takeoff climb rate</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Takeoff climb rate</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">1 > 5 </td>
  <td style="vertical-align: top;">1.5 </td>
@@ -4109,7 +4767,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_MAN_TILT_MAX">MPC_MAN_TILT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal tilt angle in manual or altitude mode</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximal tilt angle in manual or altitude mode</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 90.0 </td>
  <td style="vertical-align: top;">35.0 </td>
@@ -4117,7 +4775,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_MAN_Y_MAX">MPC_MAN_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual yaw rate</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Max manual yaw rate</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 400 </td>
  <td style="vertical-align: top;">200.0 </td>
@@ -4125,7 +4783,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_HOLD_DZ">MPC_HOLD_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Deadzone of sticks where position hold is enabled</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Deadzone of sticks where position hold is enabled</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 </td>
  <td style="vertical-align: top;">0.1 </td>
@@ -4133,7 +4791,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_HOLD_MAX_XY">MPC_HOLD_MAX_XY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 3.0 </td>
  <td style="vertical-align: top;">0.8 </td>
@@ -4141,7 +4799,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_HOLD_MAX_Z">MPC_HOLD_MAX_Z</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical velocity for which position hold is enabled (use 0 to disable check)</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum vertical velocity for which position hold is enabled (use 0 to disable check)</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 3.0 </td>
  <td style="vertical-align: top;">0.6 </td>
@@ -4149,7 +4807,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_VELD_LP">MPC_VELD_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Low pass filter cut freq. for numerical velocity derivative</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Low pass filter cut freq. for numerical velocity derivative</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 10 </td>
  <td style="vertical-align: top;">5.0 </td>
@@ -4157,44 +4815,73 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_ACC_HOR_MAX">MPC_ACC_HOR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizonal acceleration in velocity controlled modes</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
-</td>
- <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
- <td style="vertical-align: top;">5.0 </td>
- <td style="vertical-align: top;">m/s/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPC_DEC_HOR_MAX">MPC_DEC_HOR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizonal braking deceleration in velocity controlled modes</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum horizontal acceleration for auto mode and maximum deceleration for manual mode</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
  <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;">m/s/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_ACC_UP_MAX">MPC_ACC_UP_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical acceleration in velocity controlled modes upward</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><strong id="MPC_ACC_HOR">MPC_ACC_HOR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Acceleration for auto and for manual</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
  <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_DEC_HOR_SLOW">MPC_DEC_HOR_SLOW</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Slow horizontal manual deceleration for manual mode</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.5 > 10.0 (1)</td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_ACC_UP_MAX">MPC_ACC_UP_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum vertical acceleration in velocity controlled modes upward</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
+ <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;">m/s/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_ACC_DOWN_MAX">MPC_ACC_DOWN_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical acceleration in velocity controlled modes down</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum vertical acceleration in velocity controlled modes down</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
- <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_JERK_MAX">MPC_JERK_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum jerk in manual controlled mode for BRAKING to zero.
+If this value is below MPC_JERK_MIN, the acceleration limit in xy and z
+is MPC_ACC_HOR_MAX and MPC_ACC_UP_MAX respectively instantaneously when the
+user demands brake (=zero stick input).
+Otherwise the acceleration limit increases from current acceleration limit
+towards MPC_ACC_HOR_MAX/MPC_ACC_UP_MAX with jerk limit</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 15.0 (1)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">m/s/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_JERK_MIN">MPC_JERK_MIN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Minimum jerk in manual controlled mode for BRAKING to zero</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.5 > 10.0 (1)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">m/s/s/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_ALT_MODE">MPC_ALT_MODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Altitude control mode, note mode 1 only tested with LPE</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Altitude following</li>
+<li><strong>0:</strong> Altitude following</li> 
 
-<li><strong>1:</strong> Terrain following</li>
+<li><strong>1:</strong> Terrain following</li> 
 </ul>
-   <p><b>Module:</b> src/modules/mc_pos_control</p>
+   <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4202,7 +4889,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_MAN_EXPO">MPC_XY_MAN_EXPO</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual control stick exponential curve sensitivity attenuation with small velocity setpoints</p><p><strong>Comment:</strong> The higher the value the less sensitivity the stick has around zero while still reaching the maximum value with full stick deflection. 0 Purely linear input curve (default) 1 Purely cubic input curve</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Manual control stick exponential curve sensitivity attenuation with small velocity setpoints</p><p><strong>Comment:</strong> The higher the value the less sensitivity the stick has around zero while still reaching the maximum value with full stick deflection. 0 Purely linear input curve (default) 1 Purely cubic input curve</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -4210,7 +4897,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_MAN_EXPO">MPC_Z_MAN_EXPO</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual control stick vertical exponential curve</p><p><strong>Comment:</strong> The higher the value the less sensitivity the stick has around zero while still reaching the maximum value with full stick deflection. 0 Purely linear input curve (default) 1 Purely cubic input curve</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Manual control stick vertical exponential curve</p><p><strong>Comment:</strong> The higher the value the less sensitivity the stick has around zero while still reaching the maximum value with full stick deflection. 0 Purely linear input curve (default) 1 Purely cubic input curve</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -4218,7 +4905,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_LAND_ALT1">MPC_LAND_ALT1</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Altitude for 1. step of slow landing (descend)</p><p><strong>Comment:</strong> Below this altitude descending velocity gets limited to a value between "MPC_Z_VEL_MAX" and "MPC_LAND_SPEED" to enable a smooth descent experience Value needs to be higher than "MPC_LAND_ALT2"</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Altitude for 1. step of slow landing (descend)</p><p><strong>Comment:</strong> Below this altitude descending velocity gets limited to a value between "MPC_Z_VEL_MAX" and "MPC_LAND_SPEED" to enable a smooth descent experience Value needs to be higher than "MPC_LAND_ALT2"</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 122 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -4226,11 +4913,155 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_LAND_ALT2">MPC_LAND_ALT2</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Altitude for 2. step of slow landing (landing)</p><p><strong>Comment:</strong> Below this altitude descending velocity gets limited to "MPC_LAND_SPEED" Value needs to be lower than "MPC_LAND_ALT1"</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Altitude for 2. step of slow landing (landing)</p><p><strong>Comment:</strong> Below this altitude descending velocity gets limited to "MPC_LAND_SPEED" Value needs to be lower than "MPC_LAND_ALT1"</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 122 </td>
  <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_TKO_RAMP_T">MPC_TKO_RAMP_T</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Position control smooth takeoff ramp time constant</p><p><strong>Comment:</strong> Increasing this value will make automatic and manual takeoff slower. If it's too slow the drone might scratch the ground and tip over.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.1 > 1 </td>
+ <td style="vertical-align: top;">0.4 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_THR_MIN">MPP_THR_MIN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Minimum thrust</p><p><strong>Comment:</strong> Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_THR_MAX">MPP_THR_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum thrust</p><p><strong>Comment:</strong> Limit max allowed thrust.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_P">MPP_Z_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Proportional gain for vertical position error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_VEL_P">MPP_Z_VEL_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Proportional gain for vertical velocity error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_VEL_I">MPP_Z_VEL_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Integral gain for vertical velocity error</p><p><strong>Comment:</strong> Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.02 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_VEL_D">MPP_Z_VEL_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential gain for vertical velocity error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_VEL_MAX">MPP_Z_VEL_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum vertical velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL).</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_FF">MPP_Z_FF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Vertical velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for altitude control in stabilized modes (ALTCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_P">MPP_XY_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Proportional gain for horizontal position error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_VEL_P">MPP_XY_VEL_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Proportional gain for horizontal velocity error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_VEL_I">MPP_XY_VEL_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Integral gain for horizontal velocity error</p><p><strong>Comment:</strong> Non-zero value allows to resist wind.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.02 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_VEL_D">MPP_XY_VEL_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.01 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_VEL_MAX">MPP_XY_VEL_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity in AUTO mode and endpoint for position stabilized mode (POSCTRL).</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_FF">MPP_XY_FF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Horizontal velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for position control in position control mode (POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_TILTMAX_AIR">MPP_TILTMAX_AIR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum tilt angle in air</p><p><strong>Comment:</strong> Limits maximum tilt in AUTO and POSCTRL modes during flight.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 </td>
+ <td style="vertical-align: top;">45.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_TILTMAX_LND">MPP_TILTMAX_LND</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum tilt during landing</p><p><strong>Comment:</strong> Limits maximum tilt angle on landing.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 </td>
+ <td style="vertical-align: top;">15.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_LAND_SPEED">MPP_LAND_SPEED</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Landing descend rate</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">m/s</td>
 </tr>
 </tbody></table>
 
@@ -4244,8 +5075,8 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_RATE">PWM_RATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the PWM output frequency for the main outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 400 for industry default or 1000 for high frequency ESCs. Set to 0 for Oneshot125.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Set the PWM output frequency for the main outputs</p><p><strong>Comment:</strong> Set to 400 for industry default or 1000 for high frequency ESCs. Set to 0 for Oneshot125.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1 > 2000 </td>
  <td style="vertical-align: top;">400 </td>
@@ -4253,8 +5084,8 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MIN">PWM_MIN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the minimum PWM for the main outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 1000 for industry default or 900 to increase servo travel.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Set the minimum PWM for the main outputs</p><p><strong>Comment:</strong> Set to 1000 for industry default or 900 to increase servo travel.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800 > 1400 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -4262,8 +5093,8 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAX">PWM_MAX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the maximum PWM for the main outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 2000 for industry default or 2100 to increase servo travel.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Set the maximum PWM for the main outputs</p><p><strong>Comment:</strong> Set to 2000 for industry default or 2100 to increase servo travel.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1600 > 2200 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -4271,17 +5102,143 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_DISARMED">PWM_DISARMED</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the disarmed PWM for the main outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. This is the PWM pulse the autopilot is outputting if not armed. The main use of this parameter is to silence ESCs when they are disarmed.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main outputs</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. The main use of this parameter is to silence ESCs when they are disarmed.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 2200 </td>
  <td style="vertical-align: top;">900 </td>
  <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS1">PWM_MAIN_DIS1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 1 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS2">PWM_MAIN_DIS2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 2 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS3">PWM_MAIN_DIS3</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 3 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS4">PWM_MAIN_DIS4</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 4 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS5">PWM_MAIN_DIS5</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 5 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS6">PWM_MAIN_DIS6</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 6 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS7">PWM_MAIN_DIS7</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 7 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS8">PWM_MAIN_DIS8</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 8 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS1">PWM_AUX_DIS1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 1 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS2">PWM_AUX_DIS2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 2 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS3">PWM_AUX_DIS3</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 3 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS4">PWM_AUX_DIS4</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 4 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS5">PWM_AUX_DIS5</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 5 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS6">PWM_AUX_DIS6</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 6 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_MIN">PWM_AUX_MIN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the minimum PWM for the auxiliary outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 1000 for default or 900 to increase servo travel</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Set the minimum PWM for the auxiliary outputs</p><p><strong>Comment:</strong> Set to 1000 for default or 900 to increase servo travel</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800 > 1400 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -4289,8 +5246,8 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_MAX">PWM_AUX_MAX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the maximum PWM for the auxiliary outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 2000 for default or 2100 to increase servo travel</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Set the maximum PWM for the auxiliary outputs</p><p><strong>Comment:</strong> Set to 2000 for default or 2100 to increase servo travel</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1600 > 2200 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -4298,33 +5255,17 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_DISARMED">PWM_AUX_DISARMED</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the disarmed PWM for auxiliary outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. This is the PWM pulse the autopilot is outputting if not armed. The main use of this parameter is to silence ESCs when they are disarmed.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for auxiliary outputs</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. The main use of this parameter is to silence ESCs when they are disarmed.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 2200 </td>
  <td style="vertical-align: top;">1500 </td>
  <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="THR_MDL_FAC">THR_MDL_FAC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Thrust to PWM model parameter</p><p><strong>Comment:</strong> Parameter used to model the relationship between static thrust and motor input PWM. Model is: thrust = (1-factor)*PWM + factor * PWM^2</p>    <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MOT_SLEW_MAX">MOT_SLEW_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum motor rise time (slew rate limit)</p><p><strong>Comment:</strong> Minimum time allowed for the motor input signal to pass through a range of 1000 PWM units. A value x means that the motor signal can only go from 1000 to 2000 PWM in maximum x seconds. Zero means that slew rate limiting is disabled.</p>    <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">s/(1000*PWM)</td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV1">PWM_MAIN_REV1</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 1</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4333,7 +5274,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV2">PWM_MAIN_REV2</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 2</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4342,7 +5283,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV3">PWM_MAIN_REV3</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 3</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4351,7 +5292,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV4">PWM_MAIN_REV4</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 4</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4360,7 +5301,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV5">PWM_MAIN_REV5</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 5</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4369,7 +5310,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV6">PWM_MAIN_REV6</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 6</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4378,7 +5319,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV7">PWM_MAIN_REV7</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 7</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4387,7 +5328,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV8">PWM_MAIN_REV8</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 8</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4395,7 +5336,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM1">PWM_MAIN_TRIM1</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 1</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 1</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4403,7 +5344,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM2">PWM_MAIN_TRIM2</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 2</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 2</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4411,7 +5352,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM3">PWM_MAIN_TRIM3</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 3</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 3</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4419,7 +5360,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM4">PWM_MAIN_TRIM4</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 4</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 4</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4427,7 +5368,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM5">PWM_MAIN_TRIM5</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 5</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 5</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4435,7 +5376,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM6">PWM_MAIN_TRIM6</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 6</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 6</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4443,7 +5384,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM7">PWM_MAIN_TRIM7</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 7</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 7</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4451,7 +5392,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM8">PWM_MAIN_TRIM8</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 8</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 8</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4459,7 +5400,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_SBUS_MODE">PWM_SBUS_MODE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>S.BUS out</p><p><strong>Comment:</strong> Set to 1 to enable S.BUS version 1 output instead of RSSI.</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>S.BUS out</p><p><strong>Comment:</strong> Set to 1 to enable S.BUS version 1 output instead of RSSI.</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4468,7 +5409,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_REV1">PWM_AUX_REV1</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of aux output channel 1</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4477,7 +5418,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_REV2">PWM_AUX_REV2</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of aux output channel 2</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4486,7 +5427,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_REV3">PWM_AUX_REV3</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of aux output channel 3</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4495,7 +5436,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_REV4">PWM_AUX_REV4</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of aux output channel 4</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4504,7 +5445,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_REV5">PWM_AUX_REV5</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of aux output channel 5</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4513,7 +5454,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_REV6">PWM_AUX_REV6</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of aux output channel 6</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4521,7 +5462,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM1">PWM_AUX_TRIM1</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 1</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 1</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4529,7 +5470,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM2">PWM_AUX_TRIM2</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 2</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 2</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4537,7 +5478,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM3">PWM_AUX_TRIM3</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 3</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 3</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4545,7 +5486,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM4">PWM_AUX_TRIM4</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 4</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 4</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4553,7 +5494,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM5">PWM_AUX_TRIM5</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 5</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 5</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4561,18 +5502,34 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM6">PWM_AUX_TRIM6</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 6</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 6</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="THR_MDL_FAC">THR_MDL_FAC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Thrust to PWM model parameter</p><p><strong>Comment:</strong> Parameter used to model the relationship between static thrust and motor input PWM. Model is: thrust = (1-factor)*PWM + factor * PWM^2</p>    <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MOT_SLEW_MAX">MOT_SLEW_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Minimum motor rise time (slew rate limit)</p><p><strong>Comment:</strong> Minimum time allowed for the motor input signal to pass through a range of 1000 PWM units. A value x means that the motor signal can only go from 1000 to 2000 PWM in maximum x seconds. Zero means that slew rate limiting is disabled.</p>    <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">s/(1000*PWM)</td>
 </tr>
 </tbody></table>
 
 ## Payload drop
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/bottle_drop*.
+The module where these parameters are defined is: *examples/bottle_drop*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -4627,7 +5584,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 ## Position Estimator
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/examples/ekf_att_pos_estimator*.
+The module where these parameters are defined is: *examples/ekf_att_pos_estimator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -4794,7 +5751,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 ## Position Estimator INAV
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/position_estimator_inav*.
+The module where these parameters are defined is: *modules/position_estimator_inav*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -4966,9 +5923,9 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="INAV_DISAB_MOCAP">INAV_DISAB_MOCAP</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Mo-cap</p><p><strong>Comment:</strong> Set to 0 if using fake GPS</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Mo-cap enabled</li>
+<li><strong>0:</strong> Mo-cap enabled</li> 
 
-<li><strong>1:</strong> Mo-cap disabled</li>
+<li><strong>1:</strong> Mo-cap disabled</li> 
 </ul>
    </td>
  <td style="vertical-align: top;"></td>
@@ -4999,26 +5956,6 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 </tbody></table>
 
-## RC Receiver Configuration
-
-
-이 파라미터가 정의되어 있는 모듈 : *src/platforms/qurt/fc_addon/rc_receiver*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="RC_RECEIVER_TYPE">RC_RECEIVER_TYPE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>RC receiver type</p><p><strong>Comment:</strong> Acceptable values: - RC_RECEIVER_SPEKTRUM = 1, - RC_RECEIVER_LEMONRX = 2,</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-</tbody></table>
-
 ## Radio Calibration
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
@@ -5029,7 +5966,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_MIN">RC1_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 Minimum</p><p><strong>Comment:</strong> Minimum value for RC channel 1</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 minimum</p><p><strong>Comment:</strong> Minimum value for RC channel 1</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000.0 </td>
@@ -5037,7 +5974,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_TRIM">RC1_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 Trim</p><p><strong>Comment:</strong> Mid point value (same as min for throttle)</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 trim</p><p><strong>Comment:</strong> Mid point value (same as min for throttle)</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500.0 </td>
@@ -5045,7 +5982,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_MAX">RC1_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 Maximum</p><p><strong>Comment:</strong> Maximum value for RC channel 1</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 maximum</p><p><strong>Comment:</strong> Maximum value for RC channel 1</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000.0 </td>
@@ -5053,7 +5990,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_REV">RC1_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5061,7 +5998,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_DZ">RC1_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5069,7 +6006,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_MIN">RC2_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000.0 </td>
@@ -5077,7 +6014,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_TRIM">RC2_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500.0 </td>
@@ -5085,7 +6022,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_MAX">RC2_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000.0 </td>
@@ -5093,7 +6030,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_REV">RC2_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5101,7 +6038,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_DZ">RC2_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5109,7 +6046,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_MIN">RC3_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5117,7 +6054,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_TRIM">RC3_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5125,7 +6062,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_MAX">RC3_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5133,7 +6070,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_REV">RC3_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5141,7 +6078,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_DZ">RC3_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5149,7 +6086,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_MIN">RC4_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5157,7 +6094,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_TRIM">RC4_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5165,7 +6102,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_MAX">RC4_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5173,7 +6110,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_REV">RC4_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5181,7 +6118,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_DZ">RC4_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5189,7 +6126,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_MIN">RC5_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5197,7 +6134,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_TRIM">RC5_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5205,7 +6142,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_MAX">RC5_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5213,7 +6150,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_REV">RC5_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5221,7 +6158,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_DZ">RC5_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5229,7 +6166,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_MIN">RC6_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5237,7 +6174,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_TRIM">RC6_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5245,7 +6182,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_MAX">RC6_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5253,7 +6190,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_REV">RC6_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5261,7 +6198,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_DZ">RC6_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5269,7 +6206,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_MIN">RC7_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5277,7 +6214,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_TRIM">RC7_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5285,7 +6222,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_MAX">RC7_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5293,7 +6230,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_REV">RC7_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5301,7 +6238,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_DZ">RC7_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5309,7 +6246,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_MIN">RC8_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5317,7 +6254,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_TRIM">RC8_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5325,7 +6262,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_MAX">RC8_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5333,7 +6270,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_REV">RC8_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5341,7 +6278,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_DZ">RC8_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5349,7 +6286,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_MIN">RC9_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5357,7 +6294,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_TRIM">RC9_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5365,7 +6302,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_MAX">RC9_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5373,7 +6310,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_REV">RC9_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5381,7 +6318,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_DZ">RC9_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5389,7 +6326,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_MIN">RC10_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5397,7 +6334,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_TRIM">RC10_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5405,7 +6342,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_MAX">RC10_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5413,7 +6350,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_REV">RC10_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5421,7 +6358,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_DZ">RC10_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5429,7 +6366,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_MIN">RC11_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5437,7 +6374,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_TRIM">RC11_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5445,7 +6382,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_MAX">RC11_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5453,7 +6390,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_REV">RC11_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5461,7 +6398,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_DZ">RC11_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5469,7 +6406,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_MIN">RC12_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5477,7 +6414,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_TRIM">RC12_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5485,7 +6422,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_MAX">RC12_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5493,7 +6430,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_REV">RC12_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5501,7 +6438,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_DZ">RC12_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5509,7 +6446,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_MIN">RC13_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5517,7 +6454,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_TRIM">RC13_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5525,7 +6462,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_MAX">RC13_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5533,7 +6470,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_REV">RC13_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5541,7 +6478,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_DZ">RC13_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5549,7 +6486,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_MIN">RC14_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5557,7 +6494,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_TRIM">RC14_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5565,7 +6502,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_MAX">RC14_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5573,7 +6510,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_REV">RC14_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5581,7 +6518,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_DZ">RC14_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5589,7 +6526,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_MIN">RC15_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5597,7 +6534,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_TRIM">RC15_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5605,7 +6542,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_MAX">RC15_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5613,7 +6550,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_REV">RC15_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5621,7 +6558,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_DZ">RC15_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5629,7 +6566,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_MIN">RC16_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5637,7 +6574,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_TRIM">RC16_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5645,7 +6582,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_MAX">RC16_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5653,7 +6590,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_REV">RC16_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5661,7 +6598,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_DZ">RC16_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5669,7 +6606,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_MIN">RC17_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5677,7 +6614,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_TRIM">RC17_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5685,7 +6622,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_MAX">RC17_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5693,7 +6630,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_REV">RC17_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5701,7 +6638,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_DZ">RC17_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5709,7 +6646,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_MIN">RC18_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5717,7 +6654,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_TRIM">RC18_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5725,7 +6662,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_MAX">RC18_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5733,7 +6670,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_REV">RC18_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5741,7 +6678,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_DZ">RC18_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5750,34 +6687,19 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_RL1_DSM_VCC">RC_RL1_DSM_VCC</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Relay control of relay 1 mapped to the Spektrum receiver power supply</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li>
+<li><strong>0:</strong> Disabled</li> 
 
-<li><strong>1:</strong> Relay controls DSM power</li>
+<li><strong>1:</strong> Relay controls DSM power</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="RC_DSM_BIND">RC_DSM_BIND</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>DSM binding trigger</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Inactive</li>
-
-<li><strong>0:</strong> Start DSM2 bind</li>
-
-<li><strong>1:</strong> Start DSMX bind</li>
-</ul>
-   <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">-1 > 1 </td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="RC_CHAN_CNT">RC_CHAN_CNT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>RC channel count</p><p><strong>Comment:</strong> This parameter is used by Ground Station software to save the number of channels which were used during RC calibration. It is only meant for ground station use.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel count</p><p><strong>Comment:</strong> This parameter is used by Ground Station software to save the number of channels which were used during RC calibration. It is only meant for ground station use.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -5785,7 +6707,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_TH_USER">RC_TH_USER</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>RC mode switch threshold automatic distribution</p><p><strong>Comment:</strong> This parameter is used by Ground Station software to specify whether the threshold values for flight mode switches were automatically calculated. 0 indicates that the threshold values were set by the user. Any other value indicates that the threshold value where automatically set by the ground station software. It is only meant for ground station use.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC mode switch threshold automatic distribution</p><p><strong>Comment:</strong> This parameter is used by Ground Station software to specify whether the threshold values for flight mode switches were automatically calculated. 0 indicates that the threshold values were set by the user. Any other value indicates that the threshold value where automatically set by the ground station software. It is only meant for ground station use.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -5794,45 +6716,45 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_ROLL">RC_MAP_ROLL</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Roll control channel mapping</p><p><strong>Comment:</strong> The channel index (starting from 1 for channel 1) indicates which channel should be used for reading roll inputs from. A value of zero indicates the switch is not assigned.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -5841,45 +6763,92 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_PITCH">RC_MAP_PITCH</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Pitch control channel mapping</p><p><strong>Comment:</strong> The channel index (starting from 1 for channel 1) indicates which channel should be used for reading pitch inputs from. A value of zero indicates the switch is not assigned.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">0 > 18 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="RC_MAP_FAILSAFE">RC_MAP_FAILSAFE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Failsafe channel mapping</p><p><strong>Comment:</strong> The RC mapping index indicates which channel is used for failsafe If 0, whichever channel is mapped to throttle is used otherwise the value indicates the specific RC channel to use</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Unassigned</li> 
+
+<li><strong>1:</strong> Channel 1</li> 
+
+<li><strong>2:</strong> Channel 2</li> 
+
+<li><strong>3:</strong> Channel 3</li> 
+
+<li><strong>4:</strong> Channel 4</li> 
+
+<li><strong>5:</strong> Channel 5</li> 
+
+<li><strong>6:</strong> Channel 6</li> 
+
+<li><strong>7:</strong> Channel 7</li> 
+
+<li><strong>8:</strong> Channel 8</li> 
+
+<li><strong>9:</strong> Channel 9</li> 
+
+<li><strong>10:</strong> Channel 10</li> 
+
+<li><strong>11:</strong> Channel 11</li> 
+
+<li><strong>12:</strong> Channel 12</li> 
+
+<li><strong>13:</strong> Channel 13</li> 
+
+<li><strong>14:</strong> Channel 14</li> 
+
+<li><strong>15:</strong> Channel 15</li> 
+
+<li><strong>16:</strong> Channel 16</li> 
+
+<li><strong>17:</strong> Channel 17</li> 
+
+<li><strong>18:</strong> Channel 18</li> 
+</ul>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -5888,45 +6857,45 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_THROTTLE">RC_MAP_THROTTLE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Throttle control channel mapping</p><p><strong>Comment:</strong> The channel index (starting from 1 for channel 1) indicates which channel should be used for reading throttle inputs from. A value of zero indicates the switch is not assigned.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -5935,45 +6904,45 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_YAW">RC_MAP_YAW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Yaw control channel mapping</p><p><strong>Comment:</strong> The channel index (starting from 1 for channel 1) indicates which channel should be used for reading yaw inputs from. A value of zero indicates the switch is not assigned.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -5981,46 +6950,46 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX1">RC_MAP_AUX1</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX1 Passthrough RC Channel</p><p><strong>Comment:</strong> Default function: Camera pitch</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+ <td style="vertical-align: top;"><p>AUX1 Passthrough RC channel</p><p><strong>Comment:</strong> Default function: Camera pitch</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6028,46 +6997,46 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX2">RC_MAP_AUX2</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX2 Passthrough RC Channel</p><p><strong>Comment:</strong> Default function: Camera roll</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+ <td style="vertical-align: top;"><p>AUX2 Passthrough RC channel</p><p><strong>Comment:</strong> Default function: Camera roll</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6075,46 +7044,46 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX3">RC_MAP_AUX3</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX3 Passthrough RC Channel</p><p><strong>Comment:</strong> Default function: Camera azimuth / yaw</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+ <td style="vertical-align: top;"><p>AUX3 Passthrough RC channel</p><p><strong>Comment:</strong> Default function: Camera azimuth / yaw</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6122,46 +7091,46 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX4">RC_MAP_AUX4</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX4 Passthrough RC Channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+ <td style="vertical-align: top;"><p>AUX4 Passthrough RC channel</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6169,46 +7138,46 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX5">RC_MAP_AUX5</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX5 Passthrough RC Channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+ <td style="vertical-align: top;"><p>AUX5 Passthrough RC channel</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6217,45 +7186,45 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_PARAM1">RC_MAP_PARAM1</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>PARAM1 tuning channel</p><p><strong>Comment:</strong> Can be used for parameter tuning with the RC. This one is further referenced as the 1st parameter channel. Set to 0 to deactivate *</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6264,45 +7233,45 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_PARAM2">RC_MAP_PARAM2</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>PARAM2 tuning channel</p><p><strong>Comment:</strong> Can be used for parameter tuning with the RC. This one is further referenced as the 2nd parameter channel. Set to 0 to deactivate *</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6311,45 +7280,45 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_PARAM3">RC_MAP_PARAM3</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>PARAM3 tuning channel</p><p><strong>Comment:</strong> Can be used for parameter tuning with the RC. This one is further referenced as the 3th parameter channel. Set to 0 to deactivate *</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6357,78 +7326,15 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_FAILS_THR">RC_FAILS_THR</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Failsafe channel PWM threshold</p><p><strong>Comment:</strong> Set to a value slightly above the PWM value assumed by throttle in a failsafe event, but ensure it is below the PWM value assumed by throttle during normal operation.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Failsafe channel PWM threshold</p><p><strong>Comment:</strong> Set to a value slightly above the PWM value assumed by throttle in a failsafe event, but ensure it is below the PWM value assumed by throttle during normal operation.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 2200 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_CHAN">RC_RSSI_PWM_CHAN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>PWM input channel that provides RSSI</p><p><strong>Comment:</strong> 0: do not read RSSI from input channel 1-18: read RSSI from specified input channel Specify the range for RSSI input with RC_RSSI_PWM_MIN and RC_RSSI_PWM_MAX parameters.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
-
-<li><strong>1:</strong> Channel 1</li>
-
-<li><strong>2:</strong> Channel 2</li>
-
-<li><strong>3:</strong> Channel 3</li>
-
-<li><strong>4:</strong> Channel 4</li>
-
-<li><strong>5:</strong> Channel 5</li>
-
-<li><strong>6:</strong> Channel 6</li>
-
-<li><strong>7:</strong> Channel 7</li>
-
-<li><strong>8:</strong> Channel 8</li>
-
-<li><strong>9:</strong> Channel 9</li>
-
-<li><strong>10:</strong> Channel 10</li>
-
-<li><strong>11:</strong> Channel 11</li>
-
-<li><strong>12:</strong> Channel 12</li>
-
-<li><strong>13:</strong> Channel 13</li>
-
-<li><strong>14:</strong> Channel 14</li>
-
-<li><strong>15:</strong> Channel 15</li>
-
-<li><strong>16:</strong> Channel 16</li>
-
-<li><strong>17:</strong> Channel 17</li>
-
-<li><strong>18:</strong> Channel 18</li>
-</ul>
-   <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">0 > 18 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_MAX">RC_RSSI_PWM_MAX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Max input value for RSSI reading</p><p><strong>Comment:</strong> Only used if RC_RSSI_PWM_CHAN > 0</p>    <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">0 > 2000 </td>
- <td style="vertical-align: top;">1000 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_MIN">RC_RSSI_PWM_MIN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Min input value for RSSI reading</p><p><strong>Comment:</strong> Only used if RC_RSSI_PWM_CHAN > 0</p>    <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">0 > 2000 </td>
- <td style="vertical-align: top;">2000 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="RC_FLT_SMP_RATE">RC_FLT_SMP_RATE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Sample rate of the remote control values for the low pass filter on roll,pitch, yaw and throttle</p><p><strong>Comment:</strong> Has an influence on the cutoff frequency precision.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Sample rate of the remote control values for the low pass filter on roll,pitch, yaw and throttle</p><p><strong>Comment:</strong> Has an influence on the cutoff frequency precision.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1.0 > ? </td>
  <td style="vertical-align: top;">50.0 </td>
@@ -6436,7 +7342,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_FLT_CUTOFF">RC_FLT_CUTOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Cutoff frequency for the low pass filter on roll,pitch, yaw and throttle</p><p><strong>Comment:</strong> Does not get set unless below RC_FLT_SMP_RATE/2 because of filter instability characteristics.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Cutoff frequency for the low pass filter on roll,pitch, yaw and throttle</p><p><strong>Comment:</strong> Does not get set unless below RC_FLT_SMP_RATE/2 because of filter instability characteristics.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.1 > ? </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -6444,7 +7350,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TRIM_ROLL">TRIM_ROLL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><p>Roll trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> modules/commander</p>
 </td>
  <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -6452,7 +7358,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TRIM_PITCH">TRIM_PITCH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><p>Pitch trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> modules/commander</p>
 </td>
  <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -6460,10 +7366,73 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TRIM_YAW">TRIM_YAW</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><p>Yaw trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> modules/commander</p>
 </td>
  <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_CHAN">RC_RSSI_PWM_CHAN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>PWM input channel that provides RSSI</p><p><strong>Comment:</strong> 0: do not read RSSI from input channel 1-18: read RSSI from specified input channel Specify the range for RSSI input with RC_RSSI_PWM_MIN and RC_RSSI_PWM_MAX parameters.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Unassigned</li> 
+
+<li><strong>1:</strong> Channel 1</li> 
+
+<li><strong>2:</strong> Channel 2</li> 
+
+<li><strong>3:</strong> Channel 3</li> 
+
+<li><strong>4:</strong> Channel 4</li> 
+
+<li><strong>5:</strong> Channel 5</li> 
+
+<li><strong>6:</strong> Channel 6</li> 
+
+<li><strong>7:</strong> Channel 7</li> 
+
+<li><strong>8:</strong> Channel 8</li> 
+
+<li><strong>9:</strong> Channel 9</li> 
+
+<li><strong>10:</strong> Channel 10</li> 
+
+<li><strong>11:</strong> Channel 11</li> 
+
+<li><strong>12:</strong> Channel 12</li> 
+
+<li><strong>13:</strong> Channel 13</li> 
+
+<li><strong>14:</strong> Channel 14</li> 
+
+<li><strong>15:</strong> Channel 15</li> 
+
+<li><strong>16:</strong> Channel 16</li> 
+
+<li><strong>17:</strong> Channel 17</li> 
+
+<li><strong>18:</strong> Channel 18</li> 
+</ul>
+   <p><b>Module:</b> drivers/px4io</p>
+</td>
+ <td style="vertical-align: top;">0 > 18 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_MAX">RC_RSSI_PWM_MAX</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Max input value for RSSI reading</p><p><strong>Comment:</strong> Only used if RC_RSSI_PWM_CHAN > 0</p>    <p><b>Module:</b> drivers/px4io</p>
+</td>
+ <td style="vertical-align: top;">0 > 2000 </td>
+ <td style="vertical-align: top;">1000 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_MIN">RC_RSSI_PWM_MIN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Min input value for RSSI reading</p><p><strong>Comment:</strong> Only used if RC_RSSI_PWM_CHAN > 0</p>    <p><b>Module:</b> drivers/px4io</p>
+</td>
+ <td style="vertical-align: top;">0 > 2000 </td>
+ <td style="vertical-align: top;">2000 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -6471,7 +7440,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 ## Radio Signal Loss
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -6491,7 +7460,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 ## Radio Switches
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/sensors*.
+The module where these parameters are defined is: *modules/sensors*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -6502,43 +7471,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_FLTMODE">RC_MAP_FLTMODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Single channel flight mode selection</p><p><strong>Comment:</strong> If this parameter is non-zero, flight modes are only selected by this channel and are assigned to six slots.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6548,43 +7517,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_MODE_SW">RC_MAP_MODE_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Mode switch channel mapping</p><p><strong>Comment:</strong> This is the main flight mode selector. The channel index (starting from 1 for channel 1) indicates which channel should be used for deciding about the main mode. A value of zero indicates the switch is not assigned.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6594,43 +7563,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_RETURN_SW">RC_MAP_RETURN_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Return switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6640,43 +7609,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_RATT_SW">RC_MAP_RATT_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Rattitude switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6686,43 +7655,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_POSCTL_SW">RC_MAP_POSCTL_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Position Control switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6732,43 +7701,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_LOITER_SW">RC_MAP_LOITER_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Loiter switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6778,43 +7747,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_ACRO_SW">RC_MAP_ACRO_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Acro switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6824,43 +7793,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_OFFB_SW">RC_MAP_OFFB_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Offboard switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6870,43 +7839,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_KILL_SW">RC_MAP_KILL_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Kill switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6916,43 +7885,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_ARM_SW">RC_MAP_ARM_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Arm switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -6962,43 +7931,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_FLAPS">RC_MAP_FLAPS</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Flaps channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -7008,43 +7977,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_TRANS_SW">RC_MAP_TRANS_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>VTOL transition switch channel mapping</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -7054,43 +8023,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_GEAR_SW">RC_MAP_GEAR_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Landing gear switch channel</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -7100,43 +8069,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_STAB_SW">RC_MAP_STAB_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Stabilize switch channel mapping</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -7146,43 +8115,43 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_MAN_SW">RC_MAP_MAN_SW</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Manual switch channel mapping</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
+<li><strong>0:</strong> Unassigned</li> 
 
-<li><strong>1:</strong> Channel 1</li>
+<li><strong>1:</strong> Channel 1</li> 
 
-<li><strong>2:</strong> Channel 2</li>
+<li><strong>2:</strong> Channel 2</li> 
 
-<li><strong>3:</strong> Channel 3</li>
+<li><strong>3:</strong> Channel 3</li> 
 
-<li><strong>4:</strong> Channel 4</li>
+<li><strong>4:</strong> Channel 4</li> 
 
-<li><strong>5:</strong> Channel 5</li>
+<li><strong>5:</strong> Channel 5</li> 
 
-<li><strong>6:</strong> Channel 6</li>
+<li><strong>6:</strong> Channel 6</li> 
 
-<li><strong>7:</strong> Channel 7</li>
+<li><strong>7:</strong> Channel 7</li> 
 
-<li><strong>8:</strong> Channel 8</li>
+<li><strong>8:</strong> Channel 8</li> 
 
-<li><strong>9:</strong> Channel 9</li>
+<li><strong>9:</strong> Channel 9</li> 
 
-<li><strong>10:</strong> Channel 10</li>
+<li><strong>10:</strong> Channel 10</li> 
 
-<li><strong>11:</strong> Channel 11</li>
+<li><strong>11:</strong> Channel 11</li> 
 
-<li><strong>12:</strong> Channel 12</li>
+<li><strong>12:</strong> Channel 12</li> 
 
-<li><strong>13:</strong> Channel 13</li>
+<li><strong>13:</strong> Channel 13</li> 
 
-<li><strong>14:</strong> Channel 14</li>
+<li><strong>14:</strong> Channel 14</li> 
 
-<li><strong>15:</strong> Channel 15</li>
+<li><strong>15:</strong> Channel 15</li> 
 
-<li><strong>16:</strong> Channel 16</li>
+<li><strong>16:</strong> Channel 16</li> 
 
-<li><strong>17:</strong> Channel 17</li>
+<li><strong>17:</strong> Channel 17</li> 
 
-<li><strong>18:</strong> Channel 18</li>
+<li><strong>18:</strong> Channel 18</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 18 </td>
@@ -7292,7 +8261,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 ## Return To Land
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -7333,7 +8302,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 ## Runway Takeoff
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/lib/runway_takeoff*.
+The module where these parameters are defined is: *lib/runway_takeoff*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -7351,9 +8320,9 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="RWTO_HDG">RWTO_HDG</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Specifies which heading should be held during runnway takeoff</p><p><strong>Comment:</strong> 0: airframe heading, 1: heading towards takeoff waypoint</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Airframe</li>
+<li><strong>0:</strong> Airframe</li> 
 
-<li><strong>1:</strong> Waypoint</li>
+<li><strong>1:</strong> Waypoint</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 1 </td>
@@ -7427,7 +8396,7 @@ FW_AIRSPD_MIN * RWTO_AIRSPD_SCL</p>    </td>
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="SDLOG_RATE">SDLOG_RATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Logging rate</p><p><strong>Comment:</strong> A value of -1 indicates the commandline argument should be obeyed. A value of 0 sets the minimum rate, any other value is interpreted as rate in Hertz. This parameter is only read out before logging starts (which commonly is before arming).</p>    <p><b>Module:</b> src/modules/sdlog2</p>
+ <td style="vertical-align: top;"><p>Logging rate</p><p><strong>Comment:</strong> A value of -1 indicates the commandline argument should be obeyed. A value of 0 sets the minimum rate, any other value is interpreted as rate in Hertz. This parameter is only read out before logging starts (which commonly is before arming).</p>    <p><b>Module:</b> modules/sdlog2</p>
 </td>
  <td style="vertical-align: top;">-1 > 250 </td>
  <td style="vertical-align: top;">-1 </td>
@@ -7436,13 +8405,13 @@ FW_AIRSPD_MIN * RWTO_AIRSPD_SCL</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="SDLOG_EXT">SDLOG_EXT</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Extended logging mode</p><p><strong>Comment:</strong> A value of -1 indicates the command line argument should be obeyed. A value of 0 disables extended logging mode, a value of 1 enables it. This parameter is only read out before logging starts (which commonly is before arming).</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Command Line</li>
+<li><strong>-1:</strong> Command Line</li> 
 
-<li><strong>0:</strong> Disable</li>
+<li><strong>0:</strong> Disable</li> 
 
-<li><strong>1:</strong> Enable</li>
+<li><strong>1:</strong> Enable</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sdlog2</p>
+   <p><b>Module:</b> modules/sdlog2</p>
 </td>
  <td style="vertical-align: top;">-1 > 1 </td>
  <td style="vertical-align: top;">-1 </td>
@@ -7450,7 +8419,7 @@ FW_AIRSPD_MIN * RWTO_AIRSPD_SCL</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SDLOG_GPSTIME">SDLOG_GPSTIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Use timestamps only if GPS 3D fix is available</p><p><strong>Comment:</strong> Constrain the log folder creation to only use the time stamp if a 3D GPS lock is present.</p>    <p><b>Module:</b> src/modules/sdlog2</p>
+ <td style="vertical-align: top;"><p>Use timestamps only if GPS 3D fix is available</p><p><strong>Comment:</strong> Constrain the log folder creation to only use the time stamp if a 3D GPS lock is present.</p>    <p><b>Module:</b> modules/sdlog2</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -7460,15 +8429,15 @@ FW_AIRSPD_MIN * RWTO_AIRSPD_SCL</p>    </td>
  <td style="vertical-align: top;"><strong id="SDLOG_PRIO_BOOST">SDLOG_PRIO_BOOST</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Give logging app higher thread priority to avoid data loss.
 This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment:</strong> A value of 0 indicates that the default priority is used. Increasing the parameter in steps of one increases the priority.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Low priority</li>
+<li><strong>0:</strong> Low priority</li> 
 
-<li><strong>1:</strong> Default priority</li>
+<li><strong>1:</strong> Default priority</li> 
 
-<li><strong>2:</strong> Medium priority</li>
+<li><strong>2:</strong> Medium priority</li> 
 
-<li><strong>3:</strong> Max priority</li>
+<li><strong>3:</strong> Max priority</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sdlog2</p>
+   <p><b>Module:</b> modules/sdlog2</p>
 </td>
  <td style="vertical-align: top;">0 > 3 </td>
  <td style="vertical-align: top;">2 </td>
@@ -7476,7 +8445,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SDLOG_UTC_OFFSET">SDLOG_UTC_OFFSET</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UTC offset (unit: min)</p><p><strong>Comment:</strong> the difference in hours and minutes from Coordinated Universal Time (UTC) for a your place and date. for example, In case of South Korea(UTC+09:00), UTC offset is 540 min (9*60) refer to https://en.wikipedia.org/wiki/List_of_UTC_time_offsets</p>    <p><b>Module:</b> src/modules/logger</p>
+ <td style="vertical-align: top;"><p>UTC offset (unit: min)</p><p><strong>Comment:</strong> the difference in hours and minutes from Coordinated Universal Time (UTC) for a your place and date. for example, In case of South Korea(UTC+09:00), UTC offset is 540 min (9*60) refer to https://en.wikipedia.org/wiki/List_of_UTC_time_offsets</p>    <p><b>Module:</b> modules/logger</p>
 </td>
  <td style="vertical-align: top;">-1000 > 1000 </td>
  <td style="vertical-align: top;">0 </td>
@@ -7485,25 +8454,40 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="SDLOG_MODE">SDLOG_MODE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Logging Mode</p><p><strong>Comment:</strong> Determines when to start and stop logging. By default, logging is started when arming the system, and stopped when disarming. This parameter is only for the new logger (SYS_LOGGER=1).</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> when armed until disarm (default)</li>
+<li><strong>0:</strong> when armed until disarm (default)</li> 
 
-<li><strong>1:</strong> from boot until disarm</li>
+<li><strong>1:</strong> from boot until disarm</li> 
 
-<li><strong>2:</strong> from boot until shutdown</li>
-
-<li><strong>3:</strong> from boot until shutdown - IMU and Baro data only (used for thermal calibration)</li>
+<li><strong>2:</strong> from boot until shutdown</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/logger</p>
+ <p><b>Module:</b> modules/logger</p>
 </td>
- <td style="vertical-align: top;">0 > 3 </td>
+ <td style="vertical-align: top;">0 > 2 </td>
  <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SDLOG_PROFILE">SDLOG_PROFILE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Logging Topic Profile</p><p><strong>Comment:</strong> This is an integer bitmask controlling the set and rates of logged topics. The default allows for general log analysis and estimator replay, while keeping the log file size reasonably small. Enabling multiple sets leads to higher bandwidth requirements and larger log files. Set bits in the following positions to enable: 0 : Set to true to use the default set (used for general log analysis) 1 : Set to true to enable full rate estimator (EKF2) replay topics 2 : Set to true to enable topics for thermal calibration (high rate raw IMU and Baro sensor data) 3 : Set to true to enable topics for system identification (high rate actuator control and IMU data) 4 : Set to true to enable full rates for analysis of fast maneuvers (RC, attitude, rates and actuators) 5 : Set to true to enable debugging topics (debug_*.msg topics, for custom code) 6 : Set to true to enable topics for sensor comparison (low rate raw IMU, Baro and Magnetomer data)</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> default set (log analysis)</li> 
+  <li><strong>1:</strong> estimator replay (EKF2)</li> 
+  <li><strong>2:</strong> thermal calibration</li> 
+  <li><strong>3:</strong> system identification</li> 
+  <li><strong>4:</strong> high rate</li> 
+  <li><strong>5:</strong> debug</li> 
+  <li><strong>6:</strong> sensor comparison</li> 
+</ul>
+ <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/logger</p>
+</td>
+ <td style="vertical-align: top;">0 > 127 </td>
+ <td style="vertical-align: top;">3 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SDLOG_DIRS_MAX">SDLOG_DIRS_MAX</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Maximum number of log directories to keep</p><p><strong>Comment:</strong> If there are more log directories than this value, the system will delete the oldest directories during startup. In addition, the system will delete old logs if there is not enough free space left. The minimum amount is 300 MB. If this is set to 0, old directories will only be removed if the free space falls below the minimum.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/logger</p>
+ <p><b>Module:</b> modules/logger</p>
 </td>
  <td style="vertical-align: top;">0 > 1000 </td>
  <td style="vertical-align: top;">0 </td>
@@ -7511,7 +8495,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SDLOG_UUID">SDLOG_UUID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Log UUID</p><p><strong>Comment:</strong> If set to 1, add an ID to the log, which uniquely identifies the vehicle</p>    <p><b>Module:</b> src/modules/logger</p>
+ <td style="vertical-align: top;"><p>Log UUID</p><p><strong>Comment:</strong> If set to 1, add an ID to the log, which uniquely identifies the vehicle</p>    <p><b>Module:</b> modules/logger</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -7519,10 +8503,10 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 </tbody></table>
 
-## Sensor Calibration
+## SITL
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/sensors*.
+The module where these parameters are defined is: *modules/simulator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -7531,59 +8515,51 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="CAL_BOARD_ID">CAL_BOARD_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the board this parameter set was calibrated on</p>    </td>
+ <td style="vertical-align: top;"><strong id="SITL_UDP_PRT">SITL_UDP_PRT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Simulator UDP port</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">14560 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SIM_BAT_DRAIN">SIM_BAT_DRAIN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Simulator Battery drain interval</p>    </td>
+ <td style="vertical-align: top;">1 > 86400 (1)</td>
+ <td style="vertical-align: top;">60 </td>
+ <td style="vertical-align: top;">s</td>
+</tr>
+</tbody></table>
+
+## Sensor Calibration
+
+
+The module where these parameters are defined is: *modules/sensors*.
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG_PRIME">CAL_MAG_PRIME</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Primary mag ID</p>    </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_ID">CAL_GYRO0_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_XOFF">CAL_GYRO0_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_YOFF">CAL_GYRO0_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_ZOFF">CAL_GYRO0_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-5.0 > 5.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_XSCALE">CAL_GYRO0_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_YSCALE">CAL_GYRO0_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_ZSCALE">CAL_GYRO0_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"><strong id="CAL_MAG_SIDES">CAL_MAG_SIDES</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Bitfield selecting mag sides for calibration</p><p><strong>Comment:</strong> DETECT_ORIENTATION_TAIL_DOWN = 1 DETECT_ORIENTATION_NOSE_DOWN = 2 DETECT_ORIENTATION_LEFT = 4 DETECT_ORIENTATION_RIGHT = 8 DETECT_ORIENTATION_UPSIDE_DOWN = 16 DETECT_ORIENTATION_RIGHTSIDE_UP = 32</p> <strong>Values:</strong><ul>
+<li><strong>34:</strong> Two side calibration</li> 
+
+<li><strong>38:</strong> Three side calibration</li> 
+
+<li><strong>63:</strong> Six side calibration</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;">34 > 63 </td>
+ <td style="vertical-align: top;">63 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -7596,61 +8572,62 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG0_ROT">CAL_MAG0_ROT</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Rotation of magnetometer 0 relative to airframe</p><p><strong>Comment:</strong> An internal magnetometer will force a value of -1, so a GCS should only attempt to configure the rotation if the value is greater than or equal to zero.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Internal mag</li>
+<li><strong>-1:</strong> Internal mag</li> 
 
-<li><strong>0:</strong> No rotation</li>
+<li><strong>0:</strong> No rotation</li> 
 
-<li><strong>1:</strong> Yaw 45°</li>
+<li><strong>1:</strong> Yaw 45°</li> 
 
-<li><strong>2:</strong> Yaw 90°</li>
+<li><strong>2:</strong> Yaw 90°</li> 
 
-<li><strong>3:</strong> Yaw 135°</li>
+<li><strong>3:</strong> Yaw 135°</li> 
 
-<li><strong>4:</strong> Yaw 180°</li>
+<li><strong>4:</strong> Yaw 180°</li> 
 
-<li><strong>5:</strong> Yaw 225°</li>
+<li><strong>5:</strong> Yaw 225°</li> 
 
-<li><strong>6:</strong> Yaw 270°</li>
+<li><strong>6:</strong> Yaw 270°</li> 
 
-<li><strong>7:</strong> Yaw 315°</li>
+<li><strong>7:</strong> Yaw 315°</li> 
 
-<li><strong>8:</strong> Roll 180°</li>
+<li><strong>8:</strong> Roll 180°</li> 
 
-<li><strong>9:</strong> Roll 180°, Yaw 45°</li>
+<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
 
-<li><strong>10:</strong> Roll 180°, Yaw 90°</li>
+<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
 
-<li><strong>11:</strong> Roll 180°, Yaw 135°</li>
+<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
 
-<li><strong>12:</strong> Pitch 180°</li>
+<li><strong>12:</strong> Pitch 180°</li> 
 
-<li><strong>13:</strong> Roll 180°, Yaw 225°</li>
+<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
 
-<li><strong>14:</strong> Roll 180°, Yaw 270°</li>
+<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
 
-<li><strong>15:</strong> Roll 180°, Yaw 315°</li>
+<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
 
-<li><strong>16:</strong> Roll 90°</li>
+<li><strong>16:</strong> Roll 90°</li> 
 
-<li><strong>17:</strong> Roll 90°, Yaw 45°</li>
+<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
 
-<li><strong>18:</strong> Roll 90°, Yaw 90°</li>
+<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
 
-<li><strong>19:</strong> Roll 90°, Yaw 135°</li>
+<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
 
-<li><strong>20:</strong> Roll 270°</li>
+<li><strong>20:</strong> Roll 270°</li> 
 
-<li><strong>21:</strong> Roll 270°, Yaw 45°</li>
+<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
 
-<li><strong>22:</strong> Roll 270°, Yaw 90°</li>
+<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
 
-<li><strong>23:</strong> Roll 270°, Yaw 135°</li>
+<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
 
-<li><strong>24:</strong> Pitch 90°</li>
+<li><strong>24:</strong> Pitch 90°</li> 
 
-<li><strong>25:</strong> Pitch 270°</li>
+<li><strong>25:</strong> Pitch 270°</li> 
 </ul>
-   </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">-1 > 30 </td>
  <td style="vertical-align: top;">-1 </td>
  <td style="vertical-align: top;"></td>
@@ -7658,21 +8635,21 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG0_XOFF">CAL_MAG0_XOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG0_YOFF">CAL_MAG0_YOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG0_ZOFF">CAL_MAG0_ZOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
@@ -7695,6 +8672,541 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
  <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG1_ID">CAL_MAG1_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of Magnetometer the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG1_ROT">CAL_MAG1_ROT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Rotation of magnetometer 1 relative to airframe</p><p><strong>Comment:</strong> An internal magnetometer will force a value of -1, so a GCS should only attempt to configure the rotation if the value is greater than or equal to zero.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Internal mag</li> 
+
+<li><strong>0:</strong> No rotation</li> 
+
+<li><strong>1:</strong> Yaw 45°</li> 
+
+<li><strong>2:</strong> Yaw 90°</li> 
+
+<li><strong>3:</strong> Yaw 135°</li> 
+
+<li><strong>4:</strong> Yaw 180°</li> 
+
+<li><strong>5:</strong> Yaw 225°</li> 
+
+<li><strong>6:</strong> Yaw 270°</li> 
+
+<li><strong>7:</strong> Yaw 315°</li> 
+
+<li><strong>8:</strong> Roll 180°</li> 
+
+<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
+
+<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
+
+<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
+
+<li><strong>12:</strong> Pitch 180°</li> 
+
+<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
+
+<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
+
+<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
+
+<li><strong>16:</strong> Roll 90°</li> 
+
+<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
+
+<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
+
+<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
+
+<li><strong>20:</strong> Roll 270°</li> 
+
+<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
+
+<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
+
+<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
+
+<li><strong>24:</strong> Pitch 90°</li> 
+
+<li><strong>25:</strong> Pitch 270°</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-1 > 30 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG1_XOFF">CAL_MAG1_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG1_YOFF">CAL_MAG1_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG1_ZOFF">CAL_MAG1_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG1_XSCALE">CAL_MAG1_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG1_YSCALE">CAL_MAG1_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG1_ZSCALE">CAL_MAG1_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG2_ID">CAL_MAG2_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of Magnetometer the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG2_ROT">CAL_MAG2_ROT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Rotation of magnetometer 2 relative to airframe</p><p><strong>Comment:</strong> An internal magnetometer will force a value of -1, so a GCS should only attempt to configure the rotation if the value is greater than or equal to zero.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Internal mag</li> 
+
+<li><strong>0:</strong> No rotation</li> 
+
+<li><strong>1:</strong> Yaw 45°</li> 
+
+<li><strong>2:</strong> Yaw 90°</li> 
+
+<li><strong>3:</strong> Yaw 135°</li> 
+
+<li><strong>4:</strong> Yaw 180°</li> 
+
+<li><strong>5:</strong> Yaw 225°</li> 
+
+<li><strong>6:</strong> Yaw 270°</li> 
+
+<li><strong>7:</strong> Yaw 315°</li> 
+
+<li><strong>8:</strong> Roll 180°</li> 
+
+<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
+
+<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
+
+<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
+
+<li><strong>12:</strong> Pitch 180°</li> 
+
+<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
+
+<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
+
+<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
+
+<li><strong>16:</strong> Roll 90°</li> 
+
+<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
+
+<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
+
+<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
+
+<li><strong>20:</strong> Roll 270°</li> 
+
+<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
+
+<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
+
+<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
+
+<li><strong>24:</strong> Pitch 90°</li> 
+
+<li><strong>25:</strong> Pitch 270°</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-1 > 30 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG2_XOFF">CAL_MAG2_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG2_YOFF">CAL_MAG2_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG2_ZOFF">CAL_MAG2_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
+ <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG2_XSCALE">CAL_MAG2_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG2_YSCALE">CAL_MAG2_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG2_ZSCALE">CAL_MAG2_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_ID">CAL_MAG3_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of Magnetometer the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_ROT">CAL_MAG3_ROT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Rotation of magnetometer 2 relative to airframe</p><p><strong>Comment:</strong> An internal magnetometer will force a value of -1, so a GCS should only attempt to configure the rotation if the value is greater than or equal to zero.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Internal mag</li> 
+
+<li><strong>0:</strong> No rotation</li> 
+
+<li><strong>1:</strong> Yaw 45°</li> 
+
+<li><strong>2:</strong> Yaw 90°</li> 
+
+<li><strong>3:</strong> Yaw 135°</li> 
+
+<li><strong>4:</strong> Yaw 180°</li> 
+
+<li><strong>5:</strong> Yaw 225°</li> 
+
+<li><strong>6:</strong> Yaw 270°</li> 
+
+<li><strong>7:</strong> Yaw 315°</li> 
+
+<li><strong>8:</strong> Roll 180°</li> 
+
+<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
+
+<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
+
+<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
+
+<li><strong>12:</strong> Pitch 180°</li> 
+
+<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
+
+<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
+
+<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
+
+<li><strong>16:</strong> Roll 90°</li> 
+
+<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
+
+<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
+
+<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
+
+<li><strong>20:</strong> Roll 270°</li> 
+
+<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
+
+<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
+
+<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
+
+<li><strong>24:</strong> Pitch 90°</li> 
+
+<li><strong>25:</strong> Pitch 270°</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-1 > 30 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_XOFF">CAL_MAG3_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
+ <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_YOFF">CAL_MAG3_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
+ <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_ZOFF">CAL_MAG3_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
+ <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_XSCALE">CAL_MAG3_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_YSCALE">CAL_MAG3_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_ZSCALE">CAL_MAG3_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO_PRIME">CAL_GYRO_PRIME</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Primary gyro ID</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_ID">CAL_GYRO0_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_XOFF">CAL_GYRO0_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_YOFF">CAL_GYRO0_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_ZOFF">CAL_GYRO0_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_XSCALE">CAL_GYRO0_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_YSCALE">CAL_GYRO0_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_ZSCALE">CAL_GYRO0_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_ID">CAL_GYRO1_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_XOFF">CAL_GYRO1_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_YOFF">CAL_GYRO1_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_ZOFF">CAL_GYRO1_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_XSCALE">CAL_GYRO1_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_YSCALE">CAL_GYRO1_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_ZSCALE">CAL_GYRO1_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_ID">CAL_GYRO2_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_XOFF">CAL_GYRO2_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_YOFF">CAL_GYRO2_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_ZOFF">CAL_GYRO2_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_XSCALE">CAL_GYRO2_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_YSCALE">CAL_GYRO2_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_ZSCALE">CAL_GYRO2_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_BARO_PRIME">CAL_BARO_PRIME</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Primary baro ID</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_AIR_PMODEL">CAL_AIR_PMODEL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Airspeed sensor pitot model</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> HB Pitot</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_AIR_TUBELEN">CAL_AIR_TUBELEN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Airspeed sensor tube length</p>    </td>
+ <td style="vertical-align: top;">0.01 > 0.5 </td>
+ <td style="vertical-align: top;">0.2 </td>
+ <td style="vertical-align: top;">meter</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_DPRES_OFF">SENS_DPRES_OFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential pressure sensor offset</p><p><strong>Comment:</strong> The offset (zero-reading) in Pascal</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_DPRES_ANSC">SENS_DPRES_ANSC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential pressure sensor analog scaling</p><p><strong>Comment:</strong> Pick the appropriate scaling from the datasheet. this number defines the (linear) conversion from voltage to Pascal (pa). For the MPXV7002DP this is 1000. NOTE: If the sensor always registers zero, try switching the static and dynamic tubes.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC_PRIME">CAL_ACC_PRIME</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Primary accel ID</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -7742,166 +9254,6 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_ACC0_ZSCALE">CAL_ACC0_ZSCALE</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Accelerometer Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_ID">CAL_GYRO1_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_XOFF">CAL_GYRO1_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_YOFF">CAL_GYRO1_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_ZOFF">CAL_GYRO1_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-5.0 > 5.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_XSCALE">CAL_GYRO1_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_YSCALE">CAL_GYRO1_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_ZSCALE">CAL_GYRO1_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG1_ID">CAL_MAG1_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of Magnetometer the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG1_ROT">CAL_MAG1_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Rotation of magnetometer 1 relative to airframe</p><p><strong>Comment:</strong> An internal magnetometer will force a value of -1, so a GCS should only attempt to configure the rotation if the value is greater than or equal to zero.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Internal mag</li>
-
-<li><strong>0:</strong> No rotation</li>
-
-<li><strong>1:</strong> Yaw 45°</li>
-
-<li><strong>2:</strong> Yaw 90°</li>
-
-<li><strong>3:</strong> Yaw 135°</li>
-
-<li><strong>4:</strong> Yaw 180°</li>
-
-<li><strong>5:</strong> Yaw 225°</li>
-
-<li><strong>6:</strong> Yaw 270°</li>
-
-<li><strong>7:</strong> Yaw 315°</li>
-
-<li><strong>8:</strong> Roll 180°</li>
-
-<li><strong>9:</strong> Roll 180°, Yaw 45°</li>
-
-<li><strong>10:</strong> Roll 180°, Yaw 90°</li>
-
-<li><strong>11:</strong> Roll 180°, Yaw 135°</li>
-
-<li><strong>12:</strong> Pitch 180°</li>
-
-<li><strong>13:</strong> Roll 180°, Yaw 225°</li>
-
-<li><strong>14:</strong> Roll 180°, Yaw 270°</li>
-
-<li><strong>15:</strong> Roll 180°, Yaw 315°</li>
-
-<li><strong>16:</strong> Roll 90°</li>
-
-<li><strong>17:</strong> Roll 90°, Yaw 45°</li>
-
-<li><strong>18:</strong> Roll 90°, Yaw 90°</li>
-
-<li><strong>19:</strong> Roll 90°, Yaw 135°</li>
-
-<li><strong>20:</strong> Roll 270°</li>
-
-<li><strong>21:</strong> Roll 270°, Yaw 45°</li>
-
-<li><strong>22:</strong> Roll 270°, Yaw 90°</li>
-
-<li><strong>23:</strong> Roll 270°, Yaw 135°</li>
-
-<li><strong>24:</strong> Pitch 90°</li>
-
-<li><strong>25:</strong> Pitch 270°</li>
-</ul>
-   </td>
- <td style="vertical-align: top;">-1 > 30 </td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG1_XOFF">CAL_MAG1_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG1_YOFF">CAL_MAG1_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG1_ZOFF">CAL_MAG1_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG1_XSCALE">CAL_MAG1_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG1_YSCALE">CAL_MAG1_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG1_ZSCALE">CAL_MAG1_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
@@ -7956,166 +9308,6 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_ID">CAL_GYRO2_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_XOFF">CAL_GYRO2_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_YOFF">CAL_GYRO2_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_ZOFF">CAL_GYRO2_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-5.0 > 5.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_XSCALE">CAL_GYRO2_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_YSCALE">CAL_GYRO2_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_ZSCALE">CAL_GYRO2_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG2_ID">CAL_MAG2_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of Magnetometer the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG2_ROT">CAL_MAG2_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Rotation of magnetometer 2 relative to airframe</p><p><strong>Comment:</strong> An internal magnetometer will force a value of -1, so a GCS should only attempt to configure the rotation if the value is greater than or equal to zero.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Internal mag</li>
-
-<li><strong>0:</strong> No rotation</li>
-
-<li><strong>1:</strong> Yaw 45°</li>
-
-<li><strong>2:</strong> Yaw 90°</li>
-
-<li><strong>3:</strong> Yaw 135°</li>
-
-<li><strong>4:</strong> Yaw 180°</li>
-
-<li><strong>5:</strong> Yaw 225°</li>
-
-<li><strong>6:</strong> Yaw 270°</li>
-
-<li><strong>7:</strong> Yaw 315°</li>
-
-<li><strong>8:</strong> Roll 180°</li>
-
-<li><strong>9:</strong> Roll 180°, Yaw 45°</li>
-
-<li><strong>10:</strong> Roll 180°, Yaw 90°</li>
-
-<li><strong>11:</strong> Roll 180°, Yaw 135°</li>
-
-<li><strong>12:</strong> Pitch 180°</li>
-
-<li><strong>13:</strong> Roll 180°, Yaw 225°</li>
-
-<li><strong>14:</strong> Roll 180°, Yaw 270°</li>
-
-<li><strong>15:</strong> Roll 180°, Yaw 315°</li>
-
-<li><strong>16:</strong> Roll 90°</li>
-
-<li><strong>17:</strong> Roll 90°, Yaw 45°</li>
-
-<li><strong>18:</strong> Roll 90°, Yaw 90°</li>
-
-<li><strong>19:</strong> Roll 90°, Yaw 135°</li>
-
-<li><strong>20:</strong> Roll 270°</li>
-
-<li><strong>21:</strong> Roll 270°, Yaw 45°</li>
-
-<li><strong>22:</strong> Roll 270°, Yaw 90°</li>
-
-<li><strong>23:</strong> Roll 270°, Yaw 135°</li>
-
-<li><strong>24:</strong> Pitch 90°</li>
-
-<li><strong>25:</strong> Pitch 270°</li>
-</ul>
-   </td>
- <td style="vertical-align: top;">-1 > 30 </td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG2_XOFF">CAL_MAG2_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG2_YOFF">CAL_MAG2_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG2_ZOFF">CAL_MAG2_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG2_XSCALE">CAL_MAG2_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG2_YSCALE">CAL_MAG2_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG2_ZSCALE">CAL_MAG2_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="CAL_ACC2_ID">CAL_ACC2_ID</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>ID of the Accelerometer that the calibration is for</p>    </td>
  <td style="vertical-align: top;"></td>
@@ -8164,469 +9356,12 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG3_ID">CAL_MAG3_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of Magnetometer the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG3_ROT">CAL_MAG3_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Rotation of magnetometer 2 relative to airframe</p><p><strong>Comment:</strong> An internal magnetometer will force a value of -1, so a GCS should only attempt to configure the rotation if the value is greater than or equal to zero.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Internal mag</li>
-
-<li><strong>0:</strong> No rotation</li>
-
-<li><strong>1:</strong> Yaw 45°</li>
-
-<li><strong>2:</strong> Yaw 90°</li>
-
-<li><strong>3:</strong> Yaw 135°</li>
-
-<li><strong>4:</strong> Yaw 180°</li>
-
-<li><strong>5:</strong> Yaw 225°</li>
-
-<li><strong>6:</strong> Yaw 270°</li>
-
-<li><strong>7:</strong> Yaw 315°</li>
-
-<li><strong>8:</strong> Roll 180°</li>
-
-<li><strong>9:</strong> Roll 180°, Yaw 45°</li>
-
-<li><strong>10:</strong> Roll 180°, Yaw 90°</li>
-
-<li><strong>11:</strong> Roll 180°, Yaw 135°</li>
-
-<li><strong>12:</strong> Pitch 180°</li>
-
-<li><strong>13:</strong> Roll 180°, Yaw 225°</li>
-
-<li><strong>14:</strong> Roll 180°, Yaw 270°</li>
-
-<li><strong>15:</strong> Roll 180°, Yaw 315°</li>
-
-<li><strong>16:</strong> Roll 90°</li>
-
-<li><strong>17:</strong> Roll 90°, Yaw 45°</li>
-
-<li><strong>18:</strong> Roll 90°, Yaw 90°</li>
-
-<li><strong>19:</strong> Roll 90°, Yaw 135°</li>
-
-<li><strong>20:</strong> Roll 270°</li>
-
-<li><strong>21:</strong> Roll 270°, Yaw 45°</li>
-
-<li><strong>22:</strong> Roll 270°, Yaw 90°</li>
-
-<li><strong>23:</strong> Roll 270°, Yaw 135°</li>
-
-<li><strong>24:</strong> Pitch 90°</li>
-
-<li><strong>25:</strong> Pitch 270°</li>
-</ul>
-   </td>
- <td style="vertical-align: top;">-1 > 30 </td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG3_XOFF">CAL_MAG3_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG3_YOFF">CAL_MAG3_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG3_ZOFF">CAL_MAG3_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG3_XSCALE">CAL_MAG3_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG3_YSCALE">CAL_MAG3_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG3_ZSCALE">CAL_MAG3_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC_PRIME">CAL_ACC_PRIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Primary accel ID</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO_PRIME">CAL_GYRO_PRIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Primary gyro ID</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG_PRIME">CAL_MAG_PRIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Primary mag ID</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG_SIDES">CAL_MAG_SIDES</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Bitfield selecting mag sides for calibration</p><p><strong>Comment:</strong> DETECT_ORIENTATION_TAIL_DOWN = 1 DETECT_ORIENTATION_NOSE_DOWN = 2 DETECT_ORIENTATION_LEFT = 4 DETECT_ORIENTATION_RIGHT = 8 DETECT_ORIENTATION_UPSIDE_DOWN = 16 DETECT_ORIENTATION_RIGHTSIDE_UP = 32</p> <strong>Values:</strong><ul>
-<li><strong>34:</strong> Two side calibration</li>
-
-<li><strong>38:</strong> Three side calibration</li>
-
-<li><strong>63:</strong> Six side calibration</li>
-</ul>
-   </td>
- <td style="vertical-align: top;">34 > 63 </td>
- <td style="vertical-align: top;">63 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_BARO_PRIME">CAL_BARO_PRIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Primary baro ID</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_DPRES_OFF">SENS_DPRES_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential pressure sensor offset</p><p><strong>Comment:</strong> The offset (zero-reading) in Pascal</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_DPRES_ANSC">SENS_DPRES_ANSC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential pressure sensor analog scaling</p><p><strong>Comment:</strong> Pick the appropriate scaling from the datasheet. this number defines the (linear) conversion from voltage to Pascal (pa). For the MPXV7002DP this is 1000. NOTE: If the sensor always registers zero, try switching the static and dynamic tubes.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BARO_QNH">SENS_BARO_QNH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>QNH for barometer</p>    </td>
- <td style="vertical-align: top;">500 > 1500 </td>
- <td style="vertical-align: top;">1013.25 </td>
- <td style="vertical-align: top;">hPa</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BOARD_ROT">SENS_BOARD_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Board rotation</p><p><strong>Comment:</strong> This parameter defines the rotation of the FMU board relative to the platform.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> No rotation</li>
-
-<li><strong>1:</strong> Yaw 45°</li>
-
-<li><strong>2:</strong> Yaw 90°</li>
-
-<li><strong>3:</strong> Yaw 135°</li>
-
-<li><strong>4:</strong> Yaw 180°</li>
-
-<li><strong>5:</strong> Yaw 225°</li>
-
-<li><strong>6:</strong> Yaw 270°</li>
-
-<li><strong>7:</strong> Yaw 315°</li>
-
-<li><strong>8:</strong> Roll 180°</li>
-
-<li><strong>9:</strong> Roll 180°, Yaw 45°</li>
-
-<li><strong>10:</strong> Roll 180°, Yaw 90°</li>
-
-<li><strong>11:</strong> Roll 180°, Yaw 135°</li>
-
-<li><strong>12:</strong> Pitch 180°</li>
-
-<li><strong>13:</strong> Roll 180°, Yaw 225°</li>
-
-<li><strong>14:</strong> Roll 180°, Yaw 270°</li>
-
-<li><strong>15:</strong> Roll 180°, Yaw 315°</li>
-
-<li><strong>16:</strong> Roll 90°</li>
-
-<li><strong>17:</strong> Roll 90°, Yaw 45°</li>
-
-<li><strong>18:</strong> Roll 90°, Yaw 90°</li>
-
-<li><strong>19:</strong> Roll 90°, Yaw 135°</li>
-
-<li><strong>20:</strong> Roll 270°</li>
-
-<li><strong>21:</strong> Roll 270°, Yaw 45°</li>
-
-<li><strong>22:</strong> Roll 270°, Yaw 90°</li>
-
-<li><strong>23:</strong> Roll 270°, Yaw 135°</li>
-
-<li><strong>24:</strong> Pitch 90°</li>
-
-<li><strong>25:</strong> Pitch 270°</li>
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_FLOW_ROT">SENS_FLOW_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>PX4Flow board rotation</p><p><strong>Comment:</strong> This parameter defines the yaw rotation of the PX4FLOW board relative to the vehicle body frame. Zero rotation is defined as X on flow board pointing towards front of vehicle. The recommneded installation default for the PX4FLOW board is with the Y axis forward (270 deg yaw).</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> No rotation</li>
-
-<li><strong>1:</strong> Yaw 45°</li>
-
-<li><strong>2:</strong> Yaw 90°</li>
-
-<li><strong>3:</strong> Yaw 135°</li>
-
-<li><strong>4:</strong> Yaw 180°</li>
-
-<li><strong>5:</strong> Yaw 225°</li>
-
-<li><strong>6:</strong> Yaw 270°</li>
-
-<li><strong>7:</strong> Yaw 315°</li>
-</ul>
-  <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">6 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BOARD_Y_OFF">SENS_BOARD_Y_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Board rotation Y (Pitch) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BOARD_X_OFF">SENS_BOARD_X_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Board rotation X (Roll) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the X (Roll) axis It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BOARD_Z_OFF">SENS_BOARD_Z_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Board rotation Z (YAW) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the Z (Yaw) axis. It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EXT_MAG_ROT">SENS_EXT_MAG_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>External magnetometer rotation</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> No rotation</li>
-
-<li><strong>1:</strong> Yaw 45°</li>
-
-<li><strong>2:</strong> Yaw 90°</li>
-
-<li><strong>3:</strong> Yaw 135°</li>
-
-<li><strong>4:</strong> Yaw 180°</li>
-
-<li><strong>5:</strong> Yaw 225°</li>
-
-<li><strong>6:</strong> Yaw 270°</li>
-
-<li><strong>7:</strong> Yaw 315°</li>
-
-<li><strong>8:</strong> Roll 180°</li>
-
-<li><strong>9:</strong> Roll 180°, Yaw 45°</li>
-
-<li><strong>10:</strong> Roll 180°, Yaw 90°</li>
-
-<li><strong>11:</strong> Roll 180°, Yaw 135°</li>
-
-<li><strong>12:</strong> Pitch 180°</li>
-
-<li><strong>13:</strong> Roll 180°, Yaw 225°</li>
-
-<li><strong>14:</strong> Roll 180°, Yaw 270°</li>
-
-<li><strong>15:</strong> Roll 180°, Yaw 315°</li>
-
-<li><strong>16:</strong> Roll 90°</li>
-
-<li><strong>17:</strong> Roll 90°, Yaw 45°</li>
-
-<li><strong>18:</strong> Roll 90°, Yaw 90°</li>
-
-<li><strong>19:</strong> Roll 90°, Yaw 135°</li>
-
-<li><strong>20:</strong> Roll 270°</li>
-
-<li><strong>21:</strong> Roll 270°, Yaw 45°</li>
-
-<li><strong>22:</strong> Roll 270°, Yaw 90°</li>
-
-<li><strong>23:</strong> Roll 270°, Yaw 135°</li>
-
-<li><strong>24:</strong> Pitch 90°</li>
-
-<li><strong>25:</strong> Pitch 270°</li>
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EXT_MAG">SENS_EXT_MAG</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Select primary magnetometer</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Auto-select Mag</li>
-
-<li><strong>1:</strong> External is primary Mag</li>
-
-<li><strong>2:</strong> Internal is primary Mag</li>
-</ul>
-   </td>
- <td style="vertical-align: top;">0 > 2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="ATT_VIBE_THRESH">ATT_VIBE_THRESH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Threshold (of RMS) to warn about high vibration levels</p>    </td>
- <td style="vertical-align: top;">0.01 > 10 </td>
- <td style="vertical-align: top;">0.2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-</tbody></table>
-
-## Sensor Enable
-
-
-이 파라미터가 정의되어 있는 모듈 : *src/modules/sensors*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_LL40LS">SENS_EN_LL40LS</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Lidar-Lite (LL40LS)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li>
-
-<li><strong>1:</strong> PWM</li>
-
-<li><strong>2:</strong> I2C</li>
-</ul>
-  <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;">0 > 2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_SF0X">SENS_EN_SF0X</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Lightware laser rangefinder (serial)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li>
-
-<li><strong>1:</strong> SF02</li>
-
-<li><strong>2:</strong> SF10/a</li>
-
-<li><strong>3:</strong> SF10/b</li>
-
-<li><strong>4:</strong> SF10/c</li>
-
-<li><strong>5:</strong> SF11/c</li>
-</ul>
-  <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;">0 > 4 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_MB12XX">SENS_EN_MB12XX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Maxbotix Soanr (mb12xx)</p>   <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_TRONE">SENS_EN_TRONE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>TeraRanger One (trone)</p>   <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_SF1XX">SENS_EN_SF1XX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Lightware SF1xx laser rangefinder (i2c)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li>
-
-<li><strong>1:</strong> SF10/a</li>
-
-<li><strong>2:</strong> SF10/b</li>
-
-<li><strong>3:</strong> SF10/c</li>
-
-<li><strong>4:</strong> SF11/c</li>
-</ul>
-  <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;">0 > 4 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_THERMAL">SENS_EN_THERMAL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Thermal control of sensor temperature</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Thermal control unavailable</li>
-
-<li><strong>0:</strong> Thermal control off</li>
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
 </tbody></table>
 
 ## Sensor Thermal Compensation
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/sensors*.
+The module where these parameters are defined is: *modules/sensors*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -9686,10 +10421,10 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 </tbody></table>
 
-## Snapdragon UART ESC
+## Sensors
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/platforms/qurt/fc_addon/uart_esc*.
+The module where these parameters are defined is: *modules/sensors*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -9698,60 +10433,242 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MODEL">UART_ESC_MODEL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ESC model</p><p><strong>Comment:</strong> See esc_model_t enum definition in uart_esc_dev.h for all supported ESC model enum values.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> ESC_200QX</li>
+ <td style="vertical-align: top;"><strong id="SENS_BARO_QNH">SENS_BARO_QNH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>QNH for barometer</p>    </td>
+ <td style="vertical-align: top;">500 > 1500 </td>
+ <td style="vertical-align: top;">1013.25 </td>
+ <td style="vertical-align: top;">hPa</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_BOARD_ROT">SENS_BOARD_ROT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Board rotation</p><p><strong>Comment:</strong> This parameter defines the rotation of the FMU board relative to the platform.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> No rotation</li> 
 
-<li><strong>1:</strong> ESC_350QX</li>
+<li><strong>1:</strong> Yaw 45°</li> 
 
-<li><strong>2:</strong> ESC_210QC</li>
+<li><strong>2:</strong> Yaw 90°</li> 
+
+<li><strong>3:</strong> Yaw 135°</li> 
+
+<li><strong>4:</strong> Yaw 180°</li> 
+
+<li><strong>5:</strong> Yaw 225°</li> 
+
+<li><strong>6:</strong> Yaw 270°</li> 
+
+<li><strong>7:</strong> Yaw 315°</li> 
+
+<li><strong>8:</strong> Roll 180°</li> 
+
+<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
+
+<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
+
+<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
+
+<li><strong>12:</strong> Pitch 180°</li> 
+
+<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
+
+<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
+
+<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
+
+<li><strong>16:</strong> Roll 90°</li> 
+
+<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
+
+<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
+
+<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
+
+<li><strong>20:</strong> Roll 270°</li> 
+
+<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
+
+<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
+
+<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
+
+<li><strong>24:</strong> Pitch 90°</li> 
+
+<li><strong>25:</strong> Pitch 270°</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_FLOW_ROT">SENS_FLOW_ROT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>PX4Flow board rotation</p><p><strong>Comment:</strong> This parameter defines the yaw rotation of the PX4FLOW board relative to the vehicle body frame. Zero rotation is defined as X on flow board pointing towards front of vehicle. The recommneded installation default for the PX4FLOW board is with the Y axis forward (270 deg yaw).</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> No rotation</li> 
+
+<li><strong>1:</strong> Yaw 45°</li> 
+
+<li><strong>2:</strong> Yaw 90°</li> 
+
+<li><strong>3:</strong> Yaw 135°</li> 
+
+<li><strong>4:</strong> Yaw 180°</li> 
+
+<li><strong>5:</strong> Yaw 225°</li> 
+
+<li><strong>6:</strong> Yaw 270°</li> 
+
+<li><strong>7:</strong> Yaw 315°</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">6 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_BOARD_Y_OFF">SENS_BOARD_Y_OFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Board rotation Y (Pitch) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_BOARD_X_OFF">SENS_BOARD_X_OFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Board rotation X (Roll) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the X (Roll) axis It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_BOARD_Z_OFF">SENS_BOARD_Z_OFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Board rotation Z (YAW) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the Z (Yaw) axis. It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="ATT_VIBE_THRESH">ATT_VIBE_THRESH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Threshold (of RMS) to warn about high vibration levels</p>    </td>
+ <td style="vertical-align: top;">0.01 > 10 </td>
+ <td style="vertical-align: top;">0.2 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_LL40LS">SENS_EN_LL40LS</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Lidar-Lite (LL40LS)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> PWM</li> 
+
+<li><strong>2:</strong> I2C</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_SF0X">SENS_EN_SF0X</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Lightware laser rangefinder (serial)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> SF02</li> 
+
+<li><strong>2:</strong> SF10/a</li> 
+
+<li><strong>3:</strong> SF10/b</li> 
+
+<li><strong>4:</strong> SF10/c</li> 
+
+<li><strong>5:</strong> SF11/c</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 4 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_MB12XX">SENS_EN_MB12XX</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Maxbotix Soanr (mb12xx)</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_TRANGER">SENS_EN_TRANGER</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>TeraRanger Rangefinder (i2c)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> Autodetect</li> 
+
+<li><strong>2:</strong> TROne</li> 
+
+<li><strong>3:</strong> TREvo</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 3 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_SF1XX">SENS_EN_SF1XX</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Lightware SF1xx/SF20/LW20 laser rangefinder (i2c)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> SF10/a</li> 
+
+<li><strong>2:</strong> SF10/b</li> 
+
+<li><strong>3:</strong> SF10/c</li> 
+
+<li><strong>4:</strong> SF11/c</li> 
+
+<li><strong>5:</strong> SF/LW20</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 5 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_THERMAL">SENS_EN_THERMAL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Thermal control of sensor temperature</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Thermal control unavailable</li> 
+
+<li><strong>0:</strong> Thermal control off</li> 
 </ul>
    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">2 </td>
+ <td style="vertical-align: top;">-1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_BAUD">UART_ESC_BAUD</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ESC UART baud rate</p><p><strong>Comment:</strong> Default rate is 250Kbps, whic is used in off-the-shelf QRP ESC products.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">250000 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;"><strong id="IMU_GYRO_CUTOFF">IMU_GYRO_CUTOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Driver level cut frequency for gyro</p><p><strong>Comment:</strong> The cut frequency for the 2nd order butterworth filter on the gyro driver. This features is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the controllers, not the estimators. 0 disables the filter.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">5 > 1000 </td>
+ <td style="vertical-align: top;">30.0 </td>
+ <td style="vertical-align: top;">Hz</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MOTOR1">UART_ESC_MOTOR1</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Motor 1 Mapping</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">4 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MOTOR2">UART_ESC_MOTOR2</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Motor 2 Mapping</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MOTOR3">UART_ESC_MOTOR3</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Motor 3 Mapping</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MOTOR4">UART_ESC_MOTOR4</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Motor 4 Mapping</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">3 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;"><strong id="IMU_ACCEL_CUTOFF">IMU_ACCEL_CUTOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Driver level cut frequency for accel</p><p><strong>Comment:</strong> The cut frequency for the 2nd order butterworth filter on the accel driver. This features is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the controllers, not the estimators. 0 disables the filter.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">5 > 1000 </td>
+ <td style="vertical-align: top;">30.0 </td>
+ <td style="vertical-align: top;">Hz</td>
 </tr>
 </tbody></table>
 
 ## Subscriber Example
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/examples/subscriber*.
+The module where these parameters are defined is: *examples/subscriber*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -9778,7 +10695,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 ## Syslink
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/syslink*.
+The module where these parameters are defined is: *modules/syslink*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -9827,7 +10744,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_AUTOSTART">SYS_AUTOSTART</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Auto-start script index</p><p><strong>Comment:</strong> CHANGING THIS VALUE REQUIRES A RESTART. Defines the auto-start script used to bootstrap the system.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 99999 </td>
  <td style="vertical-align: top;">0 </td>
@@ -9836,34 +10753,35 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_AUTOCONFIG">SYS_AUTOCONFIG</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Automatically configure default values</p><p><strong>Comment:</strong> Set to 1 to reset parameters on next system startup (setting defaults). Platform-specific values are used if available. RC* parameters are preserved.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Keep parameters</li>
+<li><strong>0:</strong> Keep parameters</li> 
 
-<li><strong>1:</strong> Reset parameters</li>
+<li><strong>1:</strong> Reset parameters</li> 
 </ul>
-   <p><b>Module:</b> src/modules/systemlib</p>
+   <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="SYS_USE_IO">SYS_USE_IO</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set usage of IO board</p><p><strong>Comment:</strong> Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><strong id="SYS_HITL">SYS_HITL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Enable HITL mode on next boot</p><p><strong>Comment:</strong> While enabled the system will boot in HITL mode and not enable all sensors and checks. When disabled the same vehicle can be normally flown outdoors.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
- <td style="vertical-align: top;">0 > 1 </td>
- <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_RESTART_TYPE">SYS_RESTART_TYPE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Set restart type</p><p><strong>Comment:</strong> Set by px4io to indicate type of restart</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Data survives resets</li>
+<li><strong>0:</strong> Data survives resets</li> 
 
-<li><strong>1:</strong> Data survives in-flight resets only</li>
+<li><strong>1:</strong> Data survives in-flight resets only</li> 
 
-<li><strong>2:</strong> Data does not survive reset</li>
+<li><strong>2:</strong> Data does not survive reset</li> 
 </ul>
-   <p><b>Module:</b> src/modules/systemlib</p>
+   <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 2 </td>
  <td style="vertical-align: top;">2 </td>
@@ -9872,12 +10790,12 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_MC_EST_GROUP">SYS_MC_EST_GROUP</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Set multicopter estimator group</p><p><strong>Comment:</strong> Set the group of estimators used for multicopters and VTOLs</p> <strong>Values:</strong><ul>
-<li><strong>1:</strong> local_position_estimator, attitude_estimator_q</li>
+<li><strong>1:</strong> local_position_estimator, attitude_estimator_q</li> 
 
-<li><strong>2:</strong> ekf2</li>
+<li><strong>2:</strong> ekf2</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">1 > 2 </td>
  <td style="vertical-align: top;">2 </td>
@@ -9886,34 +10804,34 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_COMPANION">SYS_COMPANION</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>TELEM2 as companion computer link</p><p><strong>Comment:</strong> CHANGING THIS VALUE REQUIRES A RESTART. Configures the baud rate of the TELEM2 connector as companion computer interface.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li>
+<li><strong>0:</strong> Disabled</li> 
 
-<li><strong>10:</strong> FrSky Telemetry</li>
+<li><strong>10:</strong> FrSky Telemetry</li> 
 
-<li><strong>20:</strong> Crazyflie (Syslink)</li>
+<li><strong>20:</strong> Crazyflie (Syslink)</li> 
 
-<li><strong>57600:</strong> Companion Link (57600 baud, 8N1)</li>
+<li><strong>57600:</strong> Companion Link (57600 baud, 8N1)</li> 
 
-<li><strong>157600:</strong> OSD (57600 baud, 8N1)</li>
+<li><strong>157600:</strong> OSD (57600 baud, 8N1)</li> 
 
-<li><strong>257600:</strong> Command Receiver (57600 baud, 8N1)</li>
+<li><strong>257600:</strong> Command Receiver (57600 baud, 8N1)</li> 
 
-<li><strong>319200:</strong> Normal Telemetry (19200 baud, 8N1)</li>
+<li><strong>319200:</strong> Normal Telemetry (19200 baud, 8N1)</li> 
 
-<li><strong>338400:</strong> Normal Telemetry (38400 baud, 8N1)</li>
+<li><strong>338400:</strong> Normal Telemetry (38400 baud, 8N1)</li> 
 
-<li><strong>357600:</strong> Normal Telemetry (57600 baud, 8N1)</li>
+<li><strong>357600:</strong> Normal Telemetry (57600 baud, 8N1)</li> 
 
-<li><strong>419200:</strong> Iridium Telemetry (19200 baud, 8N1)</li>
+<li><strong>419200:</strong> Iridium Telemetry (19200 baud, 8N1)</li> 
 
-<li><strong>921600:</strong> Companion Link (921600 baud, 8N1)</li>
+<li><strong>921600:</strong> Companion Link (921600 baud, 8N1)</li> 
 
-<li><strong>1921600:</strong> ESP8266 (921600 baud, 8N1)</li>
+<li><strong>1921600:</strong> ESP8266 (921600 baud, 8N1)</li> 
 
-<li><strong>3115200:</strong> Normal Telemetry (115200 baud, 8N1)</li>
+<li><strong>3115200:</strong> Normal Telemetry (115200 baud, 8N1)</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1921600 </td>
  <td style="vertical-align: top;">157600 </td>
@@ -9921,7 +10839,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_PARAM_VER">SYS_PARAM_VER</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Parameter version</p><p><strong>Comment:</strong> This monotonically increasing number encodes the parameter compatibility set. whenever it increases parameters might not be backwards compatible and ground control stations should suggest a fresh configuration.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Parameter version</p><p><strong>Comment:</strong> This monotonically increasing number encodes the parameter compatibility set. whenever it increases parameters might not be backwards compatible and ground control stations should suggest a fresh configuration.</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > ? </td>
  <td style="vertical-align: top;">1 </td>
@@ -9930,12 +10848,12 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_LOGGER">SYS_LOGGER</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>SD logger</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> sdlog2 (legacy)</li>
+<li><strong>0:</strong> sdlog2 (legacy)</li> 
 
-<li><strong>1:</strong> logger (default)</li>
+<li><strong>1:</strong> logger (default)</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">1 </td>
@@ -9943,7 +10861,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_STCK_EN">SYS_STCK_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable stack checking</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Enable stack checking</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -9951,7 +10869,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_GYRO">SYS_CAL_GYRO</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable auto start of rate gyro thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Enable auto start of rate gyro thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -9959,7 +10877,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_ACCEL">SYS_CAL_ACCEL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable auto start of accelerometer thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Enable auto start of accelerometer thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -9967,7 +10885,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_BARO">SYS_CAL_BARO</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable auto start of barometer thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Enable auto start of barometer thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -9975,7 +10893,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_TDEL">SYS_CAL_TDEL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Required temperature rise during thermal calibration</p><p><strong>Comment:</strong> A temperature increase greater than this value is required during calibration. Calibration will complete for each sensor when the temperature increase above the starting temeprature exceeds the value set by SYS_CAL_TDEL. If the temperature rise is insufficient, the calibration will continue indefinitely and the board will need to be repowered to exit.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Required temperature rise during thermal calibration</p><p><strong>Comment:</strong> A temperature increase greater than this value is required during calibration. Calibration will complete for each sensor when the temperature increase above the starting temeprature exceeds the value set by SYS_CAL_TDEL. If the temperature rise is insufficient, the calibration will continue indefinitely and the board will need to be repowered to exit.</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">10 > ? </td>
  <td style="vertical-align: top;">24 </td>
@@ -9983,7 +10901,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_TMIN">SYS_CAL_TMIN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Minimum starting temperature for thermal calibration</p><p><strong>Comment:</strong> Temperature calibration for each sensor will ignore data if the temperature is lower than the value set by SYS_CAL_TMIN.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Minimum starting temperature for thermal calibration</p><p><strong>Comment:</strong> Temperature calibration for each sensor will ignore data if the temperature is lower than the value set by SYS_CAL_TMIN.</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">5 </td>
@@ -9991,18 +10909,36 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_TMAX">SYS_CAL_TMAX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Maximum starting temperature for thermal calibration</p><p><strong>Comment:</strong> Temperature calibration will not start if the temperature of any sensor is higher than the value set by SYS_CAL_TMAX.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Maximum starting temperature for thermal calibration</p><p><strong>Comment:</strong> Temperature calibration will not start if the temperature of any sensor is higher than the value set by SYS_CAL_TMAX.</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10 </td>
  <td style="vertical-align: top;">deg C</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="SYS_USE_IO">SYS_USE_IO</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set usage of IO board</p><p><strong>Comment:</strong> Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4io</p>
+</td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="LED_RGB_MAXBRT">LED_RGB_MAXBRT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>RGB Led brightness limit</p><p><strong>Comment:</strong> Set to 0 to disable, 1 for minimum brightness up to 15 (max)</p>    <p><b>Module:</b> src/drivers/rgbled</p>
+ <td style="vertical-align: top;"><p>RGB Led brightness limit</p><p><strong>Comment:</strong> Set to 0 to disable, 1 for minimum brightness up to 15 (max)</p>    <p><b>Module:</b> drivers/rgbled</p>
 </td>
  <td style="vertical-align: top;">0 > 15 </td>
  <td style="vertical-align: top;">15 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SYS_FMU_TASK">SYS_FMU_TASK</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Run the FMU as a task to reduce latency</p><p><strong>Comment:</strong> If true, the FMU will run in a separate task instead of on the work queue. Set this if low latency is required, for example for racing. This is a trade-off between RAM usage and latency: running as a task, it requires a separate stack and directly polls on the control topics, whereas running on the work queue, it runs at a fixed update rate.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -10016,8 +10952,48 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
  </thead>
 <tbody>
 <tr>
+ <td style="vertical-align: top;"><strong id="TEST_1">TEST_1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">2 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TEST_2">TEST_2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">4 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TEST_RC_X">TEST_RC_X</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">8 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TEST_RC2_X">TEST_RC2_X</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">16 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TEST_PARAMS">TEST_PARAMS</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">12345678 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="TEST_MIN">TEST_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -10025,7 +11001,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_MAX">TEST_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
@@ -10033,7 +11009,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_TRIM">TEST_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.5 </td>
@@ -10041,7 +11017,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_HP">TEST_HP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10.0 </td>
@@ -10049,7 +11025,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_LP">TEST_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10.0 </td>
@@ -10057,7 +11033,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_P">TEST_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.2 </td>
@@ -10065,7 +11041,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_I">TEST_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.1 </td>
@@ -10073,7 +11049,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_I_MAX">TEST_I_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
@@ -10081,7 +11057,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_D">TEST_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.01 </td>
@@ -10089,7 +11065,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_D_LP">TEST_D_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10.0 </td>
@@ -10097,7 +11073,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_MEAN">TEST_MEAN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
@@ -10105,18 +11081,10 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_DEV">TEST_DEV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">2.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="TEST_PARAMS">TEST_PARAMS</strong> (INT32)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/systemcmds/tests</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">12345678 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -10130,47 +11098,16 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="ESC_NODE_ID">ESC_NODE_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> src/modules/uavcanesc</p>
-</td>
- <td style="vertical-align: top;">1 > 125 </td>
- <td style="vertical-align: top;">120 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="ESC_BITRATE">ESC_BITRATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> src/modules/uavcanesc</p>
-</td>
- <td style="vertical-align: top;">20000 > 1000000 </td>
- <td style="vertical-align: top;">1000000 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CANNODE_NODE_ID">CANNODE_NODE_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> src/modules/uavcannode</p>
-</td>
- <td style="vertical-align: top;">1 > 125 </td>
- <td style="vertical-align: top;">120 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CANNODE_BITRATE">CANNODE_BITRATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> src/modules/uavcannode</p>
-</td>
- <td style="vertical-align: top;">20000 > 1000000 </td>
- <td style="vertical-align: top;">1000000 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="UAVCAN_ENABLE">UAVCAN_ENABLE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>UAVCAN mode</p><p><strong>Comment:</strong> 0 - UAVCAN disabled. 1 - Basic support for UAVCAN actuators and sensors. 2 - Full support for dynamic node ID allocation and firmware update. 3 - Sets the motor control outputs to UAVCAN and enables support for dynamic node ID allocation and firmware update.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li>
+<li><strong>0:</strong> Disabled</li> 
 
-<li><strong>2:</strong> Sensors Enabled</li>
+<li><strong>2:</strong> Only Sensors</li> 
 
-<li><strong>3:</strong> Sensors and Motors</li>
+<li><strong>3:</strong> Sensors and Motors</li> 
 </ul>
-   <p><b>Module:</b> src/modules/uavcan</p>
+  <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/uavcan</p>
 </td>
  <td style="vertical-align: top;">0 > 3 </td>
  <td style="vertical-align: top;">0 </td>
@@ -10178,7 +11115,8 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="UAVCAN_NODE_ID">UAVCAN_NODE_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> src/modules/uavcan</p>
+ <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/uavcan</p>
 </td>
  <td style="vertical-align: top;">1 > 125 </td>
  <td style="vertical-align: top;">1 </td>
@@ -10186,7 +11124,8 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="UAVCAN_BITRATE">UAVCAN_BITRATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> src/modules/uavcan</p>
+ <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/uavcan</p>
 </td>
  <td style="vertical-align: top;">20000 > 1000000 </td>
  <td style="vertical-align: top;">1000000 </td>
@@ -10195,10 +11134,42 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 <tr>
  <td style="vertical-align: top;"><strong id="UAVCAN_ESC_IDLT">UAVCAN_ESC_IDLT</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>UAVCAN ESC will spin at idle throttle when armed, even if the mixer outputs zero setpoints</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/uavcan</p>
+ <p><b>Module:</b> modules/uavcan</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CANNODE_NODE_ID">CANNODE_NODE_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> modules/uavcannode</p>
+</td>
+ <td style="vertical-align: top;">1 > 125 </td>
+ <td style="vertical-align: top;">120 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CANNODE_BITRATE">CANNODE_BITRATE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> modules/uavcannode</p>
+</td>
+ <td style="vertical-align: top;">20000 > 1000000 </td>
+ <td style="vertical-align: top;">1000000 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="ESC_NODE_ID">ESC_NODE_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> modules/uavcanesc</p>
+</td>
+ <td style="vertical-align: top;">1 > 125 </td>
+ <td style="vertical-align: top;">120 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="ESC_BITRATE">ESC_BITRATE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> modules/uavcanesc</p>
+</td>
+ <td style="vertical-align: top;">20000 > 1000000 </td>
+ <td style="vertical-align: top;">1000000 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -10206,7 +11177,7 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 ## VTOL Attitude Control
 
 
-이 파라미터가 정의되어 있는 모듈 : *src/modules/vtol_att_control*.
+The module where these parameters are defined is: *modules/vtol_att_control*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -10215,26 +11186,52 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="VT_TRANS_THR">VT_TRANS_THR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Target throttle value for pusher/puller motor during the transition to fw mode</p>    </td>
+ <td style="vertical-align: top;"><strong id="VT_TILT_MC">VT_TILT_MC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Position of tilt servo in mc mode</p>    </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
- <td style="vertical-align: top;">0.6 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_DWN_PITCH_MAX">VT_DWN_PITCH_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum allowed down-pitch the controller is able to demand. This prevents large, negative
-lift values being created when facing strong winds. The vehicle will use the pusher motor
-to accelerate forward if necessary</p>    </td>
- <td style="vertical-align: top;">0.0 > 45.0 </td>
- <td style="vertical-align: top;">5.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_FWD_THRUST_SC">VT_FWD_THRUST_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Fixed wing thrust scale for hover forward flight</p><p><strong>Comment:</strong> Scale applied to fixed wing thrust being used as source for forward acceleration in multirotor mode. This technique can be used to avoid the plane having to pitch down a lot in order to move forward. Setting this value to 0 (default) will disable this strategy.</p>    </td>
- <td style="vertical-align: top;">0.0 > 2.0 </td>
  <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_TILT_TRANS">VT_TILT_TRANS</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Position of tilt servo in transition mode</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.3 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_TILT_FW">VT_TILT_FW</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Position of tilt servo in fw mode</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_TRANS_P2_DUR">VT_TRANS_P2_DUR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Duration of front transition phase 2</p><p><strong>Comment:</strong> Time in seconds it should take for the rotors to rotate forward completely from the point when the plane has picked up enough airspeed and is ready to go into fixed wind mode.</p>    </td>
+ <td style="vertical-align: top;">0.1 > 5.0 (0.01)</td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;">s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_FW_MOT_OFFID">VT_FW_MOT_OFFID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>The channel number of motors that must be turned off in fixed wing mode</p>    </td>
+ <td style="vertical-align: top;">0 > 12345678 (1)</td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_FW_DIFTHR_EN">VT_FW_DIFTHR_EN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Differential thrust in forwards flight</p><p><strong>Comment:</strong> Set to 1 to enable differential thrust in fixed-wing flight.</p>    </td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_FW_DIFTHR_SC">VT_FW_DIFTHR_SC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential thrust scaling factor</p><p><strong>Comment:</strong> This factor specifies how the yaw input gets mapped to differential thrust in forwards flight.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.1)</td>
+ <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -10310,11 +11307,11 @@ to accelerate forward if necessary</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="VT_TYPE">VT_TYPE</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>VTOL Type (Tailsitter=0, Tiltrotor=1, Standard=2)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Tailsitter</li>
+<li><strong>0:</strong> Tailsitter</li> 
 
-<li><strong>1:</strong> Tiltrotor</li>
+<li><strong>1:</strong> Tiltrotor</li> 
 
-<li><strong>2:</strong> Standard</li>
+<li><strong>2:</strong> Standard</li> 
 </ul>
    </td>
  <td style="vertical-align: top;">0 > 2 </td>
@@ -10343,6 +11340,13 @@ to accelerate forward if necessary</p>    </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="VT_B_DEC_MSS">VT_B_DEC_MSS</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Approximate deceleration during back transition</p><p><strong>Comment:</strong> The approximate deceleration during a back transition in m/s/s Used to calculate back transition distance in mission mode. A lower value will make the VTOL transition further from the destination waypoint.</p>    </td>
+ <td style="vertical-align: top;">0.00 > 20.00 (1)</td>
+ <td style="vertical-align: top;">2.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="VT_ARSP_BLEND">VT_ARSP_BLEND</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Transition blending airspeed</p><p><strong>Comment:</strong> Airspeed at which we can start blending both fw and mc controls. Set to 0 to disable.</p>    </td>
  <td style="vertical-align: top;">0.00 > 30.00 (1)</td>
@@ -10361,13 +11365,6 @@ to accelerate forward if necessary</p>    </td>
  <td style="vertical-align: top;"><p>Optimal recovery strategy for pitch-weak tailsitters</p>    </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_WV_YAWR_SCL">VT_WV_YAWR_SCL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Weather-vane yaw rate scale</p><p><strong>Comment:</strong> The desired yawrate from the controller will be scaled in order to avoid yaw fighting against the wind.</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
- <td style="vertical-align: top;">0.15 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -10392,8 +11389,15 @@ to accelerate forward if necessary</p>    </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="VT_FW_ALT_ERR">VT_FW_ALT_ERR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Adaptive QuadChute</p><p><strong>Comment:</strong> Maximum negative altitude error, when in fixed wing the altitude drops below this copared to the altitude setpoint the vehicle will transition back to MC mode and enter failsafe RTL</p>    </td>
+ <td style="vertical-align: top;">0.0 > 200.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="VT_FW_QC_P">VT_FW_QC_P</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>QuadChute Max Pith</p><p><strong>Comment:</strong> Maximum pitch angle before QuadChute engages Above this the vehicle will transition back to MC mode and enter failsafe RTL</p>    </td>
+ <td style="vertical-align: top;"><p>QuadChute Max Pitch</p><p><strong>Comment:</strong> Maximum pitch angle before QuadChute engages Above this the vehicle will transition back to MC mode and enter failsafe RTL</p>    </td>
  <td style="vertical-align: top;">0 > 180 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
@@ -10413,362 +11417,66 @@ to accelerate forward if necessary</p>    </td>
  <td style="vertical-align: top;">seconds</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="VT_TILT_MC">VT_TILT_MC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Position of tilt servo in mc mode</p>    </td>
+ <td style="vertical-align: top;"><strong id="VT_WV_YAWR_SCL">VT_WV_YAWR_SCL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Weather-vane yaw rate scale</p><p><strong>Comment:</strong> The desired yawrate from the controller will be scaled in order to avoid yaw fighting against the wind.</p>    </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.15 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_TRANS_THR">VT_TRANS_THR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Target throttle value for pusher/puller motor during the transition to fw mode</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.6 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_DWN_PITCH_MAX">VT_DWN_PITCH_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum allowed down-pitch the controller is able to demand. This prevents large, negative
+lift values being created when facing strong winds. The vehicle will use the pusher motor
+to accelerate forward if necessary</p>    </td>
+ <td style="vertical-align: top;">0.0 > 45.0 </td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_FWD_THRUST_SC">VT_FWD_THRUST_SC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Fixed wing thrust scale for hover forward flight</p><p><strong>Comment:</strong> Scale applied to fixed wing thrust being used as source for forward acceleration in multirotor mode. This technique can be used to avoid the plane having to pitch down a lot in order to move forward. Setting this value to 0 (default) will disable this strategy.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 2.0 </td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="VT_TILT_TRANS">VT_TILT_TRANS</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Position of tilt servo in transition mode</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
- <td style="vertical-align: top;">0.3 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_TILT_FW">VT_TILT_FW</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Position of tilt servo in fw mode</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_TRANS_P2_DUR">VT_TRANS_P2_DUR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Duration of front transition phase 2</p><p><strong>Comment:</strong> Time in seconds it should take for the rotors to rotate forward completely from the point when the plane has picked up enough airspeed and is ready to go into fixed wind mode.</p>    </td>
- <td style="vertical-align: top;">0.1 > 5.0 (0.01)</td>
- <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;"><strong id="VT_B_TRANS_RAMP">VT_B_TRANS_RAMP</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Back transition MC motor ramp up time</p><p><strong>Comment:</strong> This sets the duration during wich the MC motors ramp up to the commanded thrust during the back transition stage.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 20.0 </td>
+ <td style="vertical-align: top;">3.0 </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="VT_FW_MOT_OFFID">VT_FW_MOT_OFFID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>The channel number of motors that must be turned off in fixed wing mode</p>    </td>
- <td style="vertical-align: top;">0 > 12345678 (1)</td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_FW_DIFTHR_EN">VT_FW_DIFTHR_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Differential thrust in forwards flight</p><p><strong>Comment:</strong> Set to 1 to enable differential thrust in fixed-wing flight.</p>    </td>
- <td style="vertical-align: top;">0 > 1 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_FW_DIFTHR_SC">VT_FW_DIFTHR_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential thrust scaling factor</p><p><strong>Comment:</strong> This factor specifies how the yaw input gets mapped to differential thrust in forwards flight.</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 (0.1)</td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-</tbody></table>
-
-## mTECS
-
-
-이 파라미터가 정의되어 있는 모듈 : *src/modules/fw_pos_control_l1/mtecs*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ENABLED">MT_ENABLED</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>mTECS enabled</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_THR_FF">MT_THR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Rate Control Feedforward
-Maps the total energy rate setpoint to the throttle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.7 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_THR_P">MT_THR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Rate Control P
-Maps the total energy rate error to the throttle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_THR_I">MT_THR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Rate Control I
-Maps the integrated total energy rate to the throttle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.25 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_THR_OFF">MT_THR_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Rate Control Offset (Cruise throttle sp)</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.7 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_FF">MT_PIT_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Energy Distribution Rate Control Feedforward
-Maps the energy distribution rate setpoint to the pitch setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.4 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_P">MT_PIT_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Energy Distribution Rate Control P
-Maps the energy distribution rate error to the pitch setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.03 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_I">MT_PIT_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Energy Distribution Rate Control I
-Maps the integrated energy distribution rate error to the pitch setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.03 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_OFF">MT_PIT_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Distribution Offset (Cruise pitch sp)</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
+ <td style="vertical-align: top;"><strong id="VT_B_REV_OUT">VT_B_REV_OUT</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Output on airbrakes channel during back transition
+Used for airbrakes or with ESCs that have reverse thrust enabled on a seperate channel
+Airbrakes need to be enables for your selected model/mixer</p>    </td>
+ <td style="vertical-align: top;">0 > 1 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_THR_MIN">MT_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal Throttle Setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;"><strong id="VT_B_REV_DEL">VT_B_REV_DEL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Delay in seconds before applying back transition throttle
+Set this to a value greater than 0 to give the motor time to spin down</p><p><strong>Comment:</strong> unit s</p>    </td>
+ <td style="vertical-align: top;">0 > 10 (1)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_THR_MAX">MT_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal Throttle Setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_MIN">MT_PIT_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal Pitch Setpoint in Degrees</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">-45.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_MAX">MT_PIT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal Pitch Setpoint in Degrees</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">20.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ALT_LP">MT_ALT_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass (cutoff freq.) for altitude</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;">Hz</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_LP">MT_FPA_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass (cutoff freq.) for the flight path angle</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;">Hz</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_P">MT_FPA_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>P gain for the altitude control
-Maps the altitude error to the flight path angle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.3 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_D">MT_FPA_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>D gain for the altitude control
-Maps the change of altitude error to the flight path angle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
+ <td style="vertical-align: top;"><strong id="VT_B_TRANS_THR">VT_B_TRANS_THR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Thottle output during back transition
+For ESCs and mixers that support reverse thrust on low PWM values set this to a negative value to apply active breaking
+For ESCs that support thrust reversal with a control channel please set VT_B_REV_OUT and set this to a positive value to apply active breaking</p>    </td>
+ <td style="vertical-align: top;">-1 > 1 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_D_LP">MT_FPA_D_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass for FPA error derivative calculation (see MT_FPA_D)</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_MIN">MT_FPA_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal flight path angle setpoint</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">-20.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_MAX">MT_FPA_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal flight path angle setpoint</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">30.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_A_LP">MT_A_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass (cutoff freq.) for airspeed</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_AD_LP">MT_AD_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Airspeed derivative calculation lowpass</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_P">MT_ACC_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>P gain for the airspeed control
-Maps the airspeed error to the acceleration setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.3 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_D">MT_ACC_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>D gain for the airspeed control
-Maps the change of airspeed error to the acceleration setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_D_LP">MT_ACC_D_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass for ACC error derivative calculation (see MT_ACC_D)</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_MIN">MT_ACC_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal acceleration (air)</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-40.0 </td>
- <td style="vertical-align: top;">m/s/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_MAX">MT_ACC_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal acceleration (air)</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">40.0 </td>
- <td style="vertical-align: top;">m/s/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_TKF_THR_MIN">MT_TKF_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal throttle during takeoff</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_TKF_THR_MAX">MT_TKF_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal throttle during takeoff</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_TKF_PIT_MIN">MT_TKF_PIT_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal pitch during takeoff</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_TKF_PIT_MAX">MT_TKF_PIT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal pitch during takeoff</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">45.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_USP_THR_MIN">MT_USP_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal throttle in underspeed mode</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_USP_THR_MAX">MT_USP_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal throttle in underspeed mode</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_USP_PIT_MIN">MT_USP_PIT_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal pitch in underspeed mode</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">-45.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_USP_PIT_MAX">MT_USP_PIT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal pitch in underspeed mode</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_LND_THR_MIN">MT_LND_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal throttle in landing mode (only last phase of landing)</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_LND_THR_MAX">MT_LND_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal throttle in landing mode (only last phase of landing)</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_LND_PIT_MIN">MT_LND_PIT_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal pitch in landing mode</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">-5.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_LND_PIT_MAX">MT_LND_PIT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal pitch in landing mode</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">15.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_THR_I_MAX">MT_THR_I_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integrator Limit for Total Energy Rate Control</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">10.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_I_MAX">MT_PIT_I_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integrator Limit for Energy Distribution Rate Control</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -10782,40 +11490,8 @@ Maps the change of airspeed error to the acceleration setpoint</p>    </td>
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="EXFW_HDNG_P">EXFW_HDNG_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/fixedwing_control</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="EXFW_ROLL_P">EXFW_ROLL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/fixedwing_control</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="EXFW_PITCH_P">EXFW_PITCH_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/fixedwing_control</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="RV_YAW_P">RV_YAW_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/rover_steering_control</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="SEG_TH2V_P">SEG_TH2V_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/segway</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/segway</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10.0 </td>
@@ -10823,7 +11499,7 @@ Maps the change of airspeed error to the acceleration setpoint</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SEG_TH2V_I">SEG_TH2V_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/segway</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/segway</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
@@ -10831,7 +11507,7 @@ Maps the change of airspeed error to the acceleration setpoint</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SEG_TH2V_I_MAX">SEG_TH2V_I_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/segway</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/segway</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
@@ -10839,287 +11515,43 @@ Maps the change of airspeed error to the acceleration setpoint</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SEG_Q2V">SEG_Q2V</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/segway</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/segway</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="RC_MAP_FAILSAFE">RC_MAP_FAILSAFE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Failsafe channel mapping</p><p><strong>Comment:</strong> The RC mapping index indicates which channel is used for failsafe If 0, whichever channel is mapped to throttle is used otherwise the value indicates the specific rc channel to use</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li>
-
-<li><strong>1:</strong> Channel 1</li>
-
-<li><strong>2:</strong> Channel 2</li>
-
-<li><strong>3:</strong> Channel 3</li>
-
-<li><strong>4:</strong> Channel 4</li>
-
-<li><strong>5:</strong> Channel 5</li>
-
-<li><strong>6:</strong> Channel 6</li>
-
-<li><strong>7:</strong> Channel 7</li>
-
-<li><strong>8:</strong> Channel 8</li>
-
-<li><strong>9:</strong> Channel 9</li>
-
-<li><strong>10:</strong> Channel 10</li>
-
-<li><strong>11:</strong> Channel 11</li>
-
-<li><strong>12:</strong> Channel 12</li>
-
-<li><strong>13:</strong> Channel 13</li>
-
-<li><strong>14:</strong> Channel 14</li>
-
-<li><strong>15:</strong> Channel 15</li>
-
-<li><strong>16:</strong> Channel 16</li>
-
-<li><strong>17:</strong> Channel 17</li>
-
-<li><strong>18:</strong> Channel 18</li>
-</ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><strong id="EXFW_HDNG_P">EXFW_HDNG_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/fixedwing_control</p>
 </td>
- <td style="vertical-align: top;">0 > 18 </td>
- <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_RC_STICK_OV">COM_RC_STICK_OV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><strong id="EXFW_ROLL_P">EXFW_ROLL_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/fixedwing_control</p>
 </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">12.0 </td>
+ <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE1">COM_FLTMODE1</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>First flightmode slot (1000-1160)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li>
-
-<li><strong>0:</strong> Manual</li>
-
-<li><strong>1:</strong> Altitude</li>
-
-<li><strong>2:</strong> Position</li>
-
-<li><strong>3:</strong> Mission</li>
-
-<li><strong>4:</strong> Hold</li>
-
-<li><strong>5:</strong> Return</li>
-
-<li><strong>6:</strong> Acro</li>
-
-<li><strong>7:</strong> Offboard</li>
-
-<li><strong>8:</strong> Stabilized</li>
-
-<li><strong>9:</strong> Rattitude</li>
-
-<li><strong>10:</strong> Takeoff</li>
-
-<li><strong>11:</strong> Land</li>
-
-<li><strong>12:</strong> Follow Me</li>
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><strong id="EXFW_PITCH_P">EXFW_PITCH_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/fixedwing_control</p>
 </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE2">COM_FLTMODE2</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Second flightmode slot (1160-1320)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li>
-
-<li><strong>0:</strong> Manual</li>
-
-<li><strong>1:</strong> Altitude</li>
-
-<li><strong>2:</strong> Position</li>
-
-<li><strong>3:</strong> Mission</li>
-
-<li><strong>4:</strong> Hold</li>
-
-<li><strong>5:</strong> Return</li>
-
-<li><strong>6:</strong> Acro</li>
-
-<li><strong>7:</strong> Offboard</li>
-
-<li><strong>8:</strong> Stabilized</li>
-
-<li><strong>9:</strong> Rattitude</li>
-
-<li><strong>10:</strong> Takeoff</li>
-
-<li><strong>11:</strong> Land</li>
-
-<li><strong>12:</strong> Follow Me</li>
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><strong id="RV_YAW_P">RV_YAW_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/rover_steering_control</p>
 </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE3">COM_FLTMODE3</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Third flightmode slot (1320-1480)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li>
-
-<li><strong>0:</strong> Manual</li>
-
-<li><strong>1:</strong> Altitude</li>
-
-<li><strong>2:</strong> Position</li>
-
-<li><strong>3:</strong> Mission</li>
-
-<li><strong>4:</strong> Hold</li>
-
-<li><strong>5:</strong> Return</li>
-
-<li><strong>6:</strong> Acro</li>
-
-<li><strong>7:</strong> Offboard</li>
-
-<li><strong>8:</strong> Stabilized</li>
-
-<li><strong>9:</strong> Rattitude</li>
-
-<li><strong>10:</strong> Takeoff</li>
-
-<li><strong>11:</strong> Land</li>
-
-<li><strong>12:</strong> Follow Me</li>
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE4">COM_FLTMODE4</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Fourth flightmode slot (1480-1640)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li>
-
-<li><strong>0:</strong> Manual</li>
-
-<li><strong>1:</strong> Altitude</li>
-
-<li><strong>2:</strong> Position</li>
-
-<li><strong>3:</strong> Mission</li>
-
-<li><strong>4:</strong> Hold</li>
-
-<li><strong>5:</strong> Return</li>
-
-<li><strong>6:</strong> Acro</li>
-
-<li><strong>7:</strong> Offboard</li>
-
-<li><strong>8:</strong> Stabilized</li>
-
-<li><strong>9:</strong> Rattitude</li>
-
-<li><strong>10:</strong> Takeoff</li>
-
-<li><strong>11:</strong> Land</li>
-
-<li><strong>12:</strong> Follow Me</li>
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE5">COM_FLTMODE5</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Fifth flightmode slot (1640-1800)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li>
-
-<li><strong>0:</strong> Manual</li>
-
-<li><strong>1:</strong> Altitude</li>
-
-<li><strong>2:</strong> Position</li>
-
-<li><strong>3:</strong> Mission</li>
-
-<li><strong>4:</strong> Hold</li>
-
-<li><strong>5:</strong> Return</li>
-
-<li><strong>6:</strong> Acro</li>
-
-<li><strong>7:</strong> Offboard</li>
-
-<li><strong>8:</strong> Stabilized</li>
-
-<li><strong>9:</strong> Rattitude</li>
-
-<li><strong>10:</strong> Takeoff</li>
-
-<li><strong>11:</strong> Land</li>
-
-<li><strong>12:</strong> Follow Me</li>
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE6">COM_FLTMODE6</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Sixth flightmode slot (1800-2000)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li>
-
-<li><strong>0:</strong> Manual</li>
-
-<li><strong>1:</strong> Altitude</li>
-
-<li><strong>2:</strong> Position</li>
-
-<li><strong>3:</strong> Mission</li>
-
-<li><strong>4:</strong> Hold</li>
-
-<li><strong>5:</strong> Return</li>
-
-<li><strong>6:</strong> Acro</li>
-
-<li><strong>7:</strong> Offboard</li>
-
-<li><strong>8:</strong> Stabilized</li>
-
-<li><strong>9:</strong> Rattitude</li>
-
-<li><strong>10:</strong> Takeoff</li>
-
-<li><strong>11:</strong> Land</li>
-
-<li><strong>12:</strong> Follow Me</li>
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
+

--- a/kr/tutorials/land_detector.md
+++ b/kr/tutorials/land_detector.md
@@ -12,7 +12,7 @@
 
 * [MPC_THR_HOVER](../advanced/parameter_reference.md#MPC_THR_HOVER) - 시스템의 hover 스로틀\(퍼센티지로 디폴트 50%\). altitude 제어를 정확하게 하는 목적이 아니라 정확히 착륙 감지를 하기 위해서는 이를 정확하게 설정하는 것이 중요하다. 페이로드가 없는 레이서와 큰 카메라 드론은 더 낮게 셋팅해야함\(예로 35%\)
 * [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - 시스템의 전체 최소 스로틀. 제어되면서 내려오도록 설정해야함.
-* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - 착륙시 수용하는 최소화 hover 스로틀 사이에 범위를 정의하기 위해서 스케일링 팩터로 사용. 예제: 최소 스로틀이 0.1이면 hover 스로틀은 0.5이고 범위는 0.2 \(20%\) 입니다. 착륙에서 카운트하는 가장 높은 스로틀 값은 최소 스로틀 + \(0.5 - 0.1\) \* 0.2 = 0.08. 따라서 전체 스로틀은 0.18.
+* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - 착륙시 수용하는 최소화 hover 스로틀 사이에 범위를 정의하기 위해서 스케일링 팩터로 사용. Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is: `0.1 + (0.5 - 0.1) * 0.2 = 0.18`.
 
 
 The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.

--- a/kr/tutorials/land_detector.md
+++ b/kr/tutorials/land_detector.md
@@ -4,21 +4,23 @@
 
 ## Auto-Disarming 설정
 
-디폴트로 착륙 감지기는 착륙을 감지합니다. 하지만 auto-disarm을 하지는 않습니다. 만약 `COM_DISARM_LAND`가 0이 아닌 값으로 설정되어 있다면 시스템은 N 초 후에\(설정되어 있는 값\) auto-disarm이 됩니다.
+디폴트로 착륙 감지기는 착륙을 감지합니다. 하지만 auto-disarm을 하지는 않습니다. 만약 [COM_DISARM_LAND](../advanced/parameter_reference.md#COM_DISARM_LAND)가 0이 아닌 값으로 설정되어 있다면 시스템은 N 초 후에\(설정되어 있는 값\) auto-disarm이 됩니다.
 
 ## 멀티콥터 착륙 감지기 설정
 
 파라미터의 전체 집합은 `LNDMC` 접두어로 시작하는 QGroundControl 파라미터 에디터에서 설정할 수 있습니다. airframe마다 다른 핵심 파라미터는 다음과 같이 :
 
-* `LNDMC_MAN_DWNTHR` - 상태를 착륙이라고 볼 수 있는 수동 스로틀에 대한 임계값 \(퍼센티지로 디폴트 15%\). 레이서아 같이 아주 높은 thrust-to-weight 비율은 더 낮은 셋팅이 필요하다.\(예로 8%\)
-* `MPC_THR_HOVER` - 시스템의 hover 스로틀\(퍼센티지로 디폴트 50%\). altitude 제어를 정확하게 하는 목적이 아니라 정확히 착륙 감지를 하기 위해서는 이를 정확하게 설정하는 것이 중요하다. 페이로드가 없는 레이서와 큰 카메라 드론은 더 낮게 셋팅해야함\(예로 35%\)
-* `MPC_THR_MIN` - 시스템의 전체 최소 스로틀. 제어되면서 내려오도록 설정해야함.
-* `LNDMC_THR_RANGE` - 착륙시 수용하는 최소화 hover 스로틀 사이에 범위를 정의하기 위해서 스케일링 팩터로 사용. 예제: 최소 스로틀이 0.1이면 hover 스로틀은 0.5이고 범위는 0.2 \(20%\) 입니다. 착륙에서 카운트하는 가장 높은 스로틀 값은 최소 스로틀 + \(0.5 - 0.1\) \* 0.2 = 0.08. 따라서 전체 스로틀은 0.18.
-* `LNDMC_POS_UPTHR` - 트리거 이륙에 대한 스로틀 레벨\(퍼센티지로 디폴트 65%\). 만약 조정자가 이 임계값 위로 높이면 시스템은 이륙하게 됩니다. 이 값은 hover 스로틀보다 커야합니다.
+* [MPC_THR_HOVER](../advanced/parameter_reference.md#MPC_THR_HOVER) - 시스템의 hover 스로틀\(퍼센티지로 디폴트 50%\). altitude 제어를 정확하게 하는 목적이 아니라 정확히 착륙 감지를 하기 위해서는 이를 정확하게 설정하는 것이 중요하다. 페이로드가 없는 레이서와 큰 카메라 드론은 더 낮게 셋팅해야함\(예로 35%\)
+* [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - 시스템의 전체 최소 스로틀. 제어되면서 내려오도록 설정해야함.
+* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - 착륙시 수용하는 최소화 hover 스로틀 사이에 범위를 정의하기 위해서 스케일링 팩터로 사용. 예제: 최소 스로틀이 0.1이면 hover 스로틀은 0.5이고 범위는 0.2 \(20%\) 입니다. 착륙에서 카운트하는 가장 높은 스로틀 값은 최소 스로틀 + \(0.5 - 0.1\) \* 0.2 = 0.08. 따라서 전체 스로틀은 0.18.
+
+
+The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
+
 
 ## 고정익 착륙 감지기 설정
 
 파라미터의 전체 집합은 `LNDFW` 접두어로 시작하는 QGroundControl 파라미터 에디터에서 설정할 수 있습니다. 2개 사용자 파라미터는 가끔씩 튜닝이 필요합니다. :
 
-* `LNDFW_AIRSPD_MAX` - 시스템이 허용하는 최대 airspeed는 착륙시 고려. 디폴트 값인 8 m/s는 airspeed 센싱 정확도와 빠른 트리거링을 고려했을 때 신뢰할 수 있음. 더 성능이 좋은 airspeed 센서를 사용하는 경우 이 파라미터 값을 더 낮게 설정 가능.
-* `LNDFW_VELI_MAX` - 시스템에 대한 최대 속도에서 여전히 착륙시 고려. 이 파라미터는 손으로 던져서 airframe 런칭하는 경우 착륙 감지를 시작하는 때를 조정할 수 있습니다.
+* [LNDFW_AIRSPD_MAX](../advanced/parameter_reference.md#LNDFW_AIRSPD_MAX) - 시스템이 허용하는 최대 airspeed는 착륙시 고려. 디폴트 값인 8 m/s는 airspeed 센싱 정확도와 빠른 트리거링을 고려했을 때 신뢰할 수 있음. 더 성능이 좋은 airspeed 센서를 사용하는 경우 이 파라미터 값을 더 낮게 설정 가능.
+* [LNDFW_VELI_MAX](../advanced/parameter_reference.md#LNDFW_VELI_MAX) - 시스템에 대한 최대 속도에서 여전히 착륙시 고려. 이 파라미터는 손으로 던져서 airframe 런칭하는 경우 착륙 감지를 시작하는 때를 조정할 수 있습니다.

--- a/kr/tutorials/land_detector.md
+++ b/kr/tutorials/land_detector.md
@@ -15,9 +15,6 @@
 * [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - 착륙시 수용하는 최소화 hover 스로틀 사이에 범위를 정의하기 위해서 스케일링 팩터로 사용. Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is: `0.1 + (0.5 - 0.1) * 0.2 = 0.18`.
 
 
-The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
-
-
 ## 고정익 착륙 감지기 설정
 
 파라미터의 전체 집합은 `LNDFW` 접두어로 시작하는 QGroundControl 파라미터 에디터에서 설정할 수 있습니다. 2개 사용자 파라미터는 가끔씩 튜닝이 필요합니다. :

--- a/zh/advanced/parameter_reference.md
+++ b/zh/advanced/parameter_reference.md
@@ -1,16 +1,10 @@
----
-translated_page: https://github.com/PX4/Devguide/blob/master/en/advanced/parameter_reference.md
-translated_sha: 
----
-
 # Parameter Reference
-
 > **Note** **This list is auto-generated from the source code** and contains the most recent parameter documentation.
 
 ## Attitude EKF estimator
 
 
-The module where these parameters are defined is: *src/examples/attitude_estimator_ekf*.
+The module where these parameters are defined is: *examples/attitude_estimator_ekf*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -100,7 +94,7 @@ The module where these parameters are defined is: *src/examples/attitude_estimat
 ## Attitude Q estimator
 
 
-The module where these parameters are defined is: *src/modules/attitude_estimator_q*.
+The module where these parameters are defined is: *modules/attitude_estimator_q*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -193,7 +187,7 @@ velocity</p>    </td>
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_SCALE_IO">BAT_V_SCALE_IO</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Scaling factor for battery voltage sensor on PX4IO</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Scaling factor for battery voltage sensor on PX4IO</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1 > 100000 </td>
  <td style="vertical-align: top;">10000 </td>
@@ -201,7 +195,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_CNT_V_VOLT">BAT_CNT_V_VOLT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Scaling from ADC counts to volt on the ADC input (battery voltage)</p><p><strong>Comment:</strong> This is not the battery voltage, but the intermediate ADC voltage. A value of -1 signifies that the board defaults are used, which is highly recommended.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Scaling from ADC counts to volt on the ADC input (battery voltage)</p><p><strong>Comment:</strong> This is not the battery voltage, but the intermediate ADC voltage. A value of -1 signifies that the board defaults are used, which is highly recommended.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -209,7 +203,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_CNT_V_CURR">BAT_CNT_V_CURR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Scaling from ADC counts to volt on the ADC input (battery current)</p><p><strong>Comment:</strong> This is not the battery current, but the intermediate ADC voltage. A value of -1 signifies that the board defaults are used, which is highly recommended.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Scaling from ADC counts to volt on the ADC input (battery current)</p><p><strong>Comment:</strong> This is not the battery current, but the intermediate ADC voltage. A value of -1 signifies that the board defaults are used, which is highly recommended.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -217,7 +211,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_OFFS_CURR">BAT_V_OFFS_CURR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Offset in volt as seen by the ADC input of the current sensor</p><p><strong>Comment:</strong> This offset will be subtracted before calculating the battery current based on the voltage.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Offset in volt as seen by the ADC input of the current sensor</p><p><strong>Comment:</strong> This offset will be subtracted before calculating the battery current based on the voltage.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
@@ -225,7 +219,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_DIV">BAT_V_DIV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Battery voltage divider (V divider)</p><p><strong>Comment:</strong> This is the divider from battery voltage to 3.3V ADC voltage. If using e.g. Mauch power modules the value from the datasheet can be applied straight here. A value of -1 means to use the board default.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Battery voltage divider (V divider)</p><p><strong>Comment:</strong> This is the divider from battery voltage to 3.3V ADC voltage. If using e.g. Mauch power modules the value from the datasheet can be applied straight here. A value of -1 means to use the board default.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -233,7 +227,7 @@ velocity</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_A_PER_V">BAT_A_PER_V</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Battery current per volt (A/V)</p><p><strong>Comment:</strong> The voltage seen by the 3.3V ADC multiplied by this factor will determine the battery current. A value of -1 means to use the board default.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Battery current per volt (A/V)</p><p><strong>Comment:</strong> The voltage seen by the 3.3V ADC multiplied by this factor will determine the battery current. A value of -1 means to use the board default.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -246,7 +240,7 @@ velocity</p>    </td>
 
 <li><strong>1:</strong> External</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -255,7 +249,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_EMPTY">BAT_V_EMPTY</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Empty cell voltage (5C load)</p><p><strong>Comment:</strong> Defines the voltage where a single cell of the battery is considered empty. The voltage should be chosen before the steep dropoff to 2.8V. A typical lithium battery can only be discharged down to 10% before it drops off to a voltage level damaging the cells.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">(0.01)</td>
  <td style="vertical-align: top;">3.4 </td>
@@ -264,7 +258,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_CHARGED">BAT_V_CHARGED</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Full cell voltage (5C load)</p><p><strong>Comment:</strong> Defines the voltage where a single cell of the battery is considered full under a mild load. This will never be the nominal voltage of 4.2V</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">(0.01)</td>
  <td style="vertical-align: top;">4.05 </td>
@@ -273,7 +267,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_LOW_THR">BAT_LOW_THR</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Low threshold</p><p><strong>Comment:</strong> Sets the threshold when the battery will be reported as low. This has to be higher than the critical threshold.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0.12 > 0.4 (0.01)</td>
  <td style="vertical-align: top;">0.15 </td>
@@ -282,7 +276,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_CRIT_THR">BAT_CRIT_THR</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Critical threshold</p><p><strong>Comment:</strong> Sets the threshold when the battery will be reported as critically low. This has to be lower than the low threshold. This threshold commonly will trigger RTL.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0.05 > 0.1 (0.01)</td>
  <td style="vertical-align: top;">0.07 </td>
@@ -291,7 +285,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_EMERGEN_THR">BAT_EMERGEN_THR</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Emergency threshold</p><p><strong>Comment:</strong> Sets the threshold when the battery will be reported as dangerously low. This has to be lower than the critical threshold. This threshold commonly will trigger landing.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0.03 > 0.07 (0.01)</td>
  <td style="vertical-align: top;">0.05 </td>
@@ -300,7 +294,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_V_LOAD_DROP">BAT_V_LOAD_DROP</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Voltage drop per cell on full throttle</p><p><strong>Comment:</strong> This implicitely defines the internal resistance to maximum current ratio and assumes linearity. A good value to use is the difference between the 5C and 20-25C load. Not used if BAT_R_INTERNAL is set.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0.07 > 0.5 (0.01)</td>
  <td style="vertical-align: top;">0.3 </td>
@@ -309,7 +303,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_R_INTERNAL">BAT_R_INTERNAL</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Explicitly defines the per cell internal resistance</p><p><strong>Comment:</strong> If non-negative, then this will be used in place of BAT_V_LOAD_DROP for all calculations.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 0.2 </td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -351,7 +345,7 @@ velocity</p>    </td>
 <li><strong>16:</strong> 16S Battery</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -360,7 +354,7 @@ velocity</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="BAT_CAPACITY">BAT_CAPACITY</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Battery capacity</p><p><strong>Comment:</strong> Defines the capacity of the attached battery.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 100000 (50)</td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -368,10 +362,35 @@ velocity</p>    </td>
 </tr>
 </tbody></table>
 
+## Camera Control
+
+
+The module where these parameters are defined is: *modules/camera_feedback*.
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAM_FBACK_MODE">CAM_FBACK_MODE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Camera feedback mode</p><p><strong>Comment:</strong> Sets the camera feedback mode.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> Feedback on trigger</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+</tbody></table>
+
 ## Camera trigger
 
 
-The module where these parameters are defined is: *src/drivers/camera_trigger*.
+The module where these parameters are defined is: *drivers/camera_trigger*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -384,14 +403,16 @@ The module where these parameters are defined is: *src/drivers/camera_trigger*.
  <td style="vertical-align: top;"><p>Camera trigger Interface</p><p><strong>Comment:</strong> Selects the trigger interface</p> <strong>Values:</strong><ul>
 <li><strong>1:</strong> GPIO</li> 
 
-<li><strong>2:</strong> Seagull MAP2 (PWM)</li> 
+<li><strong>2:</strong> Seagull MAP2 (over PWM)</li> 
 
 <li><strong>3:</strong> MAVLink (forward via MAV_CMD_IMAGE_START_CAPTURE)</li> 
+
+<li><strong>4:</strong> Generic PWM (IR trigger, servo)</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
  </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">2 </td>
+ <td style="vertical-align: top;">4 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -417,7 +438,7 @@ The module where these parameters are defined is: *src/drivers/camera_trigger*.
  <td style="vertical-align: top;"><strong id="TRIG_ACT_TIME">TRIG_ACT_TIME</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Camera trigger activation time</p><p><strong>Comment:</strong> This parameter sets the time the trigger needs to pulled high or low.</p>    </td>
  <td style="vertical-align: top;">0.1 > 3000 </td>
- <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;">40.0 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
@@ -425,13 +446,13 @@ The module where these parameters are defined is: *src/drivers/camera_trigger*.
  <td style="vertical-align: top;"><p>Camera trigger mode</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Disable</li> 
 
-<li><strong>1:</strong> On individual commands</li> 
+<li><strong>1:</strong> Time based, on command</li> 
 
 <li><strong>2:</strong> Time based, always on</li> 
 
 <li><strong>3:</strong> Distance based, always on</li> 
 
-<li><strong>4:</strong> Distance, mission controlled</li> 
+<li><strong>4:</strong> Distance based, on command (Survey mode)</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
  </td>
@@ -459,7 +480,7 @@ The module where these parameters are defined is: *src/drivers/camera_trigger*.
 ## Circuit Breaker
 
 
-The module where these parameters are defined is: *src/modules/systemlib*.
+The module where these parameters are defined is: *modules/systemlib*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -539,12 +560,20 @@ The module where these parameters are defined is: *src/modules/systemlib*.
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CBRK_VELPOSERR">CBRK_VELPOSERR</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Circuit breaker for position error check</p><p><strong>Comment:</strong> Setting this parameter to 201607 will disable the position and velocity accuracy checks in the commander. WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 201607 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
 </tbody></table>
 
 ## Commander
 
 
-The module where these parameters are defined is: *src/modules/commander*.
+The module where these parameters are defined is: *modules/commander*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -595,6 +624,13 @@ The module where these parameters are defined is: *src/modules/commander*.
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="COM_RC_STICK_OV">COM_RC_STICK_OV</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>RC stick override threshold</p><p><strong>Comment:</strong> If an RC stick is moved more than by this amount the system will interpret this as override request by the pilot.</p>    </td>
+ <td style="vertical-align: top;">5 > 40 (0.05)</td>
+ <td style="vertical-align: top;">12.0 </td>
+ <td style="vertical-align: top;">%</td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="COM_HOME_H_T">COM_HOME_H_T</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Home set horizontal threshold</p><p><strong>Comment:</strong> The home position will be set if the estimated positioning accuracy is below the threshold.</p>    </td>
  <td style="vertical-align: top;">2 > 15 (0.5)</td>
@@ -607,13 +643,6 @@ The module where these parameters are defined is: *src/modules/commander*.
  <td style="vertical-align: top;">5 > 25 (0.5)</td>
  <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;">m</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_AUTOS_PAR">COM_AUTOS_PAR</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Autosaving of params</p><p><strong>Comment:</strong> If not equal to zero the commander will automatically save parameters to persistent storage once changed. Default is on, as the interoperability with currently deployed GCS solutions depends on parameters being sticky. Developers can default it to off.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1 </td>
- <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_RC_IN_MODE">COM_RC_IN_MODE</strong> (INT32)</td>
@@ -645,13 +674,8 @@ The module where these parameters are defined is: *src/modules/commander*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_ARM_WO_GPS">COM_ARM_WO_GPS</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Allow arming without GPS</p><p><strong>Comment:</strong> The default allows to arm the vehicle without GPS signal.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Don't allow arming without GPS</li> 
-
-<li><strong>1:</strong> Allow arming without GPS</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;"><p>Allow arming without GPS</p><p><strong>Comment:</strong> The default allows to arm the vehicle without GPS signal.</p>    </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
@@ -690,6 +714,222 @@ See COM_OBL_ACT and COM_OBL_RC_ACT to configure action</p>    </td>
  <td style="vertical-align: top;">0 > 60 (1)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">second</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE1">COM_FLTMODE1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>First flightmode slot (1000-1160)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE2">COM_FLTMODE2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Second flightmode slot (1160-1320)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE3">COM_FLTMODE3</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Third flightmode slot (1320-1480)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE4">COM_FLTMODE4</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Fourth flightmode slot (1480-1640)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE5">COM_FLTMODE5</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Fifth flightmode slot (1640-1800)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLTMODE6">COM_FLTMODE6</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Sixth flightmode slot (1800-2000)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Unassigned</li> 
+
+<li><strong>0:</strong> Manual</li> 
+
+<li><strong>1:</strong> Altitude</li> 
+
+<li><strong>2:</strong> Position</li> 
+
+<li><strong>3:</strong> Mission</li> 
+
+<li><strong>4:</strong> Hold</li> 
+
+<li><strong>5:</strong> Return</li> 
+
+<li><strong>6:</strong> Acro</li> 
+
+<li><strong>7:</strong> Offboard</li> 
+
+<li><strong>8:</strong> Stabilized</li> 
+
+<li><strong>9:</strong> Rattitude</li> 
+
+<li><strong>10:</strong> Takeoff</li> 
+
+<li><strong>11:</strong> Land</li> 
+
+<li><strong>12:</strong> Follow Me</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_ARM_EKF_POS">COM_ARM_EKF_POS</strong> (FLOAT)</td>
@@ -743,16 +983,81 @@ See COM_OBL_ACT and COM_OBL_RC_ACT to configure action</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="COM_ARM_IMU_GYR">COM_ARM_IMU_GYR</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Maximum rate gyro inconsistency between IMU units that will allow arming</p>    </td>
- <td style="vertical-align: top;">0.02 > 0.2 (0.01)</td>
- <td style="vertical-align: top;">0.15 </td>
+ <td style="vertical-align: top;">0.02 > 0.3 (0.01)</td>
+ <td style="vertical-align: top;">0.25 </td>
  <td style="vertical-align: top;">rad/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_ARM_MAG">COM_ARM_MAG</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum magnetic field inconsistency between units that will allow arming</p>    </td>
+ <td style="vertical-align: top;">0.05 > 0.5 (0.05)</td>
+ <td style="vertical-align: top;">0.15 </td>
+ <td style="vertical-align: top;">Gauss</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_RC_OVERRIDE">COM_RC_OVERRIDE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Enable RC stick override of auto modes</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_ARM_MIS_REQ">COM_ARM_MIS_REQ</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Require valid mission to arm</p><p><strong>Comment:</strong> The default allows to arm the vehicle without a valid mission.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_ARM_AUTH">COM_ARM_AUTH</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Arm authorization parameters, this uint32_t will be splitted between starting from the LSB:
+- 8bits to authorizer system id
+- 16bits to authentication method parameter, this will be used to store a timeout for the first 2 methods but can be used to another parameter for other new authentication methods.
+- 7bits to authentication method
+- one arm = 0
+- two step arm = 1
+* the MSB bit is not used to avoid problems in the conversion between int and uint</p><p><strong>Comment:</strong> Default value: (10 << 0 | 1000 << 8 | 0 << 24) = 256010 - authorizer system id = 10 - authentication method parameter = 10000msec of timeout - authentication method = during arm</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">256010 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_POS_FS_DELAY">COM_POS_FS_DELAY</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Loss of position failsafe activation delay</p><p><strong>Comment:</strong> This sets number of seconds that the position checks need to be failed before the failsafe will activate. The default value has been optimised for rotary wing applications. For fixed wing applications, a larger value between 5 and 10 should be used.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;">sec</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_POS_FS_PROB">COM_POS_FS_PROB</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Loss of position probation delay at takeoff</p><p><strong>Comment:</strong> The probation delay is the number of seconds that the EKF innovation checks need to pass for the position to be declared good after it has been declared bad. The probation delay will be reset to this parameter value when takeoff is detected. After takeoff, if position checks are passing, the probation delay will reduce by one second for every lapsed second of valid position down to a minimum of 1 second. If position checks are failing, the probation delay will increase by COM_POS_FS_GAIN seconds for every lapsed second up to a maximum of 100 seconds. The default value has been optimised for rotary wing applications. For fixed wing applications, a value of 1 should be used.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">30 </td>
+ <td style="vertical-align: top;">sec</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_POS_FS_GAIN">COM_POS_FS_GAIN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Loss of position probation gain factor</p><p><strong>Comment:</strong> This sets the rate that the loss of position probation time grows when position checks are failing. The default value has been optimised for rotary wing applications. For fixed wing applications a value of 0 should be used.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">10 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_FLIGHT_UUID">COM_FLIGHT_UUID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Next flight UUID</p><p><strong>Comment:</strong> This number is incremented automatically after every flight on disarming in order to remember the next flight UUID. The first flight is 0.</p>    </td>
+ <td style="vertical-align: top;">0 > ? </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
 
 ## Data Link Loss
 
 
-The module where these parameters are defined is: *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -760,6 +1065,27 @@ The module where these parameters are defined is: *src/modules/navigator*.
    <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
  </thead>
 <tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_AH_LAT">NAV_AH_LAT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Airfield home Lat</p><p><strong>Comment:</strong> Latitude of airfield home waypoint</p>    </td>
+ <td style="vertical-align: top;">-900000000 > 900000000 </td>
+ <td style="vertical-align: top;">-265847810 </td>
+ <td style="vertical-align: top;">deg * 1e7</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_AH_LON">NAV_AH_LON</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Airfield home Lon</p><p><strong>Comment:</strong> Longitude of airfield home waypoint</p>    </td>
+ <td style="vertical-align: top;">-1800000000 > 1800000000 </td>
+ <td style="vertical-align: top;">1518423250 </td>
+ <td style="vertical-align: top;">deg * 1e7</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_AH_ALT">NAV_AH_ALT</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Airfield home alt</p><p><strong>Comment:</strong> Altitude of airfield home waypoint</p>    </td>
+ <td style="vertical-align: top;">-50 > ? (0.5)</td>
+ <td style="vertical-align: top;">600.0 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_DLL_CH_T">NAV_DLL_CH_T</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Comms hold wait time</p><p><strong>Comment:</strong> The amount of time in seconds the system should wait at the comms hold waypoint</p>    </td>
@@ -809,33 +1135,12 @@ The module where these parameters are defined is: *src/modules/navigator*.
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_AH_LAT">NAV_AH_LAT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Airfield home Lat</p><p><strong>Comment:</strong> Latitude of airfield home waypoint</p>    </td>
- <td style="vertical-align: top;">-900000000 > 900000000 </td>
- <td style="vertical-align: top;">-265847810 </td>
- <td style="vertical-align: top;">deg * 1e7</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_AH_LON">NAV_AH_LON</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Airfield home Lon</p><p><strong>Comment:</strong> Longitude of airfield home waypoint</p>    </td>
- <td style="vertical-align: top;">-1800000000 > 1800000000 </td>
- <td style="vertical-align: top;">1518423250 </td>
- <td style="vertical-align: top;">deg * 1e7</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="NAV_AH_ALT">NAV_AH_ALT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Airfield home alt</p><p><strong>Comment:</strong> Altitude of airfield home waypoint</p>    </td>
- <td style="vertical-align: top;">-50 > ? (0.5)</td>
- <td style="vertical-align: top;">600.0 </td>
- <td style="vertical-align: top;">m</td>
-</tr>
 </tbody></table>
 
 ## EKF2
 
 
-The module where these parameters are defined is: *src/modules/ekf2*.
+The module where these parameters are defined is: *modules/ekf2*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -846,57 +1151,65 @@ The module where these parameters are defined is: *src/modules/ekf2*.
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_MIN_OBS_DT">EKF2_MIN_OBS_DT</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Minimum time of arrival delta between non-IMU observations before data is downsampled.
-Baro and Magnetometer data will be averaged before downsampling, other data will be point sampled resulting in loss of information</p>    </td>
+Baro and Magnetometer data will be averaged before downsampling, other data will be point sampled resulting in loss of information</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">10 > 50 </td>
  <td style="vertical-align: top;">20 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_MAG_DELAY">EKF2_MAG_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Magnetometer measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Magnetometer measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_BARO_DELAY">EKF2_BARO_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Barometer measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Barometer measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_GPS_DELAY">EKF2_GPS_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>GPS measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>GPS measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
- <td style="vertical-align: top;">200 </td>
+ <td style="vertical-align: top;">110 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_OF_DELAY">EKF2_OF_DELAY</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Optical flow measurement delay relative to IMU measurements
-Assumes measurement is timestamped at trailing edge of integration period</p>    </td>
+Assumes measurement is timestamped at trailing edge of integration period</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">5 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_RNG_DELAY">EKF2_RNG_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Range finder measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Range finder measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">5 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_ASP_DELAY">EKF2_ASP_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Airspeed measurement delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Airspeed measurement delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
- <td style="vertical-align: top;">200 </td>
+ <td style="vertical-align: top;">100 </td>
  <td style="vertical-align: top;">ms</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_EV_DELAY">EKF2_EV_DELAY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Vision Position Estimator delay relative to IMU measurements</p>    </td>
+ <td style="vertical-align: top;"><p>Vision Position Estimator delay relative to IMU measurements</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 300 </td>
  <td style="vertical-align: top;">175 </td>
  <td style="vertical-align: top;">ms</td>
@@ -1099,14 +1412,15 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
   <li><strong>1:</strong> save EKF2_MAG_DECL on disarm</li> 
   <li><strong>2:</strong> use declination as an observation</li> 
 </ul>
-  </td>
+ <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0 > 7 </td>
  <td style="vertical-align: top;">7 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_MAG_TYPE">EKF2_MAG_TYPE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Type of magnetometer fusion</p><p><strong>Comment:</strong> Integer controlling the type of magnetometer fusion used - magnetic heading or 3-axis magnetometer. If set to automatic: heading fusion on-ground and 3-axis fusion in-flight</p> <strong>Values:</strong><ul>
+ <td style="vertical-align: top;"><p>Type of magnetometer fusion</p><p><strong>Comment:</strong> Integer controlling the type of magnetometer fusion used - magnetic heading or 3-axis magnetometer. If set to automatic: heading fusion on-ground and 3-axis fusion in-flight with fallback to heading fusion if there is insufficient motion to make yaw or mag biases observable.</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Automatic</li> 
 
 <li><strong>1:</strong> Magnetic heading</li> 
@@ -1115,10 +1429,27 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
 
 <li><strong>3:</strong> None</li> 
 </ul>
-   </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAG_ACCLIM">EKF2_MAG_ACCLIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Horizontal acceleration threshold used by automatic selection of magnetometer fusion method.
+This parameter is used when the magnetometer fusion method is set automatically (EKF2_MAG_TYPE = 0). If the filtered horizontal acceleration is greater than this parameter value, then the EKF will use 3-axis magnetomer fusion</p>    </td>
+ <td style="vertical-align: top;">0.0 > 5.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;">m/s**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAG_YAWLIM">EKF2_MAG_YAWLIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw rate threshold used by automatic selection of magnetometer fusion method.
+This parameter is used when the magnetometer fusion method is set automatically (EKF2_MAG_TYPE = 0). If the filtered yaw rate is greater than this parameter value, then the EKF will use 3-axis magnetomer fusion</p>    </td>
+ <td style="vertical-align: top;">0.0 > 0.5 </td>
+ <td style="vertical-align: top;">0.25 </td>
+ <td style="vertical-align: top;">rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_BARO_GATE">EKF2_BARO_GATE</strong> (FLOAT)</td>
@@ -1149,22 +1480,17 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
  <td style="vertical-align: top;">SD</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="EKF2_REC_RPL">EKF2_REC_RPL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Replay mode</p><p><strong>Comment:</strong> A value of 1 indicates that the ekf2 module will publish replay messages for logging.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="EKF2_AID_MASK">EKF2_AID_MASK</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Integer bitmask controlling data fusion and aiding methods</p><p><strong>Comment:</strong> Set bits in the following positions to enable: 0 : Set to true to use GPS data if available 1 : Set to true to use optical flow data if available 2 : Set to true to inhibit IMU bias estimation 3 : Set to true to enable vision position fusion 4 : Set to true to enable vision yaw fusion</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> use GPS</li> 
+ <td style="vertical-align: top;"><p>Integer bitmask controlling data fusion and aiding methods</p><p><strong>Comment:</strong> Set bits in the following positions to enable: 0 : Set to true to use GPS data if available 1 : Set to true to use optical flow data if available 2 : Set to true to inhibit IMU bias estimation 3 : Set to true to enable vision position fusion 4 : Set to true to enable vision yaw fusion 5 : Set to true to enable multi-rotor drag specific force fusion</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> use GPS</li> 
   <li><strong>1:</strong> use optical flow</li> 
   <li><strong>2:</strong> inhibit IMU bias estimation</li> 
   <li><strong>3:</strong> vision position fusion</li> 
   <li><strong>4:</strong> vision yaw fusion</li> 
+  <li><strong>5:</strong> multi-rotor drag fusion</li> 
 </ul>
-  </td>
- <td style="vertical-align: top;">0 > 28 </td>
+ <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 63 </td>
  <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
@@ -1179,7 +1505,8 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
 
 <li><strong>3:</strong> Vision</li> 
 </ul>
-   </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
@@ -1190,6 +1517,13 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
  <td style="vertical-align: top;">0.01 > ? </td>
  <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_SFE">EKF2_RNG_SFE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Range finder range dependant noise scaler</p><p><strong>Comment:</strong> Specifies the increase in range finder noise with range.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 0.2 </td>
+ <td style="vertical-align: top;">0.05 </td>
+ <td style="vertical-align: top;">m/m</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_RNG_GATE">EKF2_RNG_GATE</strong> (FLOAT)</td>
@@ -1225,13 +1559,6 @@ Assumes measurement is timestamped at trailing edge of integration period</p>   
  <td style="vertical-align: top;">1.0 > ? </td>
  <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;">SD</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="EKF2_MIN_EV">EKF2_MIN_EV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum valid range for the vision estimate</p>    </td>
- <td style="vertical-align: top;">0.01 > ? </td>
- <td style="vertical-align: top;">0.01 </td>
- <td style="vertical-align: top;">m</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_OF_N_MIN">EKF2_OF_N_MIN</strong> (FLOAT)</td>
@@ -1418,21 +1745,24 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_GBIAS_INIT">EKF2_GBIAS_INIT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>1-sigma IMU gyro switch-on bias</p>    </td>
+ <td style="vertical-align: top;"><p>1-sigma IMU gyro switch-on bias</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0.0 > 0.2 </td>
  <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;">rad/sec</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_ABIAS_INIT">EKF2_ABIAS_INIT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>1-sigma IMU accelerometer switch-on bias</p>    </td>
+ <td style="vertical-align: top;"><p>1-sigma IMU accelerometer switch-on bias</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0.0 > 0.5 </td>
  <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;">m/s/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="EKF2_ANGERR_INIT">EKF2_ANGERR_INIT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>1-sigma tilt angle uncertainty after gravity vector alignment</p>    </td>
+ <td style="vertical-align: top;"><p>1-sigma tilt angle uncertainty after gravity vector alignment</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">0.0 > 0.5 </td>
  <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;">rad</td>
@@ -1444,12 +1774,194 @@ value will determine the minimum airspeed which will still be fused</p>    </td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">rad</td>
 </tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGBIAS_X">EKF2_MAGBIAS_X</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Learned value of magnetometer X axis bias.
+This is the amount of X-axis magnetometer bias learned by the EKF and saved from the last flight. It must be set to zero if the ground based magnetometer calibration is repeated</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">mGauss</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGBIAS_Y">EKF2_MAGBIAS_Y</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Learned value of magnetometer Y axis bias.
+This is the amount of Y-axis magnetometer bias learned by the EKF and saved from the last flight. It must be set to zero if the ground based magnetometer calibration is repeated</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">mGauss</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGBIAS_Z">EKF2_MAGBIAS_Z</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Learned value of magnetometer Z axis bias.
+This is the amount of Z-axis magnetometer bias learned by the EKF and saved from the last flight. It must be set to zero if the ground based magnetometer calibration is repeated</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">mGauss</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGBIAS_ID">EKF2_MAGBIAS_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of Magnetometer the learned bias is for</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGB_VREF">EKF2_MAGB_VREF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>State variance assumed for magnetometer bias storage.
+This is a reference variance used to calculate the fraction of learned magnetometer bias that will be used to update the stored value. Smaller values will make the stored bias data adjust more slowly from flight to flight. Larger values will make it adjust faster</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">2.5E-7 </td>
+ <td style="vertical-align: top;">mGauss**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_MAGB_K">EKF2_MAGB_K</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum fraction of learned mag bias saved at each disarm.
+Smaller values make the saved mag bias learn slower from flight to flight. Larger values make it learn faster. Must be > 0.0 and <= 1.0</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.2 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_AID">EKF2_RNG_AID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Range sensor aid</p><p><strong>Comment:</strong> If this parameter is enabled then the estimator will make use of the range finder measurements to estimate it's height even if range sensor is not the primary height source. It will only do so if conditions for range measurement fusion are met.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Range aid disabled</li> 
+
+<li><strong>1:</strong> Range aid enabled</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_A_VMAX">EKF2_RNG_A_VMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity allowed for range aid mode</p><p><strong>Comment:</strong> If the vehicle horizontal speed exceeds this value then the estimator will not fuse range measurements to estimate it's height. This only applies when range aid mode is activated (EKF2_RNG_AID = enabled).</p>    </td>
+ <td style="vertical-align: top;">0.1 > 2 </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_A_HMAX">EKF2_RNG_A_HMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum absolute altitude (height above ground level) allowed for range aid mode</p><p><strong>Comment:</strong> If the vehicle absolute altitude exceeds this value then the estimator will not fuse range measurements to estimate it's height. This only applies when range aid mode is activated (EKF2_RNG_AID = enabled).</p>    </td>
+ <td style="vertical-align: top;">1.0 > 10.0 </td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_RNG_A_IGATE">EKF2_RNG_A_IGATE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gate size used for innovation consistency checks for range aid fusion</p><p><strong>Comment:</strong> A lower value means HAGL needs to be more stable in order to use range finder for height estimation in range aid mode</p>    </td>
+ <td style="vertical-align: top;">0.1 > 5.0 </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">SD</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_DRAG_NOISE">EKF2_DRAG_NOISE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Specific drag force observation noise variance used by the multi-rotor specific drag force model.
+Increasing it makes the multi-rotor wind estimates adjust more slowly</p>    </td>
+ <td style="vertical-align: top;">0.5 > 10.0 </td>
+ <td style="vertical-align: top;">2.5 </td>
+ <td style="vertical-align: top;">(m/sec**2)**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_BCOEF_X">EKF2_BCOEF_X</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>X-axis ballistic coefficient used by the multi-rotor specific drag force model.
+This should be adjusted to minimise variance of the X-axis drag specific force innovation sequence</p>    </td>
+ <td style="vertical-align: top;">1.0 > 100.0 </td>
+ <td style="vertical-align: top;">25.0 </td>
+ <td style="vertical-align: top;">kg/m**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_BCOEF_Y">EKF2_BCOEF_Y</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Y-axis ballistic coefficient used by the multi-rotor specific drag force model.
+This should be adjusted to minimise variance of the Y-axis drag specific force innovation sequence</p>    </td>
+ <td style="vertical-align: top;">1.0 > 100.0 </td>
+ <td style="vertical-align: top;">25.0 </td>
+ <td style="vertical-align: top;">kg/m**2</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ASPD_MAX">EKF2_ASPD_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Upper limit on airspeed along individual axes used to correct baro for position error effects</p>    </td>
+ <td style="vertical-align: top;">5.0 > 50.0 </td>
+ <td style="vertical-align: top;">20.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_PCOEF_XP">EKF2_PCOEF_XP</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Static pressure position error coefficient for the positive X axis
+This is the ratio of static pressure error to dynamic pressure generated by a positive wind relative velocity along the X body axis.
+If the baro height estimate rises during forward flight, then this will be a negative number</p>    </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_PCOEF_XN">EKF2_PCOEF_XN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Static pressure position error coefficient for the negative X axis.
+This is the ratio of static pressure error to dynamic pressure generated by a negative wind relative velocity along the X body axis.
+If the baro height estimate rises during backwards flight, then this will be a negative number</p>    </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_PCOEF_Y">EKF2_PCOEF_Y</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pressure position error coefficient for the Y axis.
+This is the ratio of static pressure error to dynamic pressure generated by a wind relative velocity along the Y body axis.
+If the baro height estimate rises during sideways flight, then this will be a negative number</p>    </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_PCOEF_Z">EKF2_PCOEF_Z</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Static pressure position error coefficient for the Z axis.
+This is the ratio of static pressure error to dynamic pressure generated by a wind relative velocity along the Z body axis</p>    </td>
+ <td style="vertical-align: top;">-0.5 > 0.5 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ABL_LIM">EKF2_ABL_LIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer bias learning limit. The ekf delta velocity bias states will be limited to within a range equivalent to +- of this value</p>    </td>
+ <td style="vertical-align: top;">0.0 > 0.8 </td>
+ <td style="vertical-align: top;">0.4 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ABL_ACCLIM">EKF2_ABL_ACCLIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum IMU accel magnitude that allows IMU bias learning.
+If the magnitude of the IMU accelerometer vector exceeds this value, the EKF delta velocity state estimation will be inhibited.
+This reduces the adverse effect of high manoeuvre accelerations and IMU nonlinerity and scale factor errors on the delta velocity bias estimates</p>    </td>
+ <td style="vertical-align: top;">20.0 > 200.0 </td>
+ <td style="vertical-align: top;">25.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ABL_GYRLIM">EKF2_ABL_GYRLIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum IMU gyro angular rate magnitude that allows IMU bias learning.
+If the magnitude of the IMU angular rate vector exceeds this value, the EKF delta velocity state estimation will be inhibited.
+This reduces the adverse effect of rapid rotation rates and associated errors on the delta velocity bias estimates</p>    </td>
+ <td style="vertical-align: top;">2.0 > 20.0 </td>
+ <td style="vertical-align: top;">3.0 </td>
+ <td style="vertical-align: top;">rad/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="EKF2_ABL_TAU">EKF2_ABL_TAU</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Time constant used by acceleration and angular rate magnitude checks used to inhibit delta velocity bias learning.
+The vector magnitude of angular rate and acceleration used to check if learning should be inhibited has a peak hold filter applied to it with an exponential decay.
+This parameter controls the time constant of the decay</p>    </td>
+ <td style="vertical-align: top;">0.1 > 1.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;">s</td>
+</tr>
 </tbody></table>
 
 ## FW Attitude Control
-
-
-The module where these parameters are defined is: *src/modules/fw_att_control*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -1459,182 +1971,208 @@ The module where these parameters are defined is: *src/modules/fw_att_control*.
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_R_TC">FW_R_TC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Attitude Roll Time Constant</p><p><strong>Comment:</strong> This defines the latency between a roll step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    </td>
+ <td style="vertical-align: top;"><p>Attitude Roll Time Constant</p><p><strong>Comment:</strong> This defines the latency between a roll step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.4 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.4 </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_P_TC">FW_P_TC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Attitude Pitch Time Constant</p><p><strong>Comment:</strong> This defines the latency between a pitch step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    </td>
+ <td style="vertical-align: top;"><p>Attitude pitch time constant</p><p><strong>Comment:</strong> This defines the latency between a pitch step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.2 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.4 </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PR_P">FW_PR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate proportional gain</p><p><strong>Comment:</strong> This defines how much the elevator input will be commanded depending on the current body angular rate error.</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch rate proportional gain</p><p><strong>Comment:</strong> This defines how much the elevator input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
  <td style="vertical-align: top;">0.08 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PR_I">FW_PR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 0.5 (0.005)</td>
  <td style="vertical-align: top;">0.02 </td>
  <td style="vertical-align: top;">%/rad</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_P_RMAX_POS">FW_P_RMAX_POS</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum positive / up pitch rate</p><p><strong>Comment:</strong> This limits the maximum pitch up angular rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum positive / up pitch rate</p><p><strong>Comment:</strong> This limits the maximum pitch up angular rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">60.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_P_RMAX_NEG">FW_P_RMAX_NEG</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum negative / down pitch rate</p><p><strong>Comment:</strong> This limits the maximum pitch down up angular rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum negative / down pitch rate</p><p><strong>Comment:</strong> This limits the maximum pitch down up angular rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">60.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PR_IMAX">FW_PR_IMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.4 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RR_P">FW_RR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate proportional Gain</p><p><strong>Comment:</strong> This defines how much the aileron input will be commanded depending on the current body angular rate error.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll rate proportional Gain</p><p><strong>Comment:</strong> This defines how much the aileron input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
  <td style="vertical-align: top;">0.05 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RR_I">FW_RR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate integrator Gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll rate integrator Gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 0.2 (0.005)</td>
  <td style="vertical-align: top;">0.01 </td>
  <td style="vertical-align: top;">%/rad</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RR_IMAX">FW_RR_IMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll Integrator Anti-Windup</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll integrator anti-windup</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_R_RMAX">FW_R_RMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum Roll Rate</p><p><strong>Comment:</strong> This limits the maximum roll rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum roll rate</p><p><strong>Comment:</strong> This limits the maximum roll rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">70.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YR_P">FW_YR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate proportional gain</p><p><strong>Comment:</strong> This defines how much the rudder input will be commanded depending on the current body angular rate error.</p>    </td>
+ <td style="vertical-align: top;"><p>Yaw rate proportional gain</p><p><strong>Comment:</strong> This defines how much the rudder input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
  <td style="vertical-align: top;">0.05 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YR_I">FW_YR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    </td>
+ <td style="vertical-align: top;"><p>Yaw rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 50.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">%/rad</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YR_IMAX">FW_YR_IMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    </td>
+ <td style="vertical-align: top;"><p>Yaw rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_Y_RMAX">FW_Y_RMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum Yaw Rate</p><p><strong>Comment:</strong> This limits the maximum yaw rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum yaw rate</p><p><strong>Comment:</strong> This limits the maximum yaw rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RLL_TO_YAW_FF">FW_RLL_TO_YAW_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll control to yaw control feedforward gain</p><p><strong>Comment:</strong> This gain can be used to counteract the "adverse yaw" effect for fixed wings. When the plane enters a roll it will tend to yaw the nose out of the turn. This gain enables the use of a yaw actuator (rudder, airbrakes, ...) to counteract this effect.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll control to yaw control feedforward gain</p><p><strong>Comment:</strong> This gain can be used to counteract the "adverse yaw" effect for fixed wings. When the plane enters a roll it will tend to yaw the nose out of the turn. This gain enables the use of a yaw actuator (rudder, airbrakes, ...) to counteract this effect.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_W_EN">FW_W_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable wheel steering controller</p>    </td>
+ <td style="vertical-align: top;"><p>Enable wheel steering controller</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_WR_P">FW_WR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Wheel steering rate proportional gain</p><p><strong>Comment:</strong> This defines how much the wheel steering input will be commanded depending on the current body angular rate error.</p>    </td>
+ <td style="vertical-align: top;"><p>Wheel steering rate proportional gain</p><p><strong>Comment:</strong> This defines how much the wheel steering input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
  <td style="vertical-align: top;">0.5 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_WR_I">FW_WR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Wheel steering rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    </td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.005 > 0.5 (0.005)</td>
  <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;">%/rad</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_WR_IMAX">FW_WR_IMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Wheel steering rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    </td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_W_RMAX">FW_W_RMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum wheel steering rate</p><p><strong>Comment:</strong> This limits the maximum wheel steering rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    </td>
+ <td style="vertical-align: top;"><p>Maximum wheel steering rate</p><p><strong>Comment:</strong> This limits the maximum wheel steering rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RR_FF">FW_RR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output. Use this to obtain a tigher response of the controller without introducing noise amplification.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output. Use this to obtain a tigher response of the controller without introducing noise amplification.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
  <td style="vertical-align: top;">0.5 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PR_FF">FW_PR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
  <td style="vertical-align: top;">0.5 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YR_FF">FW_YR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    </td>
+ <td style="vertical-align: top;"><p>Yaw rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
  <td style="vertical-align: top;">0.3 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_WR_FF">FW_WR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Wheel steering rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    </td>
+ <td style="vertical-align: top;"><p>Wheel steering rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
  <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;">%/rad/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_YCO_VMIN">FW_YCO_VMIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal speed for yaw coordination</p><p><strong>Comment:</strong> For airspeeds above this value, the yaw rate is calculated for a coordinated turn. Set to a very high value to disable.</p>    </td>
+ <td style="vertical-align: top;"><p>Minimal speed for yaw coordination</p><p><strong>Comment:</strong> For airspeeds above this value, the yaw rate is calculated for a coordinated turn. Set to a very high value to disable.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1000.0 (0.5)</td>
  <td style="vertical-align: top;">1000.0 </td>
  <td style="vertical-align: top;">m/s</td>
@@ -1646,129 +2184,146 @@ The module where these parameters are defined is: *src/modules/fw_att_control*.
 
 <li><strong>1:</strong> closed-loop</li> 
 </ul>
-   </td>
+   <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RSP_OFF">FW_RSP_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll Setpoint Offset</p><p><strong>Comment:</strong> An airframe specific offset of the roll setpoint in degrees, the value is added to the roll setpoint and should correspond to the typical cruise speed of the airframe.</p>    </td>
+ <td style="vertical-align: top;"><p>Roll setpoint offset</p><p><strong>Comment:</strong> An airframe specific offset of the roll setpoint in degrees, the value is added to the roll setpoint and should correspond to the typical cruise speed of the airframe.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">-90.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_PSP_OFF">FW_PSP_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch Setpoint Offset</p><p><strong>Comment:</strong> An airframe specific offset of the pitch setpoint in degrees, the value is added to the pitch setpoint and should correspond to the typical cruise speed of the airframe.</p>    </td>
+ <td style="vertical-align: top;"><p>Pitch setpoint offset</p><p><strong>Comment:</strong> An airframe specific offset of the pitch setpoint in degrees, the value is added to the pitch setpoint and should correspond to the typical cruise speed of the airframe.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">-90.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_R_MAX">FW_MAN_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max Manual Roll</p><p><strong>Comment:</strong> Max roll for manual control in attitude stabilized mode</p>    </td>
+ <td style="vertical-align: top;"><p>Max manual roll</p><p><strong>Comment:</strong> Max roll for manual control in attitude stabilized mode</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">45.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_P_MAX">FW_MAN_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max Manual Pitch</p><p><strong>Comment:</strong> Max pitch for manual control in attitude stabilized mode</p>    </td>
+ <td style="vertical-align: top;"><p>Max manual pitch</p><p><strong>Comment:</strong> Max pitch for manual control in attitude stabilized mode</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
  <td style="vertical-align: top;">45.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_FLAPS_SCL">FW_FLAPS_SCL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Scale factor for flaps</p>    </td>
+ <td style="vertical-align: top;"><p>Scale factor for flaps</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_FLAPERON_SCL">FW_FLAPERON_SCL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Scale factor for flaperons</p>    </td>
+ <td style="vertical-align: top;"><p>Scale factor for flaperons</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_ARSP_MODE">FW_ARSP_MODE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Airspeed mode</p><p><strong>Comment:</strong> The param value sets the method used to publish the control state airspeed. For small wings or VTOL without airspeed sensor this parameter can be used to enable flying without an airspeed reading</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> use measured airspeed</li> 
-
-<li><strong>1:</strong> use vehicle ground velocity as airspeed</li> 
-
-<li><strong>2:</strong> declare airspeed invalid</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;">0 > 2 </td>
+ <td style="vertical-align: top;"><p>Disable airspeed sensor</p><p><strong>Comment:</strong> For small wings or VTOL without airspeed sensor this parameter can be used to enable flying without an airspeed reading</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_R_SC">FW_MAN_R_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual roll scale</p><p><strong>Comment:</strong> Scale factor applied to the desired roll actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    </td>
+ <td style="vertical-align: top;"><p>Manual roll scale</p><p><strong>Comment:</strong> Scale factor applied to the desired roll actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_P_SC">FW_MAN_P_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual pitch scale</p><p><strong>Comment:</strong> Scale factor applied to the desired pitch actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    </td>
+ <td style="vertical-align: top;"><p>Manual pitch scale</p><p><strong>Comment:</strong> Scale factor applied to the desired pitch actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_MAN_Y_SC">FW_MAN_Y_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual yaw scale</p><p><strong>Comment:</strong> Scale factor applied to the desired yaw actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    </td>
+ <td style="vertical-align: top;"><p>Manual yaw scale</p><p><strong>Comment:</strong> Scale factor applied to the desired yaw actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_BAT_SCALE_EN">FW_BAT_SCALE_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Whether to scale throttle by battery power level</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The fixed wing should constantly behave as if it was fully charged with reduced max thrust at lower battery percentages. i.e. if cruise speed is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    </td>
+ <td style="vertical-align: top;"><p>Whether to scale throttle by battery power level</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The fixed wing should constantly behave as if it was fully charged with reduced max thrust at lower battery percentages. i.e. if cruise speed is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_ACRO_X_MAX">FW_ACRO_X_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Acro body x max rate</p><p><strong>Comment:</strong> This is the rate the controller is trying to achieve if the user applies full roll stick input in acro mode.</p>    </td>
+ <td style="vertical-align: top;"><p>Acro body x max rate</p><p><strong>Comment:</strong> This is the rate the controller is trying to achieve if the user applies full roll stick input in acro mode.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">45 > 720 </td>
  <td style="vertical-align: top;">90 </td>
  <td style="vertical-align: top;">degrees</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_ACRO_Y_MAX">FW_ACRO_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Acro body y max rate</p><p><strong>Comment:</strong> This is the body y rate the controller is trying to achieve if the user applies full pitch stick input in acro mode.</p>    </td>
+ <td style="vertical-align: top;"><p>Acro body y max rate</p><p><strong>Comment:</strong> This is the body y rate the controller is trying to achieve if the user applies full pitch stick input in acro mode.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">45 > 720 </td>
  <td style="vertical-align: top;">90 </td>
  <td style="vertical-align: top;">degrees</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_ACRO_Z_MAX">FW_ACRO_Z_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Acro body z max rate</p><p><strong>Comment:</strong> This is the body z rate the controller is trying to achieve if the user applies full yaw stick input in acro mode.</p>    </td>
+ <td style="vertical-align: top;"><p>Acro body z max rate</p><p><strong>Comment:</strong> This is the body z rate the controller is trying to achieve if the user applies full yaw stick input in acro mode.</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">10 > 180 </td>
  <td style="vertical-align: top;">45 </td>
  <td style="vertical-align: top;">degrees</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_RATT_TH">FW_RATT_TH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Threshold for Rattitude mode</p><p><strong>Comment:</strong> Manual input needed in order to override attitude control rate setpoints and instead pass manual stick inputs as rate setpoints</p>    </td>
+ <td style="vertical-align: top;"><p>Threshold for Rattitude mode</p><p><strong>Comment:</strong> Manual input needed in order to override attitude control rate setpoints and instead pass manual stick inputs as rate setpoints</p>    <p><b>Module:</b> modules/fw_att_control</p>
+</td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.8 </td>
  <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_TC">GND_WR_TC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Attitude Wheel Time Constant</p><p><strong>Comment:</strong> This defines the latency between a steering step input and the achieved setpoint (inverse to a P gain). Half a second is a good start value and fits for most average systems. Smaller systems may require smaller values, but as this will wear out servos faster, the value should only be decreased as needed.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.4 > 1.0 (0.05)</td>
+ <td style="vertical-align: top;">0.4 </td>
+ <td style="vertical-align: top;">s</td>
 </tr>
 </tbody></table>
 
 ## FW L1 Control
 
 
-The module where these parameters are defined is: *src/modules/fw_pos_control_l1*.
+The module where these parameters are defined is: *modules/fw_pos_control_l1*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -1890,7 +2445,8 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_LND_HHDIST">FW_LND_HHDIST</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Landing heading hold horizontal distance</p>    </td>
+ <td style="vertical-align: top;"><p>Landing heading hold horizontal distance.
+Set to 0 to disable heading hold</p>    </td>
  <td style="vertical-align: top;">0 > 30.0 (0.5)</td>
  <td style="vertical-align: top;">15.0 </td>
  <td style="vertical-align: top;">m</td>
@@ -1925,6 +2481,54 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 </tbody></table>
 
+## FW Launch detection
+
+
+The module where these parameters are defined is: *lib/launchdetection*.
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="LAUN_ALL_ON">LAUN_ALL_ON</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Launch detection</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="LAUN_CAT_A">LAUN_CAT_A</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Catapult accelerometer threshold</p><p><strong>Comment:</strong> LAUN_CAT_A for LAUN_CAT_T serves as threshold to trigger launch detection.</p>    </td>
+ <td style="vertical-align: top;">0 > ? (0.5)</td>
+ <td style="vertical-align: top;">30.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="LAUN_CAT_T">LAUN_CAT_T</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Catapult time threshold</p><p><strong>Comment:</strong> LAUN_CAT_A for LAUN_CAT_T serves as threshold to trigger launch detection.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 5.0 (0.05)</td>
+ <td style="vertical-align: top;">0.05 </td>
+ <td style="vertical-align: top;">s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="LAUN_CAT_MDEL">LAUN_CAT_MDEL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Motor delay</p><p><strong>Comment:</strong> Delay between starting attitude control and powering up the throttle (giving throttle control to the controller) Before this timespan is up the throttle will be set to FW_THR_IDLE, set to 0 to deactivate</p>    </td>
+ <td style="vertical-align: top;">0.0 > 10.0 (0.5)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="LAUN_CAT_PMAX">LAUN_CAT_PMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum pitch before the throttle is powered up (during motor delay phase)</p><p><strong>Comment:</strong> This is an extra limit for the maximum pitch which is imposed in the phase before the throttle turns on. This allows to limit the maximum pitch angle during a bungee launch (make the launch less steep).</p>    </td>
+ <td style="vertical-align: top;">0.0 > 45.0 (0.5)</td>
+ <td style="vertical-align: top;">30.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+</tbody></table>
+
 ## FW TECS
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
@@ -1935,7 +2539,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_AIRSPD_MIN">FW_AIRSPD_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum Airspeed</p><p><strong>Comment:</strong> If the airspeed falls below this value, the TECS controller will try to increase airspeed more aggressively.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Minimum Airspeed</p><p><strong>Comment:</strong> If the airspeed falls below this value, the TECS controller will try to increase airspeed more aggressively.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
  <td style="vertical-align: top;">10.0 </td>
@@ -1943,15 +2547,23 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_AIRSPD_MAX">FW_AIRSPD_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum Airspeed</p><p><strong>Comment:</strong> If the airspeed is above this value, the TECS controller will try to decrease airspeed more aggressively.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Maximum Airspeed</p><p><strong>Comment:</strong> If the airspeed is above this value, the TECS controller will try to decrease airspeed more aggressively.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
  <td style="vertical-align: top;">20.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="FW_AIRSPD_TRIM">FW_AIRSPD_TRIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Cruise Airspeed</p><p><strong>Comment:</strong> The fixed wing controller tries to fly at this airspeed.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
+ <td style="vertical-align: top;">15.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="FW_T_CLMB_MAX">FW_T_CLMB_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum climb rate</p><p><strong>Comment:</strong> This is the best climb rate that the aircraft can achieve with the throttle set to THR_MAX and the airspeed set to the default value. For electric aircraft make sure this number can be achieved towards the end of flight when the battery voltage has reduced. The setting of this parameter can be checked by commanding a positive altitude change of 100m in loiter, RTL or guided mode. If the throttle required to climb is close to THR_MAX and the aircraft is maintaining airspeed, then this parameter is set correctly. If the airspeed starts to reduce, then the parameter is set to high, and if the throttle demand required to climb and maintain speed is noticeably less than FW_THR_MAX, then either FW_T_CLMB_MAX should be increased or FW_THR_MAX reduced.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Maximum climb rate</p><p><strong>Comment:</strong> This is the best climb rate that the aircraft can achieve with the throttle set to THR_MAX and the airspeed set to the default value. For electric aircraft make sure this number can be achieved towards the end of flight when the battery voltage has reduced. The setting of this parameter can be checked by commanding a positive altitude change of 100m in loiter, RTL or guided mode. If the throttle required to climb is close to THR_MAX and the aircraft is maintaining airspeed, then this parameter is set correctly. If the airspeed starts to reduce, then the parameter is set to high, and if the throttle demand required to climb and maintain speed is noticeably less than FW_THR_MAX, then either FW_T_CLMB_MAX should be increased or FW_THR_MAX reduced.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 15.0 (0.5)</td>
  <td style="vertical-align: top;">5.0 </td>
@@ -1959,7 +2571,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SINK_MIN">FW_T_SINK_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum descent rate</p><p><strong>Comment:</strong> This is the sink rate of the aircraft with the throttle set to THR_MIN and flown at the same airspeed as used to measure FW_T_CLMB_MAX.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Minimum descent rate</p><p><strong>Comment:</strong> This is the sink rate of the aircraft with the throttle set to THR_MIN and flown at the same airspeed as used to measure FW_T_CLMB_MAX.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 5.0 (0.5)</td>
  <td style="vertical-align: top;">2.0 </td>
@@ -1967,7 +2579,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SINK_MAX">FW_T_SINK_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum descent rate</p><p><strong>Comment:</strong> This sets the maximum descent rate that the controller will use. If this value is too large, the aircraft can over-speed on descent. This should be set to a value that can be achieved without exceeding the lower pitch angle limit and without over-speeding the aircraft.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Maximum descent rate</p><p><strong>Comment:</strong> This sets the maximum descent rate that the controller will use. If this value is too large, the aircraft can over-speed on descent. This should be set to a value that can be achieved without exceeding the lower pitch angle limit and without over-speeding the aircraft.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">2.0 > 15.0 (0.5)</td>
  <td style="vertical-align: top;">5.0 </td>
@@ -1975,7 +2587,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_TIME_CONST">FW_T_TIME_CONST</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TECS time constant</p><p><strong>Comment:</strong> This is the time constant of the TECS control algorithm (in seconds). Smaller values make it faster to respond, larger values make it slower to respond.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>TECS time constant</p><p><strong>Comment:</strong> This is the time constant of the TECS control algorithm (in seconds). Smaller values make it faster to respond, larger values make it slower to respond.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">5.0 </td>
@@ -1983,7 +2595,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_THRO_CONST">FW_T_THRO_CONST</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TECS Throttle time constant</p><p><strong>Comment:</strong> This is the time constant of the TECS throttle control algorithm (in seconds). Smaller values make it faster to respond, larger values make it slower to respond.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>TECS Throttle time constant</p><p><strong>Comment:</strong> This is the time constant of the TECS throttle control algorithm (in seconds). Smaller values make it faster to respond, larger values make it slower to respond.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">8.0 </td>
@@ -1991,7 +2603,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_THR_DAMP">FW_T_THR_DAMP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Throttle damping factor</p><p><strong>Comment:</strong> This is the damping gain for the throttle demand loop. Increase to add damping to correct for oscillations in speed and height.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Throttle damping factor</p><p><strong>Comment:</strong> This is the damping gain for the throttle demand loop. Increase to add damping to correct for oscillations in speed and height.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (0.1)</td>
  <td style="vertical-align: top;">0.5 </td>
@@ -1999,7 +2611,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_INTEG_GAIN">FW_T_INTEG_GAIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integrator gain</p><p><strong>Comment:</strong> This is the integrator gain on the control loop. Increasing this gain increases the speed at which speed and height offsets are trimmed out, but reduces damping and increases overshoot.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Integrator gain</p><p><strong>Comment:</strong> This is the integrator gain on the control loop. Increasing this gain increases the speed at which speed and height offsets are trimmed out, but reduces damping and increases overshoot.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (0.05)</td>
  <td style="vertical-align: top;">0.1 </td>
@@ -2007,7 +2619,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_VERT_ACC">FW_T_VERT_ACC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical acceleration</p><p><strong>Comment:</strong> This is the maximum vertical acceleration (in m/s/s) either up or down that the controller will use to correct speed or height errors. The default value of 7 m/s/s (equivalent to +- 0.7 g) allows for reasonably aggressive pitch changes if required to recover from under-speed conditions.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Maximum vertical acceleration</p><p><strong>Comment:</strong> This is the maximum vertical acceleration (in m/s/s) either up or down that the controller will use to correct speed or height errors. The default value of 7 m/s/s (equivalent to +- 0.7 g) allows for reasonably aggressive pitch changes if required to recover from under-speed conditions.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">7.0 </td>
@@ -2015,7 +2627,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_HGT_OMEGA">FW_T_HGT_OMEGA</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Complementary filter "omega" parameter for height</p><p><strong>Comment:</strong> This is the cross-over frequency (in radians/second) of the complementary filter used to fuse vertical acceleration and barometric height to obtain an estimate of height rate and height. Increasing this frequency weights the solution more towards use of the barometer, whilst reducing it weights the solution more towards use of the accelerometer data.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Complementary filter "omega" parameter for height</p><p><strong>Comment:</strong> This is the cross-over frequency (in radians/second) of the complementary filter used to fuse vertical acceleration and barometric height to obtain an estimate of height rate and height. Increasing this frequency weights the solution more towards use of the barometer, whilst reducing it weights the solution more towards use of the accelerometer data.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">3.0 </td>
@@ -2023,7 +2635,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SPD_OMEGA">FW_T_SPD_OMEGA</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Complementary filter "omega" parameter for speed</p><p><strong>Comment:</strong> This is the cross-over frequency (in radians/second) of the complementary filter used to fuse longitudinal acceleration and airspeed to obtain an improved airspeed estimate. Increasing this frequency weights the solution more towards use of the airspeed sensor, whilst reducing it weights the solution more towards use of the accelerometer data.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Complementary filter "omega" parameter for speed</p><p><strong>Comment:</strong> This is the cross-over frequency (in radians/second) of the complementary filter used to fuse longitudinal acceleration and airspeed to obtain an improved airspeed estimate. Increasing this frequency weights the solution more towards use of the airspeed sensor, whilst reducing it weights the solution more towards use of the accelerometer data.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">1.0 > 10.0 (0.5)</td>
  <td style="vertical-align: top;">2.0 </td>
@@ -2031,7 +2643,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_RLL2THR">FW_T_RLL2THR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll -> Throttle feedforward</p><p><strong>Comment:</strong> Increasing this gain turn increases the amount of throttle that will be used to compensate for the additional drag created by turning. Ideally this should be set to  approximately 10 x the extra sink rate in m/s created by a 45 degree bank turn. Increase this gain if the aircraft initially loses energy in turns and reduce if the aircraft initially gains energy in turns. Efficient high aspect-ratio aircraft (eg powered sailplanes) can use a lower value, whereas inefficient low aspect-ratio models (eg delta wings) can use a higher value.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Roll -> Throttle feedforward</p><p><strong>Comment:</strong> Increasing this gain turn increases the amount of throttle that will be used to compensate for the additional drag created by turning. Ideally this should be set to  approximately 10 x the extra sink rate in m/s created by a 45 degree bank turn. Increase this gain if the aircraft initially loses energy in turns and reduce if the aircraft initially gains energy in turns. Efficient high aspect-ratio aircraft (eg powered sailplanes) can use a lower value, whereas inefficient low aspect-ratio models (eg delta wings) can use a higher value.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 20.0 (0.5)</td>
  <td style="vertical-align: top;">15.0 </td>
@@ -2039,7 +2651,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SPDWEIGHT">FW_T_SPDWEIGHT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Speed <--> Altitude priority</p><p><strong>Comment:</strong> This parameter adjusts the amount of weighting that the pitch control applies to speed vs height errors. Setting it to 0.0 will cause the pitch control to control height and ignore speed errors. This will normally improve height accuracy but give larger airspeed errors. Setting it to 2.0 will cause the pitch control loop to control speed and ignore height errors. This will normally reduce airspeed errors, but give larger height errors. The default value of 1.0 allows the pitch control to simultaneously control height and speed. Note to Glider Pilots - set this parameter to 2.0 (The glider will adjust its pitch angle to maintain airspeed, ignoring changes in height).</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Speed <--> Altitude priority</p><p><strong>Comment:</strong> This parameter adjusts the amount of weighting that the pitch control applies to speed vs height errors. Setting it to 0.0 will cause the pitch control to control height and ignore speed errors. This will normally improve height accuracy but give larger airspeed errors. Setting it to 2.0 will cause the pitch control loop to control speed and ignore height errors. This will normally reduce airspeed errors, but give larger height errors. The default value of 1.0 allows the pitch control to simultaneously control height and speed. Note to Glider Pilots - set this parameter to 2.0 (The glider will adjust its pitch angle to maintain airspeed, ignoring changes in height).</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (1.0)</td>
  <td style="vertical-align: top;">1.0 </td>
@@ -2047,7 +2659,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_PTCH_DAMP">FW_T_PTCH_DAMP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch damping factor</p><p><strong>Comment:</strong> This is the damping gain for the pitch demand loop. Increase to add damping to correct for oscillations in height. The default value of 0.0 will work well provided the pitch to servo controller has been tuned properly.</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Pitch damping factor</p><p><strong>Comment:</strong> This is the damping gain for the pitch demand loop. Increase to add damping to correct for oscillations in height. The default value of 0.0 will work well provided the pitch to servo controller has been tuned properly.</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (0.1)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -2055,7 +2667,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_HRATE_P">FW_T_HRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Height rate proportional factor</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Height rate proportional factor</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.05 </td>
@@ -2063,7 +2675,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_HRATE_FF">FW_T_HRATE_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Height rate feed forward</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Height rate feed forward</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.8 </td>
@@ -2071,18 +2683,26 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="FW_T_SRATE_P">FW_T_SRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Speed rate P factor</p>    <p><b>Module:</b> src/modules/fw_pos_control_l1</p>
+ <td style="vertical-align: top;"><p>Speed rate P factor</p>    <p><b>Module:</b> modules/fw_pos_control_l1</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 (0.01)</td>
  <td style="vertical-align: top;">0.02 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="FW_AIRSPD_TRIM">FW_AIRSPD_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Cruise Airspeed</p><p><strong>Comment:</strong> The fixed wing controller tries to fly at this airspeed.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_TRIM">GND_SPEED_TRIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Trim ground speed</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
- <td style="vertical-align: top;">15.0 </td>
+ <td style="vertical-align: top;">3.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_MAX">GND_SPEED_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum ground speed</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 40 (0.5)</td>
+ <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 </tbody></table>
@@ -2090,7 +2710,7 @@ The module where these parameters are defined is: *src/modules/fw_pos_control_l1
 ## Follow target
 
 
-The module where these parameters are defined is: *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2130,10 +2750,207 @@ but also ignore less noise</p>    </td>
 </tr>
 </tbody></table>
 
+## GND Attitude Control
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_P">GND_WR_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate proportional gain</p><p><strong>Comment:</strong> This defines how much the wheel steering input will be commanded depending on the current body angular rate error.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.005 > 1.0 (0.005)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">%/rad/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_I">GND_WR_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator gain</p><p><strong>Comment:</strong> This gain defines how much control response will result out of a steady state error. It trims any constant error.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.00 > 0.5 (0.005)</td>
+ <td style="vertical-align: top;">0.00 </td>
+ <td style="vertical-align: top;">%/rad</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_D">GND_WR_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator gain</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.00 > 30 (0.005)</td>
+ <td style="vertical-align: top;">0.00 </td>
+ <td style="vertical-align: top;">%/rad</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_IMAX">GND_WR_IMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate integrator limit</p><p><strong>Comment:</strong> The portion of the integrator part in the control surface deflection is limited to this value</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_W_RMAX">GND_W_RMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum wheel steering rate</p><p><strong>Comment:</strong> This limits the maximum wheel steering rate the controller will output (in degrees per second). Setting a value of zero disables the limit.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 (0.5)</td>
+ <td style="vertical-align: top;">90.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_WR_FF">GND_WR_FF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Wheel steering rate feed forward</p><p><strong>Comment:</strong> Direct feed forward from rate setpoint to control surface output</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 10.0 (0.05)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">%/rad/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_MAN_Y_SC">GND_MAN_Y_SC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Manual yaw scale</p><p><strong>Comment:</strong> Scale factor applied to the desired yaw actuator command in full manual mode. This parameter allows to adjust the throws of the control surfaces.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? (0.01)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_GSPD_SP_TRIM">GND_GSPD_SP_TRIM</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Groundspeed speed trim</p><p><strong>Comment:</strong> This allows to scale the turning radius depending on the speed.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? (0.1)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_BAT_SCALE_EN">GND_BAT_SCALE_EN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Whether to scale throttle by battery power level</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The fixed wing should constantly behave as if it was fully charged with reduced max thrust at lower battery percentages. i.e. if cruise speed is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    <p><b>Module:</b> modules/gnd_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SP_CTRL_MODE">GND_SP_CTRL_MODE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Control mode for speed</p><p><strong>Comment:</strong> This allows the user to choose between closed loop gps speed or open loop cruise throttle speed</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> open loop control</li> 
+
+<li><strong>1:</strong> close the loop with gps speed</li> 
+</ul>
+   <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_P">GND_SPEED_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed proportional gain</p><p><strong>Comment:</strong> This is the proportional gain for the speed closed loop controller</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.005 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">2.0 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_I">GND_SPEED_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed Integral gain</p><p><strong>Comment:</strong> This is the integral gain for the speed closed loop controller</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.00 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_D">GND_SPEED_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed proportional gain</p><p><strong>Comment:</strong> This is the derivative gain for the speed closed loop controller</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.00 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_IMAX">GND_SPEED_IMAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed integral maximum value</p><p><strong>Comment:</strong> This is the maxim value the integral can reach to prevent wind-up.</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.005 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_SPEED_THR_SC">GND_SPEED_THR_SC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Speed to throttle scaler</p><p><strong>Comment:</strong> This is a gain to map the speed control output to the throttle linearly.</p>    <p><b>Module:</b> modules/gnd_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.005 > 50.0 (0.005)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">%m/s</td>
+</tr>
+</tbody></table>
+
+## GND POS Control
+
+
+The module where these parameters are defined is: *modules/gnd_pos_control*.
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_L1_DIST">GND_L1_DIST</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>L1 distance</p><p><strong>Comment:</strong> This is the waypoint radius</p>    </td>
+ <td style="vertical-align: top;">0.0 > 100.0 (0.1)</td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_L1_PERIOD">GND_L1_PERIOD</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>L1 period</p><p><strong>Comment:</strong> This is the L1 distance and defines the tracking point ahead of the rover it's following. Using values around 2-5 for a traxxas stampede. Shorten slowly during tuning until response is sharp without oscillation.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 50.0 (0.5)</td>
+ <td style="vertical-align: top;">10.0 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_L1_DAMPING">GND_L1_DAMPING</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>L1 damping</p><p><strong>Comment:</strong> Damping factor for L1 control.</p>    </td>
+ <td style="vertical-align: top;">0.6 > 0.9 (0.05)</td>
+ <td style="vertical-align: top;">0.75 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_THR_CRUISE">GND_THR_CRUISE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Cruise throttle</p><p><strong>Comment:</strong> This is the throttle setting required to achieve the desired cruise speed. 10% is ok for a traxxas stampede vxl with ESC set to training mode</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_THR_MAX">GND_THR_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Throttle limit max</p><p><strong>Comment:</strong> This is the maximum throttle % that can be used by the controller. For a Traxxas stampede vxl with the ESC set to training, 30 % is enough</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.3 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_THR_MIN">GND_THR_MIN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Throttle limit min</p><p><strong>Comment:</strong> This is the minimum throttle % that can be used by the controller. Set to 0 for rover</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GND_THR_IDLE">GND_THR_IDLE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Idle throttle</p><p><strong>Comment:</strong> This is the minimum throttle while on the ground, it should be 0 for a rover</p>    </td>
+ <td style="vertical-align: top;">0.0 > 0.4 (0.01)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">norm</td>
+</tr>
+</tbody></table>
+
 ## GPS
 
 
-The module where these parameters are defined is: *src/drivers/gps*.
+The module where these parameters are defined is: *drivers/gps*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2153,12 +2970,31 @@ The module where these parameters are defined is: *src/drivers/gps*.
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="GPS_UBX_DYNMODEL">GPS_UBX_DYNMODEL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>u-blox GPS dynamic platform model</p><p><strong>Comment:</strong> u-blox receivers support different dynamic platform models to adjust the navigation engine to the expected application environment.</p> <strong>Values:</strong><ul>
+<li><strong>2:</strong> stationary</li> 
+
+<li><strong>4:</strong> automotive</li> 
+
+<li><strong>6:</strong> airborne with <1g acceleration</li> 
+
+<li><strong>7:</strong> airborne with <2g acceleration</li> 
+
+<li><strong>8:</strong> airborne with <4g acceleration</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 9 </td>
+ <td style="vertical-align: top;">7 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
 </tbody></table>
 
 ## GPS Failure Navigation
 
 
-The module where these parameters are defined is: *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2168,30 +3004,30 @@ The module where these parameters are defined is: *src/modules/navigator*.
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_GPSF_LT">NAV_GPSF_LT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Loiter time</p><p><strong>Comment:</strong> The amount of time in seconds the system should do open loop loiter and wait for gps recovery before it goes into flight termination.</p>    </td>
+ <td style="vertical-align: top;"><p>Loiter time</p><p><strong>Comment:</strong> The time in seconds the system should do open loop loiter and wait for GPS recovery before it goes into flight termination. Set to 0 to disable.</p>    </td>
  <td style="vertical-align: top;">0.0 > 3600.0 (1)</td>
- <td style="vertical-align: top;">30.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_GPSF_R">NAV_GPSF_R</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Open loop loiter roll</p><p><strong>Comment:</strong> Roll in degrees during the open loop loiter</p>    </td>
+ <td style="vertical-align: top;"><p>Fixed bank angle</p><p><strong>Comment:</strong> Roll in degrees during the loiter</p>    </td>
  <td style="vertical-align: top;">0.0 > 30.0 (0.5)</td>
  <td style="vertical-align: top;">15.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_GPSF_P">NAV_GPSF_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Open loop loiter pitch</p><p><strong>Comment:</strong> Pitch in degrees during the open loop loiter</p>    </td>
+ <td style="vertical-align: top;"><p>Fixed pitch angle</p><p><strong>Comment:</strong> Pitch in degrees during the open loop loiter</p>    </td>
  <td style="vertical-align: top;">-30.0 > 30.0 (0.5)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_GPSF_TR">NAV_GPSF_TR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Open loop loiter thrust</p><p><strong>Comment:</strong> Thrust value which is set during the open loop loiter</p>    </td>
+ <td style="vertical-align: top;"><p>Thrust</p><p><strong>Comment:</strong> Thrust value which is set during the open loop loiter</p>    </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
- <td style="vertical-align: top;">0.7 </td>
+ <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;">norm</td>
 </tr>
 </tbody></table>
@@ -2199,7 +3035,7 @@ The module where these parameters are defined is: *src/modules/navigator*.
 ## Geofence
 
 
-The module where these parameters are defined is: *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2275,7 +3111,7 @@ The module where these parameters are defined is: *src/modules/navigator*.
 ## Iridium SBD
 
 
-The module where these parameters are defined is: *src/drivers/iridiumsbd*.
+The module where these parameters are defined is: *drivers/iridiumsbd*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2295,7 +3131,7 @@ The module where these parameters are defined is: *src/drivers/iridiumsbd*.
 ## Land Detector
 
 
-The module where these parameters are defined is: *src/modules/land_detector*.
+The module where these parameters are defined is: *modules/land_detector*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2307,14 +3143,14 @@ The module where these parameters are defined is: *src/modules/land_detector*.
  <td style="vertical-align: top;"><strong id="LNDMC_Z_VEL_MAX">LNDMC_Z_VEL_MAX</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Multicopter max climb rate</p><p><strong>Comment:</strong> Maximum vertical velocity allowed in the landed state (m/s up and down)</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.70 </td>
+ <td style="vertical-align: top;">0.50 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="LNDMC_XY_VEL_MAX">LNDMC_XY_VEL_MAX</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Multicopter max horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity allowed in the landed state (m/s)</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.50 </td>
+ <td style="vertical-align: top;">1.5 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
@@ -2344,20 +3180,6 @@ The module where these parameters are defined is: *src/modules/land_detector*.
  <td style="vertical-align: top;">0.02 > 5 </td>
  <td style="vertical-align: top;">0.3 </td>
  <td style="vertical-align: top;">s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="LNDMC_MAN_DWNTHR">LNDMC_MAN_DWNTHR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual flight stick down threshold for landing</p><p><strong>Comment:</strong> When controlling manually the throttle stick value (0 to 1) has to be bellow this threshold in order to pass the check for landing. So if set to 1 it's allowed to land with any stick position.</p>    </td>
- <td style="vertical-align: top;">0 > 1 </td>
- <td style="vertical-align: top;">0.15 </td>
- <td style="vertical-align: top;">norm</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="LNDMC_POS_UPTHR">LNDMC_POS_UPTHR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual position flight stick up threshold for taking off</p><p><strong>Comment:</strong> When controlling manually in position mode the throttle stick value (0 to 1) has to get above this threshold after arming in order to take off.</p>    </td>
- <td style="vertical-align: top;">0 > 1 </td>
- <td style="vertical-align: top;">0.65 </td>
- <td style="vertical-align: top;">norm</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="LNDFW_VEL_XY_MAX">LNDFW_VEL_XY_MAX</strong> (FLOAT)</td>
@@ -2403,65 +3225,17 @@ The module where these parameters are defined is: *src/modules/land_detector*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="LNDMC_ALT_MAX">LNDMC_ALT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum altitude that can be reached prior to subconditions</p>    </td>
- <td style="vertical-align: top;">10 > 150 </td>
- <td style="vertical-align: top;">100.0 </td>
+ <td style="vertical-align: top;"><p>Maximum altitude for multicopters</p><p><strong>Comment:</strong> The system will obey this limit as a hard altitude limit. This setting will be consolidated with the GF_MAX_VER_DIST parameter. A negative value indicates no altitude limitation.</p>    </td>
+ <td style="vertical-align: top;">-1 > 10000 </td>
+ <td style="vertical-align: top;">-1.0 </td>
  <td style="vertical-align: top;">m</td>
-</tr>
-</tbody></table>
-
-## Launch detection
-
-
-The module where these parameters are defined is: *src/lib/launchdetection*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="LAUN_ALL_ON">LAUN_ALL_ON</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Launch detection</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="LAUN_CAT_A">LAUN_CAT_A</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Catapult accelerometer threshold</p><p><strong>Comment:</strong> LAUN_CAT_A for LAUN_CAT_T serves as threshold to trigger launch detection.</p>    </td>
- <td style="vertical-align: top;">0 > ? (0.5)</td>
- <td style="vertical-align: top;">30.0 </td>
- <td style="vertical-align: top;">m/s/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="LAUN_CAT_T">LAUN_CAT_T</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Catapult time threshold</p><p><strong>Comment:</strong> LAUN_CAT_A for LAUN_CAT_T serves as threshold to trigger launch detection.</p>    </td>
- <td style="vertical-align: top;">0.0 > 5.0 (0.05)</td>
- <td style="vertical-align: top;">0.05 </td>
- <td style="vertical-align: top;">s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="LAUN_CAT_MDEL">LAUN_CAT_MDEL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Motor delay</p><p><strong>Comment:</strong> Delay between starting attitude control and powering up the throttle (giving throttle control to the controller) Before this timespan is up the throttle will be set to FW_THR_IDLE, set to 0 to deactivate</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 (0.5)</td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="LAUN_CAT_PMAX">LAUN_CAT_PMAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum pitch before the throttle is powered up (during motor delay phase)</p><p><strong>Comment:</strong> This is an extra limit for the maximum pitch which is imposed in the phase before the throttle turns on. This allows to limit the maximum pitch angle during a bungee launch (make the launch less steep).</p>    </td>
- <td style="vertical-align: top;">0.0 > 45.0 (0.5)</td>
- <td style="vertical-align: top;">30.0 </td>
- <td style="vertical-align: top;">deg</td>
 </tr>
 </tbody></table>
 
 ## Local Position Estimator
 
 
-The module where these parameters are defined is: *src/modules/local_position_estimator*.
+The module where these parameters are defined is: *modules/local_position_estimator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2537,14 +3311,14 @@ The module where these parameters are defined is: *src/modules/local_position_es
  <td style="vertical-align: top;"><p>Accelerometer xy noise density</p><p><strong>Comment:</strong> Data sheet noise density = 150ug/sqrt(Hz) = 0.0015 m/s^2/sqrt(Hz) Larger than data sheet to account for tilt error.</p>    </td>
  <td style="vertical-align: top;">0.00001 > 2 </td>
  <td style="vertical-align: top;">0.012 </td>
- <td style="vertical-align: top;">m/s^2/srqt(Hz)</td>
+ <td style="vertical-align: top;">m/s^2/sqrt(Hz)</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="LPE_ACC_Z">LPE_ACC_Z</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Accelerometer z noise density</p><p><strong>Comment:</strong> Data sheet noise density = 150ug/sqrt(Hz) = 0.0015 m/s^2/sqrt(Hz)</p>    </td>
  <td style="vertical-align: top;">0.00001 > 2 </td>
  <td style="vertical-align: top;">0.02 </td>
- <td style="vertical-align: top;">m/s^2/srqt(Hz)</td>
+ <td style="vertical-align: top;">m/s^2/sqrt(Hz)</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="LPE_BAR_Z">LPE_BAR_Z</strong> (FLOAT)</td>
@@ -2752,7 +3526,7 @@ by initializing the estimator to the LPE_LAT/LON parameters when global informat
 ## MAVLink
 
 
-The module where these parameters are defined is: *src/modules/mavlink*.
+The module where these parameters are defined is: *modules/mavlink*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2762,14 +3536,16 @@ The module where these parameters are defined is: *src/modules/mavlink*.
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="MAV_SYS_ID">MAV_SYS_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>MAVLink system ID</p>    </td>
+ <td style="vertical-align: top;"><p>MAVLink system ID</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">1 > 250 </td>
  <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MAV_COMP_ID">MAV_COMP_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>MAVLink component ID</p>    </td>
+ <td style="vertical-align: top;"><p>MAVLink component ID</p>   <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">1 > 250 </td>
  <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
@@ -2840,7 +3616,7 @@ The module where these parameters are defined is: *src/modules/mavlink*.
 ## MKBLCTRL Testmode
 
 
-The module where these parameters are defined is: *src/drivers/mkblctrl*.
+The module where these parameters are defined is: *drivers/mkblctrl*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -2857,83 +3633,6 @@ The module where these parameters are defined is: *src/drivers/mkblctrl*.
 </tr>
 </tbody></table>
 
-## MPU9x50 Configuration
-
-
-The module where these parameters are defined is: *src/platforms/qurt/fc_addon/mpu_spi*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="MPU_GYRO_LPF_ENM">MPU_GYRO_LPF_ENM</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Low pass filter frequency for Gyro</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> MPU9X50_GYRO_LPF_250HZ</li> 
-
-<li><strong>1:</strong> MPU9X50_GYRO_LPF_184HZ</li> 
-
-<li><strong>2:</strong> MPU9X50_GYRO_LPF_92HZ</li> 
-
-<li><strong>3:</strong> MPU9X50_GYRO_LPF_41HZ</li> 
-
-<li><strong>4:</strong> MPU9X50_GYRO_LPF_20HZ</li> 
-
-<li><strong>5:</strong> MPU9X50_GYRO_LPF_10HZ</li> 
-
-<li><strong>6:</strong> MPU9X50_GYRO_LPF_5HZ</li> 
-
-<li><strong>7:</strong> MPU9X50_GYRO_LPF_3600HZ_NOLPF</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">4 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPU_ACC_LPF_ENM">MPU_ACC_LPF_ENM</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Low pass filter frequency for Accelerometer</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> MPU9X50_ACC_LPF_460HZ</li> 
-
-<li><strong>1:</strong> MPU9X50_ACC_LPF_184HZ</li> 
-
-<li><strong>2:</strong> MPU9X50_ACC_LPF_92HZ</li> 
-
-<li><strong>3:</strong> MPU9X50_ACC_LPF_41HZ</li> 
-
-<li><strong>4:</strong> MPU9X50_ACC_LPF_20HZ</li> 
-
-<li><strong>5:</strong> MPU9X50_ACC_LPF_10HZ</li> 
-
-<li><strong>6:</strong> MPU9X50_ACC_LPF_5HZ</li> 
-
-<li><strong>7:</strong> MPU9X50_ACC_LPF_460HZ_NOLPF</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">4 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPU_SAMPLE_R_ENM">MPU_SAMPLE_R_ENM</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Sample rate in Hz</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> MPU9x50_SAMPLE_RATE_100HZ</li> 
-
-<li><strong>1:</strong> MPU9x50_SAMPLE_RATE_200HZ</li> 
-
-<li><strong>2:</strong> MPU9x50_SAMPLE_RATE_500HZ</li> 
-
-<li><strong>3:</strong> MPU9x50_SAMPLE_RATE_1000HZ</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-</tbody></table>
-
 ## Mission
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
@@ -2943,42 +3642,8 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_OBL_ACT">COM_OBL_ACT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set offboard loss failsafe mode</p><p><strong>Comment:</strong> The offboard loss failsafe will only be entered after a timeout, set by COM_OF_LOSS_T in seconds.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Land at current position</li> 
-
-<li><strong>1:</strong> Loiter</li> 
-
-<li><strong>2:</strong> Return to Land</li> 
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_OBL_RC_ACT">COM_OBL_RC_ACT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set offboard loss failsafe mode when RC is available</p><p><strong>Comment:</strong> The offboard loss failsafe will only be entered after a timeout, set by COM_OF_LOSS_T in seconds.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Position control</li> 
-
-<li><strong>1:</strong> Altitude control</li> 
-
-<li><strong>2:</strong> Manual</li> 
-
-<li><strong>3:</strong> Return to Land</li> 
-
-<li><strong>4:</strong> Land at current position</li> 
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MIS_TAKEOFF_ALT">MIS_TAKEOFF_ALT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Take-off altitude</p><p><strong>Comment:</strong> This is the minimum altitude the system will take off to.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Take-off altitude</p><p><strong>Comment:</strong> This is the minimum altitude the system will take off to.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0 > 80 (0.5)</td>
  <td style="vertical-align: top;">2.5 </td>
@@ -2986,15 +3651,15 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_LTRMIN_ALT">MIS_LTRMIN_ALT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum Loiter altitude</p><p><strong>Comment:</strong> This is the minimum altitude the system will always obey. The intent is to stay out of ground effect.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Minimum Loiter altitude</p><p><strong>Comment:</strong> This is the minimum altitude the system will always obey. The intent is to stay out of ground effect. set to -1, if there shouldn't be a minimum loiter altitude</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
- <td style="vertical-align: top;">0 > 80 (0.5)</td>
- <td style="vertical-align: top;">1.2 </td>
+ <td style="vertical-align: top;">-1 > 80 (0.5)</td>
+ <td style="vertical-align: top;">-1.0 </td>
  <td style="vertical-align: top;">m</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_ONBOARD_EN">MIS_ONBOARD_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Persistent onboard mission storage</p><p><strong>Comment:</strong> When enabled, missions that have been uploaded by the GCS are stored and reloaded after reboot persistently.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Persistent onboard mission storage</p><p><strong>Comment:</strong> When enabled, missions that have been uploaded by the GCS are stored and reloaded after reboot persistently.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -3002,9 +3667,17 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_DIST_1WP">MIS_DIST_1WP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal horizontal distance from home to first waypoint</p><p><strong>Comment:</strong> Failsafe check to prevent running mission stored from previous flight at a new takeoff location. Set a value of zero or less to disable. The mission will not be started if the current waypoint is more distant than MIS_DIS_1WP from the current position.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Maximal horizontal distance from home to first waypoint</p><p><strong>Comment:</strong> Failsafe check to prevent running mission stored from previous flight at a new takeoff location. Set a value of zero or less to disable. The mission will not be started if the current waypoint is more distant than MIS_DIS_1WP from the home position.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
- <td style="vertical-align: top;">0 > 1000 (0.5)</td>
+ <td style="vertical-align: top;">0 > 10000 (100)</td>
+ <td style="vertical-align: top;">900 </td>
+ <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MIS_DIST_WPS">MIS_DIST_WPS</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximal horizontal distance between waypoint</p><p><strong>Comment:</strong> Failsafe check to prevent running missions which are way too big. Set a value of zero or less to disable. The mission will not be started if any distance between two subsequent waypoints is greater than MIS_DIST_WPS.</p>    <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;">0 > 10000 (100)</td>
  <td style="vertical-align: top;">900 </td>
  <td style="vertical-align: top;">m</td>
 </tr>
@@ -3015,7 +3688,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 
 <li><strong>1:</strong> First Order Hold</li> 
 </ul>
-   <p><b>Module:</b> src/modules/navigator</p>
+   <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">1 </td>
@@ -3031,8 +3704,10 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 <li><strong>2:</strong> Heading towards home</li> 
 
 <li><strong>3:</strong> Heading away from home</li> 
+
+<li><strong>4:</strong> Heading towards ROI</li> 
 </ul>
-   <p><b>Module:</b> src/modules/navigator</p>
+   <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0 > 3 </td>
  <td style="vertical-align: top;">1 </td>
@@ -3040,7 +3715,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_YAW_TMT">MIS_YAW_TMT</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Time in seconds we wait on reaching target heading at a waypoint if it is forced</p><p><strong>Comment:</strong> If set > 0 it will ignore the target heading for normal waypoint acceptance. If the waypoint forces the heading the timeout will matter. For example on VTOL forwards transiton. Mainly useful for VTOLs that have less yaw authority and might not reach target yaw in wind. Disabled by default.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Time in seconds we wait on reaching target heading at a waypoint if it is forced</p><p><strong>Comment:</strong> If set > 0 it will ignore the target heading for normal waypoint acceptance. If the waypoint forces the heading the timeout will matter. For example on VTOL forwards transition. Mainly useful for VTOLs that have less yaw authority and might not reach target yaw in wind. Disabled by default.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">-1 > 20 (1)</td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -3048,39 +3723,15 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MIS_YAW_ERR">MIS_YAW_ERR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max yaw error in degrees needed for waypoint heading acceptance</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Max yaw error in degrees needed for waypoint heading acceptance</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0 > 90 (1)</td>
  <td style="vertical-align: top;">12.0 </td>
  <td style="vertical-align: top;">deg</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="VT_WV_LND_EN">VT_WV_LND_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Weather-vane mode landings for missions</p>    <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_WV_TKO_EN">VT_WV_TKO_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable weather-vane mode takeoff for missions</p>    <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_WV_LTR_EN">VT_WV_LTR_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Weather-vane mode for loiter</p>    <p><b>Module:</b> src/modules/navigator</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="NAV_LOITER_RAD">NAV_LOITER_RAD</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Loiter radius (FW only)</p><p><strong>Comment:</strong> Default value of loiter radius for missions, loiter, RTL, etc. (fixedwing only).</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Loiter radius (FW only)</p><p><strong>Comment:</strong> Default value of loiter radius for missions, loiter, RTL, etc. (fixedwing only).</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">25 > 1000 (0.5)</td>
  <td style="vertical-align: top;">50.0 </td>
@@ -3088,7 +3739,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_ACC_RAD">NAV_ACC_RAD</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Acceptance Radius</p><p><strong>Comment:</strong> Default acceptance radius, overridden by acceptance radius of waypoint if set. For fixed wing the L1 turning distance is used for horizontal acceptance.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>Acceptance Radius</p><p><strong>Comment:</strong> Default acceptance radius, overridden by acceptance radius of waypoint if set. For fixed wing the L1 turning distance is used for horizontal acceptance.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
  <td style="vertical-align: top;">10.0 </td>
@@ -3096,7 +3747,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_FW_ALT_RAD">NAV_FW_ALT_RAD</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>FW Altitude Acceptance Radius</p><p><strong>Comment:</strong> Acceptance radius for fixedwing altitude.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>FW Altitude Acceptance Radius</p><p><strong>Comment:</strong> Acceptance radius for fixedwing altitude.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
  <td style="vertical-align: top;">10.0 </td>
@@ -3104,10 +3755,10 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="NAV_MC_ALT_RAD">NAV_MC_ALT_RAD</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>MC Altitude Acceptance Radius</p><p><strong>Comment:</strong> Acceptance radius for multicopter altitude.</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><p>MC Altitude Acceptance Radius</p><p><strong>Comment:</strong> Acceptance radius for multicopter altitude.</p>    <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;">0.05 > 200.0 (0.5)</td>
- <td style="vertical-align: top;">3.0 </td>
+ <td style="vertical-align: top;">0.8 </td>
  <td style="vertical-align: top;">m</td>
 </tr>
 <tr>
@@ -3127,7 +3778,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 
 <li><strong>6:</strong> Lockdown</li> 
 </ul>
-   <p><b>Module:</b> src/modules/navigator</p>
+   <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -3150,18 +3801,108 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 
 <li><strong>6:</strong> Lockdown</li> 
 </ul>
-   <p><b>Module:</b> src/modules/navigator</p>
+   <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="NAV_FORCE_VT">NAV_FORCE_VT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Force VTOL mode takeoff and land</p>    <p><b>Module:</b> src/modules/navigator</p>
+ <td style="vertical-align: top;"><strong id="NAV_TRAFF_AVOID">NAV_TRAFF_AVOID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set traffic avoidance mode</p><p><strong>Comment:</strong> Enabling this will allow the system to respond to transponder data from e.g. ADSB transponders</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> Warn only</li> 
+
+<li><strong>2:</strong> Return to Land</li> 
+
+<li><strong>3:</strong> Land immediately</li> 
+</ul>
+   <p><b>Module:</b> modules/navigator</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="NAV_FORCE_VT">NAV_FORCE_VT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Force VTOL mode takeoff and land</p>    <p><b>Module:</b> modules/navigator</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_WV_TKO_EN">VT_WV_TKO_EN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Enable weather-vane mode takeoff for missions</p>    <p><b>Module:</b> modules/vtol_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_WV_LTR_EN">VT_WV_LTR_EN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Weather-vane mode for loiter</p>    <p><b>Module:</b> modules/vtol_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_WV_LND_EN">VT_WV_LND_EN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Weather-vane mode landings for missions</p>    <p><b>Module:</b> modules/vtol_att_control</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_OBL_ACT">COM_OBL_ACT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set offboard loss failsafe mode</p><p><strong>Comment:</strong> The offboard loss failsafe will only be entered after a timeout, set by COM_OF_LOSS_T in seconds.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Land at current position</li> 
+
+<li><strong>1:</strong> Loiter</li> 
+
+<li><strong>2:</strong> Return to Land</li> 
+</ul>
+   <p><b>Module:</b> modules/commander</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_OBL_RC_ACT">COM_OBL_RC_ACT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set offboard loss failsafe mode when RC is available</p><p><strong>Comment:</strong> The offboard loss failsafe will only be entered after a timeout, set by COM_OF_LOSS_T in seconds.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Position control</li> 
+
+<li><strong>1:</strong> Altitude control</li> 
+
+<li><strong>2:</strong> Manual</li> 
+
+<li><strong>3:</strong> Return to Land</li> 
+
+<li><strong>4:</strong> Land at current position</li> 
+
+<li><strong>5:</strong> Loiter</li> 
+</ul>
+   <p><b>Module:</b> modules/commander</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="COM_POSCTL_NAVL">COM_POSCTL_NAVL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Position control navigation loss response</p><p><strong>Comment:</strong> This sets the flight mode that will be used if navigation accuracy is no longer adequte for position control. Navigation accuracy checks can be disabled using the CBRK_VELPOSERR parameter, but doing so will remove protection for all flight modes.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Assume use of remote control after fallback. Switch to ALTCTL if a height estimate is available, else switch to MANUAL.</li> 
+
+<li><strong>1:</strong> Assume no use of remote control after fallback. Switch to DESCEND if a height estimate is available, else switch to TERMINATION.</li> 
+</ul>
+   <p><b>Module:</b> modules/commander</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -3169,7 +3910,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/m
 ## Mount
 
 
-The module where these parameters are defined is: *src/drivers/vmount*.
+The module where these parameters are defined is: *drivers/vmount*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -3179,11 +3920,10 @@ The module where these parameters are defined is: *src/drivers/vmount*.
 <tbody>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MODE_IN">MNT_MODE_IN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Mount input mode
-RC uses the AUX input channels (see MNT_MAN_* parameters),
-MAVLINK_ROI uses the MAV_CMD_DO_SET_ROI Mavlink message, and MAVLINK_DO_MOUNT the
-MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mount</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> DISABLE</li> 
+ <td style="vertical-align: top;"><p>Mount input mode</p><p><strong>Comment:</strong> RC uses the AUX input channels (see MNT_MAN_* parameters), MAVLINK_ROI uses the MAV_CMD_DO_SET_ROI Mavlink message, and MAVLINK_DO_MOUNT the MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mount.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> DISABLED</li> 
+
+<li><strong>0:</strong> AUTO</li> 
 
 <li><strong>1:</strong> RC</li> 
 
@@ -3191,17 +3931,15 @@ MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mo
 
 <li><strong>3:</strong> MAVLINK_DO_MOUNT</li> 
 </ul>
-   </td>
- <td style="vertical-align: top;">0 > 3 </td>
- <td style="vertical-align: top;">0 </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-1 > 3 </td>
+ <td style="vertical-align: top;">-1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MODE_OUT">MNT_MODE_OUT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Mount output mode
-AUX uses the mixer output Control Group #2.
-MAVLINK uses the MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL MavLink messages
-to control a mount (set MNT_MAV_SYSID & MNT_MAV_COMPID)</p> <strong>Values:</strong><ul>
+ <td style="vertical-align: top;"><p>Mount output mode</p><p><strong>Comment:</strong> AUX uses the mixer output Control Group #2. MAVLINK uses the MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL MavLink messages to control a mount (set MNT_MAV_SYSID & MNT_MAV_COMPID)</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> AUX</li> 
 
 <li><strong>1:</strong> MAVLINK</li> 
@@ -3213,16 +3951,16 @@ to control a mount (set MNT_MAV_SYSID & MNT_MAV_COMPID)</p> <strong>Values:</str
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MAV_SYSID">MNT_MAV_SYSID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Mavlink System ID (if MNT_MODE_OUT is MAVLINK)</p>    </td>
+ <td style="vertical-align: top;"><p>Mavlink System ID of the mount</p><p><strong>Comment:</strong> If MNT_MODE_OUT is MAVLINK, mount configure/control commands will be sent with this target ID.</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">71 </td>
+ <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MNT_MAV_COMPID">MNT_MAV_COMPID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Mavlink Component ID (if MNT_MODE_OUT is MAVLINK)</p>    </td>
+ <td style="vertical-align: top;"><p>Mavlink Component ID of the mount</p><p><strong>Comment:</strong> If MNT_MODE_OUT is MAVLINK, mount configure/control commands will be sent with this component ID.</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">67 </td>
+ <td style="vertical-align: top;">154 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -3239,13 +3977,6 @@ if required by the gimbal (only in AUX output mode)</p>    </td>
 if required for the gimbal (only in AUX output mode)</p>    </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MNT_MAN_CONTROL">MNT_MAN_CONTROL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>This enables the mount to be manually controlled when no ROI is set</p><p><strong>Comment:</strong> If set to 1, the mount will be controlled by the AUX channels below when no ROI is set.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -3308,6 +4039,56 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_DO_STAB">MNT_DO_STAB</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Stabilize the mount (set to true for servo gimbal, false for passthrough).
+Does not affect MAVLINK_ROI input</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_RANGE_PITCH">MNT_RANGE_PITCH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Range of pitch channel output in degrees (only in AUX output mode)</p>    </td>
+ <td style="vertical-align: top;">1.0 > 720.0 </td>
+ <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_RANGE_ROLL">MNT_RANGE_ROLL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Range of roll channel output in degrees (only in AUX output mode)</p>    </td>
+ <td style="vertical-align: top;">1.0 > 720.0 </td>
+ <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_RANGE_YAW">MNT_RANGE_YAW</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Range of yaw channel output in degrees (only in AUX output mode)</p>    </td>
+ <td style="vertical-align: top;">1.0 > 720.0 </td>
+ <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_OFF_PITCH">MNT_OFF_PITCH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Offset for pitch channel output in degrees</p>    </td>
+ <td style="vertical-align: top;">-360.0 > 360.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_OFF_ROLL">MNT_OFF_ROLL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Offset for roll channel output in degrees</p>    </td>
+ <td style="vertical-align: top;">-360.0 > 360.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MNT_OFF_YAW">MNT_OFF_YAW</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Offset for yaw channel output in degrees</p>    </td>
+ <td style="vertical-align: top;">-360.0 > 360.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
 </tbody></table>
 
 ## Multicopter Attitude Control
@@ -3319,168 +4100,8 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="MP_ROLL_P">MP_ROLL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll P gain</p><p><strong>Comment:</strong> Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">6.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ROLLRATE_P">MP_ROLLRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate P gain</p><p><strong>Comment:</strong> Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ROLLRATE_I">MP_ROLLRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate I gain</p><p><strong>Comment:</strong> Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ROLLRATE_D">MP_ROLLRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate D gain</p><p><strong>Comment:</strong> Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.002 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_PITCH_P">MP_PITCH_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch P gain</p><p><strong>Comment:</strong> Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">6.0 </td>
- <td style="vertical-align: top;">1/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_PITCHRATE_P">MP_PITCHRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate P gain</p><p><strong>Comment:</strong> Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_PITCHRATE_I">MP_PITCHRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate I gain</p><p><strong>Comment:</strong> Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_PITCHRATE_D">MP_PITCHRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate D gain</p><p><strong>Comment:</strong> Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.002 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAW_P">MP_YAW_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw P gain</p><p><strong>Comment:</strong> Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">2.0 </td>
- <td style="vertical-align: top;">1/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAWRATE_P">MP_YAWRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate P gain</p><p><strong>Comment:</strong> Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.3 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAWRATE_I">MP_YAWRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate I gain</p><p><strong>Comment:</strong> Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAWRATE_D">MP_YAWRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate D gain</p><p><strong>Comment:</strong> Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAW_FF">MP_YAW_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw feed forward</p><p><strong>Comment:</strong> Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_YAWRATE_MAX">MP_YAWRATE_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max yaw rate</p><p><strong>Comment:</strong> Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 360.0 </td>
- <td style="vertical-align: top;">60.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ACRO_R_MAX">MP_ACRO_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro roll rate</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 360.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ACRO_P_MAX">MP_ACRO_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro pitch rate</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 360.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MP_ACRO_Y_MAX">MP_ACRO_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro yaw rate</p>    <p><b>Module:</b> src/examples/mc_att_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">120.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_MAN_R_MAX">MPP_MAN_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual roll</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_MAN_P_MAX">MPP_MAN_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual pitch</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_MAN_Y_MAX">MPP_MAN_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual yaw rate</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">120.0 </td>
- <td style="vertical-align: top;">deg/s</td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MC_ROLL_TC">MC_ROLL_TC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll time constant</p><p><strong>Comment:</strong> Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll time constant</p><p><strong>Comment:</strong> Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.15 > 0.25 (0.01)</td>
  <td style="vertical-align: top;">0.2 </td>
@@ -3488,7 +4109,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCH_TC">MC_PITCH_TC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch time constant</p><p><strong>Comment:</strong> Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch time constant</p><p><strong>Comment:</strong> Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.15 > 0.25 (0.01)</td>
  <td style="vertical-align: top;">0.2 </td>
@@ -3496,7 +4117,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLL_P">MC_ROLL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll P gain</p><p><strong>Comment:</strong> Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll P gain</p><p><strong>Comment:</strong> Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 8 (0.1)</td>
  <td style="vertical-align: top;">6.5 </td>
@@ -3504,7 +4125,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_P">MC_ROLLRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate P gain</p><p><strong>Comment:</strong> Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate P gain</p><p><strong>Comment:</strong> Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.5 (0.01)</td>
  <td style="vertical-align: top;">0.15 </td>
@@ -3512,7 +4133,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_I">MC_ROLLRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate I gain</p><p><strong>Comment:</strong> Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate I gain</p><p><strong>Comment:</strong> Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.05 </td>
@@ -3520,7 +4141,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_RR_INT_LIM">MC_RR_INT_LIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate integrator limit</p><p><strong>Comment:</strong> Roll rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large roll moment trim changes.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate integrator limit</p><p><strong>Comment:</strong> Roll rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large roll moment trim changes.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.30 </td>
@@ -3528,7 +4149,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_D">MC_ROLLRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate D gain</p><p><strong>Comment:</strong> Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate D gain</p><p><strong>Comment:</strong> Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.01 (0.0005)</td>
  <td style="vertical-align: top;">0.003 </td>
@@ -3536,7 +4157,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_FF">MC_ROLLRATE_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Roll rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3544,7 +4165,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCH_P">MC_PITCH_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch P gain</p><p><strong>Comment:</strong> Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch P gain</p><p><strong>Comment:</strong> Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 10 (0.1)</td>
  <td style="vertical-align: top;">6.5 </td>
@@ -3552,7 +4173,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_P">MC_PITCHRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate P gain</p><p><strong>Comment:</strong> Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate P gain</p><p><strong>Comment:</strong> Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.6 (0.01)</td>
  <td style="vertical-align: top;">0.15 </td>
@@ -3560,7 +4181,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_I">MC_PITCHRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate I gain</p><p><strong>Comment:</strong> Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate I gain</p><p><strong>Comment:</strong> Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.05 </td>
@@ -3568,7 +4189,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PR_INT_LIM">MC_PR_INT_LIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate integrator limit</p><p><strong>Comment:</strong> Pitch rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large pitch moment trim changes.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate integrator limit</p><p><strong>Comment:</strong> Pitch rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large pitch moment trim changes.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.30 </td>
@@ -3576,7 +4197,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_D">MC_PITCHRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate D gain</p><p><strong>Comment:</strong> Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate D gain</p><p><strong>Comment:</strong> Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.0005)</td>
  <td style="vertical-align: top;">0.003 </td>
@@ -3584,7 +4205,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_FF">MC_PITCHRATE_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Pitch rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3592,7 +4213,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAW_P">MC_YAW_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw P gain</p><p><strong>Comment:</strong> Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw P gain</p><p><strong>Comment:</strong> Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 5 (0.1)</td>
  <td style="vertical-align: top;">2.8 </td>
@@ -3600,7 +4221,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_P">MC_YAWRATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate P gain</p><p><strong>Comment:</strong> Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate P gain</p><p><strong>Comment:</strong> Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.6 (0.01)</td>
  <td style="vertical-align: top;">0.2 </td>
@@ -3608,7 +4229,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_I">MC_YAWRATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate I gain</p><p><strong>Comment:</strong> Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate I gain</p><p><strong>Comment:</strong> Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.1 </td>
@@ -3616,7 +4237,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YR_INT_LIM">MC_YR_INT_LIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate integrator limit</p><p><strong>Comment:</strong> Yaw rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large yaw moment trim changes.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate integrator limit</p><p><strong>Comment:</strong> Yaw rate integrator limit. Can be set to increase the amount of integrator available to counteract disturbances or reduced to improve settling time after large yaw moment trim changes.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.30 </td>
@@ -3624,7 +4245,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_D">MC_YAWRATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate D gain</p><p><strong>Comment:</strong> Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate D gain</p><p><strong>Comment:</strong> Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3632,7 +4253,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_FF">MC_YAWRATE_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw rate feedforward</p><p><strong>Comment:</strong> Improves tracking performance.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3640,7 +4261,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAW_FF">MC_YAW_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw feed forward</p><p><strong>Comment:</strong> Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Yaw feed forward</p><p><strong>Comment:</strong> Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.5 </td>
@@ -3648,63 +4269,84 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ROLLRATE_MAX">MC_ROLLRATE_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max roll rate</p><p><strong>Comment:</strong> Limit for roll rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max roll rate</p><p><strong>Comment:</strong> Limit for roll rate in manual and auto modes (except acro). Has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation. This is not only limited by the vehicle's properties, but also by the maximum measurement rate of the gyro.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 360.0 (5)</td>
+ <td style="vertical-align: top;">0.0 > 1800.0 (5)</td>
  <td style="vertical-align: top;">220.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_PITCHRATE_MAX">MC_PITCHRATE_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max pitch rate</p><p><strong>Comment:</strong> Limit for pitch rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max pitch rate</p><p><strong>Comment:</strong> Limit for pitch rate in manual and auto modes (except acro). Has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation. This is not only limited by the vehicle's properties, but also by the maximum measurement rate of the gyro.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 360.0 (5)</td>
+ <td style="vertical-align: top;">0.0 > 1800.0 (5)</td>
  <td style="vertical-align: top;">220.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRATE_MAX">MC_YAWRATE_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max yaw rate</p><p><strong>Comment:</strong> A value of significantly over 120 degrees per second can already lead to mixer saturation.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max yaw rate</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 360.0 (5)</td>
+ <td style="vertical-align: top;">0.0 > 1800.0 (5)</td>
  <td style="vertical-align: top;">200.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_YAWRAUTO_MAX">MC_YAWRAUTO_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max yaw rate in auto mode</p><p><strong>Comment:</strong> Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation. A value of significantly over 60 degrees per second can already lead to mixer saturation. A value of 30 degrees / second is recommended to avoid very audible twitches.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max yaw rate in auto mode</p><p><strong>Comment:</strong> Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 120.0 (5)</td>
+ <td style="vertical-align: top;">0.0 > 360.0 (5)</td>
  <td style="vertical-align: top;">45.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ACRO_R_MAX">MC_ACRO_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro roll rate</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max acro roll rate
+default: 2 turns per second</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1000.0 (5)</td>
- <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;">720.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ACRO_P_MAX">MC_ACRO_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro pitch rate</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max acro pitch rate
+default: 2 turns per second</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1000.0 (5)</td>
- <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;">720.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_ACRO_Y_MAX">MC_ACRO_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max acro yaw rate</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Max acro yaw rate
+default 1.5 turns per second</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1000.0 (5)</td>
- <td style="vertical-align: top;">360.0 </td>
+ <td style="vertical-align: top;">540.0 </td>
  <td style="vertical-align: top;">deg/s</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="MC_ACRO_EXPO">MC_ACRO_EXPO</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Acro Expo factor
+applied to input of all axis: roll, pitch, yaw</p><p><strong>Comment:</strong> 0 Purely linear input curve 1 Purely cubic input curve</p>    <p><b>Module:</b> modules/mc_att_control</p>
+</td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">0.69 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MC_ACRO_SUPEXPO">MC_ACRO_SUPEXPO</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Acro SuperExpo factor
+applied to input of all axis: roll, pitch, yaw</p><p><strong>Comment:</strong> 0 Pure Expo function 0.7 resonable shape enhancement for intuitive stick feel 0.95 very strong bent input curve only near maxima have effect</p>    <p><b>Module:</b> modules/mc_att_control</p>
+</td>
+ <td style="vertical-align: top;">0 > 0.95 </td>
+ <td style="vertical-align: top;">0.7 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="MC_RATT_TH">MC_RATT_TH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Threshold for Rattitude mode</p><p><strong>Comment:</strong> Manual input needed in order to override attitude control rate setpoints and instead pass manual stick inputs as rate setpoints</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Threshold for Rattitude mode</p><p><strong>Comment:</strong> Manual input needed in order to override attitude control rate setpoints and instead pass manual stick inputs as rate setpoints</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.8 </td>
@@ -3712,7 +4354,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_BAT_SCALE_EN">MC_BAT_SCALE_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Battery power level scaler</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The copter should constantly behave as if it was fully charged with reduced max acceleration at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>Battery power level scaler</p><p><strong>Comment:</strong> This compensates for voltage drop of the battery over time by attempting to normalize performance across the operating range of the battery. The copter should constantly behave as if it was fully charged with reduced max acceleration at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery, it will still be 0.5 at 60% battery.</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -3720,7 +4362,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_BREAK_P">MC_TPA_BREAK_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA P Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch P gain</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA P Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch P gain</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.1)</td>
  <td style="vertical-align: top;">1.0 </td>
@@ -3728,7 +4370,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_BREAK_I">MC_TPA_BREAK_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA I Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch I gain</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA I Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch I gain</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.1)</td>
  <td style="vertical-align: top;">1.0 </td>
@@ -3736,7 +4378,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_BREAK_D">MC_TPA_BREAK_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA D Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch D gain</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA D Breakpoint</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Magnitude of throttle setpoint at which to begin attenuating roll/pitch D gain</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.1)</td>
  <td style="vertical-align: top;">1.0 </td>
@@ -3744,7 +4386,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_RATE_P">MC_TPA_RATE_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA Rate P</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch P gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA Rate P</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch P gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3752,7 +4394,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_RATE_I">MC_TPA_RATE_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA Rate I</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch I gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA Rate I</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch I gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3760,11 +4402,171 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MC_TPA_RATE_D">MC_TPA_RATE_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>TPA Rate D</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch D gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> src/modules/mc_att_control</p>
+ <td style="vertical-align: top;"><p>TPA Rate D</p><p><strong>Comment:</strong> Throttle PID Attenuation (TPA) Rate at which to attenuate roll/pitch D gain Attenuation factor is 1.0 when throttle magnitude is below the setpoint Above the setpoint, the attenuation factor is (1 - rate * (throttle - breakpoint) / (1.0 - breakpoint))</p>    <p><b>Module:</b> modules/mc_att_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.05)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ROLL_P">MP_ROLL_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll P gain</p><p><strong>Comment:</strong> Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">6.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ROLLRATE_P">MP_ROLLRATE_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll rate P gain</p><p><strong>Comment:</strong> Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ROLLRATE_I">MP_ROLLRATE_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll rate I gain</p><p><strong>Comment:</strong> Roll rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ROLLRATE_D">MP_ROLLRATE_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll rate D gain</p><p><strong>Comment:</strong> Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.002 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_PITCH_P">MP_PITCH_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch P gain</p><p><strong>Comment:</strong> Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">6.0 </td>
+ <td style="vertical-align: top;">1/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_PITCHRATE_P">MP_PITCHRATE_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch rate P gain</p><p><strong>Comment:</strong> Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_PITCHRATE_I">MP_PITCHRATE_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch rate I gain</p><p><strong>Comment:</strong> Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_PITCHRATE_D">MP_PITCHRATE_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch rate D gain</p><p><strong>Comment:</strong> Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.002 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAW_P">MP_YAW_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw P gain</p><p><strong>Comment:</strong> Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">2.0 </td>
+ <td style="vertical-align: top;">1/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAWRATE_P">MP_YAWRATE_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw rate P gain</p><p><strong>Comment:</strong> Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.3 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAWRATE_I">MP_YAWRATE_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw rate I gain</p><p><strong>Comment:</strong> Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAWRATE_D">MP_YAWRATE_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw rate D gain</p><p><strong>Comment:</strong> Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAW_FF">MP_YAW_FF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw feed forward</p><p><strong>Comment:</strong> Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_YAWRATE_MAX">MP_YAWRATE_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max yaw rate</p><p><strong>Comment:</strong> Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 360.0 </td>
+ <td style="vertical-align: top;">60.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ACRO_R_MAX">MP_ACRO_R_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max acro roll rate</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 360.0 </td>
+ <td style="vertical-align: top;">35.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ACRO_P_MAX">MP_ACRO_P_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max acro pitch rate</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 360.0 </td>
+ <td style="vertical-align: top;">35.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MP_ACRO_Y_MAX">MP_ACRO_Y_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max acro yaw rate</p>    <p><b>Module:</b> examples/mc_att_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">120.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_MAN_R_MAX">MPP_MAN_R_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max manual roll</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 </td>
+ <td style="vertical-align: top;">35.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_MAN_P_MAX">MPP_MAN_P_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max manual pitch</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 </td>
+ <td style="vertical-align: top;">35.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_MAN_Y_MAX">MPP_MAN_Y_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Max manual yaw rate</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">120.0 </td>
+ <td style="vertical-align: top;">deg/s</td>
 </tr>
 </tbody></table>
 
@@ -3777,144 +4579,8 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="MPP_THR_MIN">MPP_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum thrust</p><p><strong>Comment:</strong> Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_THR_MAX">MPP_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum thrust</p><p><strong>Comment:</strong> Limit max allowed thrust.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_P">MPP_Z_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for vertical position error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_VEL_P">MPP_Z_VEL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for vertical velocity error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_VEL_I">MPP_Z_VEL_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integral gain for vertical velocity error</p><p><strong>Comment:</strong> Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.02 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_VEL_D">MPP_Z_VEL_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential gain for vertical velocity error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_VEL_MAX">MPP_Z_VEL_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL).</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">5.0 </td>
- <td style="vertical-align: top;">m/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_Z_FF">MPP_Z_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Vertical velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for altitude control in stabilized modes (ALTCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_P">MPP_XY_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for horizontal position error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_VEL_P">MPP_XY_VEL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for horizontal velocity error</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_VEL_I">MPP_XY_VEL_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integral gain for horizontal velocity error</p><p><strong>Comment:</strong> Non-zero value allows to resist wind.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.02 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_VEL_D">MPP_XY_VEL_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">0.01 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_VEL_MAX">MPP_XY_VEL_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity in AUTO mode and endpoint for position stabilized mode (POSCTRL).</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">5.0 </td>
- <td style="vertical-align: top;">m/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_XY_FF">MPP_XY_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Horizontal velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for position control in position control mode (POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_TILTMAX_AIR">MPP_TILTMAX_AIR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum tilt angle in air</p><p><strong>Comment:</strong> Limits maximum tilt in AUTO and POSCTRL modes during flight.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">45.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_TILTMAX_LND">MPP_TILTMAX_LND</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum tilt during landing</p><p><strong>Comment:</strong> Limits maximum tilt angle on landing.</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">15.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPP_LAND_SPEED">MPP_LAND_SPEED</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Landing descend rate</p>    <p><b>Module:</b> src/examples/mc_pos_control_multiplatform</p>
-</td>
- <td style="vertical-align: top;">0.0 > ? </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;">m/s</td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MPC_THR_MIN">MPC_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum thrust in auto thrust control</p><p><strong>Comment:</strong> It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Minimum thrust in auto thrust control</p><p><strong>Comment:</strong> It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.05 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.12 </td>
@@ -3922,7 +4588,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_THR_HOVER">MPC_THR_HOVER</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Hover thrust</p><p><strong>Comment:</strong> Vertical thrust required to hover. This value is mapped to center stick for manual throttle control. With this value set to the thrust required to hover, transition from manual to ALTCTL mode while hovering will occur with the throttle stick near center, which is then interpreted as (near) zero demand for vertical speed.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Hover thrust</p><p><strong>Comment:</strong> Vertical thrust required to hover. This value is mapped to center stick for manual throttle control. With this value set to the thrust required to hover, transition from manual to ALTCTL mode while hovering will occur with the throttle stick near center, which is then interpreted as (near) zero demand for vertical speed.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.2 > 0.8 (0.01)</td>
  <td style="vertical-align: top;">0.5 </td>
@@ -3930,7 +4596,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_THR_MAX">MPC_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum thrust in auto thrust control</p><p><strong>Comment:</strong> Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum thrust in auto thrust control</p><p><strong>Comment:</strong> Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.95 (0.01)</td>
  <td style="vertical-align: top;">0.9 </td>
@@ -3938,7 +4604,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_MANTHR_MIN">MPC_MANTHR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum manual thrust</p><p><strong>Comment:</strong> Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Minimum manual thrust</p><p><strong>Comment:</strong> Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.08 </td>
@@ -3946,7 +4612,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_MANTHR_MAX">MPC_MANTHR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum manual thrust</p><p><strong>Comment:</strong> Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum manual thrust</p><p><strong>Comment:</strong> Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
  <td style="vertical-align: top;">0.9 </td>
@@ -3954,7 +4620,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_P">MPC_Z_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for vertical position error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Proportional gain for vertical position error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.5 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -3962,7 +4628,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_P">MPC_Z_VEL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for vertical velocity error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Proportional gain for vertical velocity error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.1 > 0.4 </td>
  <td style="vertical-align: top;">0.2 </td>
@@ -3970,7 +4636,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_I">MPC_Z_VEL_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integral gain for vertical velocity error</p><p><strong>Comment:</strong> Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Integral gain for vertical velocity error</p><p><strong>Comment:</strong> Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.01 > 0.1 </td>
  <td style="vertical-align: top;">0.02 </td>
@@ -3978,7 +4644,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_D">MPC_Z_VEL_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential gain for vertical velocity error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Differential gain for vertical velocity error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.1 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -3986,7 +4652,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_MAX_UP">MPC_Z_VEL_MAX_UP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical ascent velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL, POSCTRL).</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum vertical ascent velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL, POSCTRL).</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.5 > 8.0 </td>
  <td style="vertical-align: top;">3.0 </td>
@@ -3994,23 +4660,15 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_VEL_MAX_DN">MPC_Z_VEL_MAX_DN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical descent velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL, POSCTRL).</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum vertical descent velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL, POSCTRL).</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.5 > 4.0 </td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_Z_FF">MPC_Z_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Vertical velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for altitude control in stabilized modes (ALTCTRL, POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
-</td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_P">MPC_XY_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for horizontal position error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Proportional gain for horizontal position error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 2.0 </td>
  <td style="vertical-align: top;">0.95 </td>
@@ -4018,7 +4676,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_VEL_P">MPC_XY_VEL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Proportional gain for horizontal velocity error</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Proportional gain for horizontal velocity error</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.06 > 0.15 </td>
  <td style="vertical-align: top;">0.09 </td>
@@ -4026,7 +4684,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_VEL_I">MPC_XY_VEL_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integral gain for horizontal velocity error</p><p><strong>Comment:</strong> Non-zero value allows to resist wind.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Integral gain for horizontal velocity error</p><p><strong>Comment:</strong> Non-zero value allows to resist wind.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 0.1 </td>
  <td style="vertical-align: top;">0.02 </td>
@@ -4034,7 +4692,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_VEL_D">MPC_XY_VEL_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.005 > 0.1 </td>
  <td style="vertical-align: top;">0.01 </td>
@@ -4042,39 +4700,42 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_CRUISE">MPC_XY_CRUISE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Nominal horizontal velocity</p><p><strong>Comment:</strong> Normal horizontal velocity in AUTO modes (includes also RTL / hold / etc.) and endpoint for position stabilized mode (POSCTRL).</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity in mission</p><p><strong>Comment:</strong> Normal horizontal velocity in AUTO modes (includes also RTL / hold / etc.) and endpoint for position stabilized mode (POSCTRL).</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">3.0 > 20.0 (1)</td>
  <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_TARGET_THRE">MPC_TARGET_THRE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Distance Threshold Horizontal Auto</p><p><strong>Comment:</strong> The distance defines at which point the vehicle has to slow down to reach target if no direct passing to the next target is desired</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><strong id="MPC_CRUISE_90">MPC_CRUISE_90</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Cruise speed when angle prev-current/current-next setpoint
+is 90 degrees. It should be lower than MPC_XY_CRUISE</p><p><strong>Comment:</strong> Applies only in AUTO modes (includes also RTL / hold / etc.)</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
- <td style="vertical-align: top;">1.0 > 50.0 (1)</td>
- <td style="vertical-align: top;">15.0 </td>
- <td style="vertical-align: top;">m</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPC_XY_VEL_MAX">MPC_XY_VEL_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity in AUTO mode. If higher speeds are commanded in a mission they will be capped to this velocity.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
-</td>
- <td style="vertical-align: top;">0.0 > 20.0 (1)</td>
- <td style="vertical-align: top;">8.0 </td>
+ <td style="vertical-align: top;">1.0 > ? (1)</td>
+ <td style="vertical-align: top;">3.0 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_XY_FF">MPC_XY_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Horizontal velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for position control in position control mode (POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><strong id="MPC_VEL_MANUAL">MPC_VEL_MANUAL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity setpoint for manual controlled mode
+If velocity setpoint larger than MPC_XY_VEL_MAX is set, then
+the setpoint will be capped to MPC_XY_VEL_MAX</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">3.0 > 20.0 (1)</td>
+ <td style="vertical-align: top;">10.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_XY_VEL_MAX">MPC_XY_VEL_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity in AUTO mode. If higher speeds are commanded in a mission they will be capped to this velocity.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 20.0 (1)</td>
+ <td style="vertical-align: top;">12.0 </td>
+ <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_TILTMAX_AIR">MPC_TILTMAX_AIR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum tilt angle in air</p><p><strong>Comment:</strong> Limits maximum tilt in AUTO and POSCTRL modes during flight.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum tilt angle in air</p><p><strong>Comment:</strong> Limits maximum tilt in AUTO and POSCTRL modes during flight.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 90.0 </td>
  <td style="vertical-align: top;">45.0 </td>
@@ -4082,7 +4743,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_TILTMAX_LND">MPC_TILTMAX_LND</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum tilt during landing</p><p><strong>Comment:</strong> Limits maximum tilt angle on landing.</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum tilt during landing</p><p><strong>Comment:</strong> Limits maximum tilt angle on landing.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 90.0 </td>
  <td style="vertical-align: top;">12.0 </td>
@@ -4090,31 +4751,23 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_LAND_SPEED">MPC_LAND_SPEED</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Landing descend rate</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Landing descend rate</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
- <td style="vertical-align: top;">0.2 > ? </td>
- <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;">0.6 > ? </td>
+ <td style="vertical-align: top;">0.7 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_TKO_SPEED">MPC_TKO_SPEED</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Takeoff climb rate</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Takeoff climb rate</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">1 > 5 </td>
  <td style="vertical-align: top;">1.5 </td>
  <td style="vertical-align: top;">m/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_MAN_R_MAX">MPC_MAN_R_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual roll</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
-</td>
- <td style="vertical-align: top;">0.0 > 90.0 </td>
- <td style="vertical-align: top;">35.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPC_MAN_P_MAX">MPC_MAN_P_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual pitch</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><strong id="MPC_MAN_TILT_MAX">MPC_MAN_TILT_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximal tilt angle in manual or altitude mode</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 90.0 </td>
  <td style="vertical-align: top;">35.0 </td>
@@ -4122,7 +4775,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_MAN_Y_MAX">MPC_MAN_Y_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Max manual yaw rate</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Max manual yaw rate</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 400 </td>
  <td style="vertical-align: top;">200.0 </td>
@@ -4130,7 +4783,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_HOLD_DZ">MPC_HOLD_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Deadzone of sticks where position hold is enabled</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Deadzone of sticks where position hold is enabled</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 </td>
  <td style="vertical-align: top;">0.1 </td>
@@ -4138,7 +4791,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_HOLD_MAX_XY">MPC_HOLD_MAX_XY</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 3.0 </td>
  <td style="vertical-align: top;">0.8 </td>
@@ -4146,7 +4799,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_HOLD_MAX_Z">MPC_HOLD_MAX_Z</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical velocity for which position hold is enabled (use 0 to disable check)</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum vertical velocity for which position hold is enabled (use 0 to disable check)</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 3.0 </td>
  <td style="vertical-align: top;">0.6 </td>
@@ -4154,7 +4807,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_VELD_LP">MPC_VELD_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Low pass filter cut freq. for numerical velocity derivative</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Low pass filter cut freq. for numerical velocity derivative</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0.0 > 10 </td>
  <td style="vertical-align: top;">5.0 </td>
@@ -4162,35 +4815,64 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_ACC_HOR_MAX">MPC_ACC_HOR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizonal acceleration in velocity controlled modes</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
-</td>
- <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
- <td style="vertical-align: top;">5.0 </td>
- <td style="vertical-align: top;">m/s/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MPC_DEC_HOR_MAX">MPC_DEC_HOR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum horizonal braking deceleration in velocity controlled modes</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Maximum horizontal acceleration for auto mode and maximum deceleration for manual mode</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
  <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;">m/s/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_ACC_UP_MAX">MPC_ACC_UP_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical acceleration in velocity controlled modes upward</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><strong id="MPC_ACC_HOR">MPC_ACC_HOR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Acceleration for auto and for manual</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
  <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;">m/s/s</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MPC_ACC_DOWN_MAX">MPC_ACC_DOWN_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum vertical acceleration in velocity controlled modes down</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><strong id="MPC_DEC_HOR_SLOW">MPC_DEC_HOR_SLOW</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Slow horizontal manual deceleration for manual mode</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
- <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
+ <td style="vertical-align: top;">0.5 > 10.0 (1)</td>
  <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_ACC_UP_MAX">MPC_ACC_UP_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum vertical acceleration in velocity controlled modes upward</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
+ <td style="vertical-align: top;">10.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_ACC_DOWN_MAX">MPC_ACC_DOWN_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum vertical acceleration in velocity controlled modes down</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">2.0 > 15.0 (1)</td>
+ <td style="vertical-align: top;">10.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_JERK_MAX">MPC_JERK_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum jerk in manual controlled mode for BRAKING to zero.
+If this value is below MPC_JERK_MIN, the acceleration limit in xy and z
+is MPC_ACC_HOR_MAX and MPC_ACC_UP_MAX respectively instantaneously when the
+user demands brake (=zero stick input).
+Otherwise the acceleration limit increases from current acceleration limit
+towards MPC_ACC_HOR_MAX/MPC_ACC_UP_MAX with jerk limit</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 15.0 (1)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">m/s/s/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_JERK_MIN">MPC_JERK_MIN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Minimum jerk in manual controlled mode for BRAKING to zero</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.5 > 10.0 (1)</td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">m/s/s/s</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_ALT_MODE">MPC_ALT_MODE</strong> (INT32)</td>
@@ -4199,7 +4881,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 
 <li><strong>1:</strong> Terrain following</li> 
 </ul>
-   <p><b>Module:</b> src/modules/mc_pos_control</p>
+   <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4207,7 +4889,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_XY_MAN_EXPO">MPC_XY_MAN_EXPO</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual control stick exponential curve sensitivity attenuation with small velocity setpoints</p><p><strong>Comment:</strong> The higher the value the less sensitivity the stick has around zero while still reaching the maximum value with full stick deflection. 0 Purely linear input curve (default) 1 Purely cubic input curve</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Manual control stick exponential curve sensitivity attenuation with small velocity setpoints</p><p><strong>Comment:</strong> The higher the value the less sensitivity the stick has around zero while still reaching the maximum value with full stick deflection. 0 Purely linear input curve (default) 1 Purely cubic input curve</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -4215,7 +4897,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_Z_MAN_EXPO">MPC_Z_MAN_EXPO</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Manual control stick vertical exponential curve</p><p><strong>Comment:</strong> The higher the value the less sensitivity the stick has around zero while still reaching the maximum value with full stick deflection. 0 Purely linear input curve (default) 1 Purely cubic input curve</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Manual control stick vertical exponential curve</p><p><strong>Comment:</strong> The higher the value the less sensitivity the stick has around zero while still reaching the maximum value with full stick deflection. 0 Purely linear input curve (default) 1 Purely cubic input curve</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -4223,7 +4905,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_LAND_ALT1">MPC_LAND_ALT1</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Altitude for 1. step of slow landing (descend)</p><p><strong>Comment:</strong> Below this altitude descending velocity gets limited to a value between "MPC_Z_VEL_MAX" and "MPC_LAND_SPEED" to enable a smooth descent experience Value needs to be higher than "MPC_LAND_ALT2"</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Altitude for 1. step of slow landing (descend)</p><p><strong>Comment:</strong> Below this altitude descending velocity gets limited to a value between "MPC_Z_VEL_MAX" and "MPC_LAND_SPEED" to enable a smooth descent experience Value needs to be higher than "MPC_LAND_ALT2"</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 122 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -4231,11 +4913,155 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MPC_LAND_ALT2">MPC_LAND_ALT2</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Altitude for 2. step of slow landing (landing)</p><p><strong>Comment:</strong> Below this altitude descending velocity gets limited to "MPC_LAND_SPEED" Value needs to be lower than "MPC_LAND_ALT1"</p>    <p><b>Module:</b> src/modules/mc_pos_control</p>
+ <td style="vertical-align: top;"><p>Altitude for 2. step of slow landing (landing)</p><p><strong>Comment:</strong> Below this altitude descending velocity gets limited to "MPC_LAND_SPEED" Value needs to be lower than "MPC_LAND_ALT1"</p>    <p><b>Module:</b> modules/mc_pos_control</p>
 </td>
  <td style="vertical-align: top;">0 > 122 </td>
  <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;">m</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPC_TKO_RAMP_T">MPC_TKO_RAMP_T</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Position control smooth takeoff ramp time constant</p><p><strong>Comment:</strong> Increasing this value will make automatic and manual takeoff slower. If it's too slow the drone might scratch the ground and tip over.</p>    <p><b>Module:</b> modules/mc_pos_control</p>
+</td>
+ <td style="vertical-align: top;">0.1 > 1 </td>
+ <td style="vertical-align: top;">0.4 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_THR_MIN">MPP_THR_MIN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Minimum thrust</p><p><strong>Comment:</strong> Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_THR_MAX">MPP_THR_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum thrust</p><p><strong>Comment:</strong> Limit max allowed thrust.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_P">MPP_Z_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Proportional gain for vertical position error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_VEL_P">MPP_Z_VEL_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Proportional gain for vertical velocity error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_VEL_I">MPP_Z_VEL_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Integral gain for vertical velocity error</p><p><strong>Comment:</strong> Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.02 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_VEL_D">MPP_Z_VEL_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential gain for vertical velocity error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_VEL_MAX">MPP_Z_VEL_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum vertical velocity</p><p><strong>Comment:</strong> Maximum vertical velocity in AUTO mode and endpoint for stabilized modes (ALTCTRL).</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_Z_FF">MPP_Z_FF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Vertical velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for altitude control in stabilized modes (ALTCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_P">MPP_XY_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Proportional gain for horizontal position error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_VEL_P">MPP_XY_VEL_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Proportional gain for horizontal velocity error</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_VEL_I">MPP_XY_VEL_I</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Integral gain for horizontal velocity error</p><p><strong>Comment:</strong> Non-zero value allows to resist wind.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.02 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_VEL_D">MPP_XY_VEL_D</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">0.01 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_VEL_MAX">MPP_XY_VEL_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum horizontal velocity</p><p><strong>Comment:</strong> Maximum horizontal velocity in AUTO mode and endpoint for position stabilized mode (POSCTRL).</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">5.0 </td>
+ <td style="vertical-align: top;">m/s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_XY_FF">MPP_XY_FF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Horizontal velocity feed forward</p><p><strong>Comment:</strong> Feed forward weight for position control in position control mode (POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;">0.5 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_TILTMAX_AIR">MPP_TILTMAX_AIR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum tilt angle in air</p><p><strong>Comment:</strong> Limits maximum tilt in AUTO and POSCTRL modes during flight.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 </td>
+ <td style="vertical-align: top;">45.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_TILTMAX_LND">MPP_TILTMAX_LND</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum tilt during landing</p><p><strong>Comment:</strong> Limits maximum tilt angle on landing.</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > 90.0 </td>
+ <td style="vertical-align: top;">15.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="MPP_LAND_SPEED">MPP_LAND_SPEED</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Landing descend rate</p>    <p><b>Module:</b> examples/mc_pos_control_multiplatform</p>
+</td>
+ <td style="vertical-align: top;">0.0 > ? </td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;">m/s</td>
 </tr>
 </tbody></table>
 
@@ -4248,111 +5074,198 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_REV1">PWM_AUX_REV1</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Invert direction of aux output channel 1</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_RATE">PWM_RATE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the PWM output frequency for the main outputs</p><p><strong>Comment:</strong> Set to 400 for industry default or 1000 for high frequency ESCs. Set to 0 for Oneshot125.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2000 </td>
+ <td style="vertical-align: top;">400 </td>
+ <td style="vertical-align: top;">Hz</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_REV2">PWM_AUX_REV2</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Invert direction of aux output channel 2</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MIN">PWM_MIN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the minimum PWM for the main outputs</p><p><strong>Comment:</strong> Set to 1000 for industry default or 900 to increase servo travel.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">800 > 1400 </td>
+ <td style="vertical-align: top;">1000 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_REV3">PWM_AUX_REV3</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Invert direction of aux output channel 3</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAX">PWM_MAX</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the maximum PWM for the main outputs</p><p><strong>Comment:</strong> Set to 2000 for industry default or 2100 to increase servo travel.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1600 > 2200 </td>
+ <td style="vertical-align: top;">2000 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_REV4">PWM_AUX_REV4</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Invert direction of aux output channel 4</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_DISARMED">PWM_DISARMED</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main outputs</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. The main use of this parameter is to silence ESCs when they are disarmed.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 > 2200 </td>
+ <td style="vertical-align: top;">900 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_REV5">PWM_AUX_REV5</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Invert direction of aux output channel 5</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS1">PWM_MAIN_DIS1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 1 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_REV6">PWM_AUX_REV6</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Invert direction of aux output channel 6</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS2">PWM_MAIN_DIS2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 2 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM1">PWM_AUX_TRIM1</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 1</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS3">PWM_MAIN_DIS3</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 3 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;">-0.2 > 0.2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM2">PWM_AUX_TRIM2</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 2</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS4">PWM_MAIN_DIS4</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 4 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;">-0.2 > 0.2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM3">PWM_AUX_TRIM3</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 3</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS5">PWM_MAIN_DIS5</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 5 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;">-0.2 > 0.2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM4">PWM_AUX_TRIM4</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 4</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS6">PWM_MAIN_DIS6</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 6 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;">-0.2 > 0.2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM5">PWM_AUX_TRIM5</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 5</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS7">PWM_MAIN_DIS7</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 7 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;">-0.2 > 0.2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM6">PWM_AUX_TRIM6</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 6</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4fmu</p>
+ <td style="vertical-align: top;"><strong id="PWM_MAIN_DIS8">PWM_MAIN_DIS8</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the main 8 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
 </td>
- <td style="vertical-align: top;">-0.2 > 0.2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS1">PWM_AUX_DIS1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 1 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS2">PWM_AUX_DIS2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 2 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS3">PWM_AUX_DIS3</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 3 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS4">PWM_AUX_DIS4</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 4 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS5">PWM_AUX_DIS5</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 5 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DIS6">PWM_AUX_DIS6</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for the AUX 6 output</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. When set to -1 the value for PWM_AUX_DISARMED will be used</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">-1 > 2200 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_MIN">PWM_AUX_MIN</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the minimum PWM for the auxiliary outputs</p><p><strong>Comment:</strong> Set to 1000 for default or 900 to increase servo travel</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">800 > 1400 </td>
+ <td style="vertical-align: top;">1000 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_MAX">PWM_AUX_MAX</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the maximum PWM for the auxiliary outputs</p><p><strong>Comment:</strong> Set to 2000 for default or 2100 to increase servo travel</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">1600 > 2200 </td>
+ <td style="vertical-align: top;">2000 </td>
+ <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_DISARMED">PWM_AUX_DISARMED</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set the disarmed PWM for auxiliary outputs</p><p><strong>Comment:</strong> This is the PWM pulse the autopilot is outputting if not armed. The main use of this parameter is to silence ESCs when they are disarmed.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">0 > 2200 </td>
+ <td style="vertical-align: top;">1500 </td>
+ <td style="vertical-align: top;">us</td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV1">PWM_MAIN_REV1</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 1</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4361,7 +5274,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV2">PWM_MAIN_REV2</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 2</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4370,7 +5283,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV3">PWM_MAIN_REV3</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 3</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4379,7 +5292,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV4">PWM_MAIN_REV4</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 4</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4388,7 +5301,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV5">PWM_MAIN_REV5</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 5</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4397,7 +5310,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV6">PWM_MAIN_REV6</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 6</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4406,7 +5319,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV7">PWM_MAIN_REV7</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 7</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4415,7 +5328,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_REV8">PWM_MAIN_REV8</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Invert direction of main output channel 8</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/drivers/px4io</p>
+ <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
@@ -4423,7 +5336,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM1">PWM_MAIN_TRIM1</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 1</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 1</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4431,7 +5344,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM2">PWM_MAIN_TRIM2</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 2</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 2</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4439,7 +5352,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM3">PWM_MAIN_TRIM3</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 3</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 3</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4447,7 +5360,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM4">PWM_MAIN_TRIM4</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 4</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 4</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4455,7 +5368,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM5">PWM_MAIN_TRIM5</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 5</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 5</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4463,7 +5376,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM6">PWM_MAIN_TRIM6</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 6</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 6</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4471,7 +5384,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM7">PWM_MAIN_TRIM7</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 7</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 7</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4479,7 +5392,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_MAIN_TRIM8">PWM_MAIN_TRIM8</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Trim value for main output channel 8</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>Trim value for main output channel 8</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">-0.2 > 0.2 </td>
  <td style="vertical-align: top;">0 </td>
@@ -4487,78 +5400,117 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="PWM_SBUS_MODE">PWM_SBUS_MODE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>S.BUS out</p><p><strong>Comment:</strong> Set to 1 to enable S.BUS version 1 output instead of RSSI.</p>    <p><b>Module:</b> src/drivers/px4io</p>
+ <td style="vertical-align: top;"><p>S.BUS out</p><p><strong>Comment:</strong> Set to 1 to enable S.BUS version 1 output instead of RSSI.</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_RATE">PWM_RATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the PWM output frequency for the main outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 400 for industry default or 1000 for high frequency ESCs.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_REV1">PWM_AUX_REV1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Invert direction of aux output channel 1</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
- <td style="vertical-align: top;">-1 > 2000 </td>
- <td style="vertical-align: top;">400 </td>
- <td style="vertical-align: top;">Hz</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_MIN">PWM_MIN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the minimum PWM for the main outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 1000 for industry default or 900 to increase servo travel.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_REV2">PWM_AUX_REV2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Invert direction of aux output channel 2</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
- <td style="vertical-align: top;">800 > 1400 </td>
- <td style="vertical-align: top;">1000 </td>
- <td style="vertical-align: top;">us</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_MAX">PWM_MAX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the maximum PWM for the main outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 2000 for industry default or 2100 to increase servo travel.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_REV3">PWM_AUX_REV3</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Invert direction of aux output channel 3</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
- <td style="vertical-align: top;">1600 > 2200 </td>
- <td style="vertical-align: top;">2000 </td>
- <td style="vertical-align: top;">us</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_DISARMED">PWM_DISARMED</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the disarmed PWM for the main outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. This is the PWM pulse the autopilot is outputting if not armed. The main use of this parameter is to silence ESCs when they are disarmed.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_REV4">PWM_AUX_REV4</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Invert direction of aux output channel 4</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
- <td style="vertical-align: top;">0 > 2200 </td>
- <td style="vertical-align: top;">900 </td>
- <td style="vertical-align: top;">us</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_MIN">PWM_AUX_MIN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the minimum PWM for the auxiliary outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 1000 for default or 900 to increase servo travel</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_REV5">PWM_AUX_REV5</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Invert direction of aux output channel 5</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
- <td style="vertical-align: top;">800 > 1400 </td>
- <td style="vertical-align: top;">1000 </td>
- <td style="vertical-align: top;">us</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_MAX">PWM_AUX_MAX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the maximum PWM for the auxiliary outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. Set to 2000 for default or 2100 to increase servo travel</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_REV6">PWM_AUX_REV6</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Invert direction of aux output channel 6</p><p><strong>Comment:</strong> Set to 1 to invert the channel, 0 for default direction.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
 </td>
- <td style="vertical-align: top;">1600 > 2200 </td>
- <td style="vertical-align: top;">2000 </td>
- <td style="vertical-align: top;">us</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="PWM_AUX_DISARMED">PWM_AUX_DISARMED</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set the disarmed PWM for auxiliary outputs</p><p><strong>Comment:</strong> IMPORTANT: CHANGING THIS PARAMETER REQUIRES A COMPLETE SYSTEM REBOOT IN ORDER TO APPLY THE CHANGES. This is the PWM pulse the autopilot is outputting if not armed. The main use of this parameter is to silence ESCs when they are disarmed.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM1">PWM_AUX_TRIM1</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 1</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
- <td style="vertical-align: top;">0 > 2200 </td>
- <td style="vertical-align: top;">1500 </td>
- <td style="vertical-align: top;">us</td>
+ <td style="vertical-align: top;">-0.2 > 0.2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM2">PWM_AUX_TRIM2</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 2</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;">-0.2 > 0.2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM3">PWM_AUX_TRIM3</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 3</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;">-0.2 > 0.2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM4">PWM_AUX_TRIM4</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 4</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;">-0.2 > 0.2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM5">PWM_AUX_TRIM5</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 5</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;">-0.2 > 0.2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="PWM_AUX_TRIM6">PWM_AUX_TRIM6</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Trim value for FMU PWM output channel 6</p><p><strong>Comment:</strong> Set to normalized offset</p>    <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;">-0.2 > 0.2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="THR_MDL_FAC">THR_MDL_FAC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Thrust to PWM model parameter</p><p><strong>Comment:</strong> Parameter used to model the relationship between static thrust and motor input PWM. Model is: thrust = (1-factor)*PWM + factor * PWM^2</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Thrust to PWM model parameter</p><p><strong>Comment:</strong> Parameter used to model the relationship between static thrust and motor input PWM. Model is: thrust = (1-factor)*PWM + factor * PWM^2</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;">0.0 > 1.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -4566,7 +5518,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="MOT_SLEW_MAX">MOT_SLEW_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimum motor rise time (slew rate limit)</p><p><strong>Comment:</strong> Minimum time allowed for the motor input signal to pass through a range of 1000 PWM units. A value x means that the motor signal can only go from 1000 to 2000 PWM in maximum x seconds. Zero means that slew rate limiting is disabled.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Minimum motor rise time (slew rate limit)</p><p><strong>Comment:</strong> Minimum time allowed for the motor input signal to pass through a range of 1000 PWM units. A value x means that the motor signal can only go from 1000 to 2000 PWM in maximum x seconds. Zero means that slew rate limiting is disabled.</p>    <p><b>Module:</b> drivers/px4fmu</p>
 </td>
  <td style="vertical-align: top;">0.0 > ? </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -4577,7 +5529,7 @@ if required for the gimbal (only in AUX output mode)</p>    </td>
 ## Payload drop
 
 
-The module where these parameters are defined is: *src/modules/bottle_drop*.
+The module where these parameters are defined is: *examples/bottle_drop*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -4632,7 +5584,7 @@ The module where these parameters are defined is: *src/modules/bottle_drop*.
 ## Position Estimator
 
 
-The module where these parameters are defined is: *src/examples/ekf_att_pos_estimator*.
+The module where these parameters are defined is: *examples/ekf_att_pos_estimator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -4799,7 +5751,7 @@ The module where these parameters are defined is: *src/examples/ekf_att_pos_esti
 ## Position Estimator INAV
 
 
-The module where these parameters are defined is: *src/modules/position_estimator_inav*.
+The module where these parameters are defined is: *modules/position_estimator_inav*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -5004,26 +5956,6 @@ The module where these parameters are defined is: *src/modules/position_estimato
 </tr>
 </tbody></table>
 
-## RC Receiver Configuration
-
-
-The module where these parameters are defined is: *src/platforms/qurt/fc_addon/rc_receiver*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="RC_RECEIVER_TYPE">RC_RECEIVER_TYPE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>RC receiver type</p><p><strong>Comment:</strong> Acceptable values: - RC_RECEIVER_SPEKTRUM = 1, - RC_RECEIVER_LEMONRX = 2,</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-</tbody></table>
-
 ## Radio Calibration
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
@@ -5033,32 +5965,8 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="TRIM_ROLL">TRIM_ROLL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Roll trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="TRIM_PITCH">TRIM_PITCH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Pitch trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="TRIM_YAW">TRIM_YAW</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Yaw trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="RC1_MIN">RC1_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 Minimum</p><p><strong>Comment:</strong> Minimum value for RC channel 1</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 minimum</p><p><strong>Comment:</strong> Minimum value for RC channel 1</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000.0 </td>
@@ -5066,7 +5974,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_TRIM">RC1_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 Trim</p><p><strong>Comment:</strong> Mid point value (same as min for throttle)</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 trim</p><p><strong>Comment:</strong> Mid point value (same as min for throttle)</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500.0 </td>
@@ -5074,7 +5982,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_MAX">RC1_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 Maximum</p><p><strong>Comment:</strong> Maximum value for RC channel 1</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 maximum</p><p><strong>Comment:</strong> Maximum value for RC channel 1</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000.0 </td>
@@ -5082,7 +5990,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_REV">RC1_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5090,7 +5998,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC1_DZ">RC1_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 1 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 1 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5098,7 +6006,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_MIN">RC2_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000.0 </td>
@@ -5106,7 +6014,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_TRIM">RC2_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500.0 </td>
@@ -5114,7 +6022,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_MAX">RC2_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000.0 </td>
@@ -5122,7 +6030,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_REV">RC2_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5130,7 +6038,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC2_DZ">RC2_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 2 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 2 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5138,7 +6046,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_MIN">RC3_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5146,7 +6054,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_TRIM">RC3_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5154,7 +6062,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_MAX">RC3_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5162,7 +6070,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_REV">RC3_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5170,7 +6078,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC3_DZ">RC3_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 3 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 3 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5178,7 +6086,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_MIN">RC4_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5186,7 +6094,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_TRIM">RC4_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5194,7 +6102,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_MAX">RC4_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5202,7 +6110,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_REV">RC4_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5210,7 +6118,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC4_DZ">RC4_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 4 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 4 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5218,7 +6126,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_MIN">RC5_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5226,7 +6134,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_TRIM">RC5_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5234,7 +6142,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_MAX">RC5_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5242,7 +6150,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_REV">RC5_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5250,7 +6158,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC5_DZ">RC5_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 5 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 5 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5258,7 +6166,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_MIN">RC6_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5266,7 +6174,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_TRIM">RC6_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5274,7 +6182,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_MAX">RC6_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5282,7 +6190,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_REV">RC6_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5290,7 +6198,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC6_DZ">RC6_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 6 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 6 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5298,7 +6206,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_MIN">RC7_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5306,7 +6214,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_TRIM">RC7_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5314,7 +6222,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_MAX">RC7_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5322,7 +6230,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_REV">RC7_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5330,7 +6238,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC7_DZ">RC7_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 7 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 7 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5338,7 +6246,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_MIN">RC8_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5346,7 +6254,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_TRIM">RC8_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5354,7 +6262,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_MAX">RC8_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5362,7 +6270,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_REV">RC8_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5370,7 +6278,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC8_DZ">RC8_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 8 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 8 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">10.0 </td>
@@ -5378,7 +6286,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_MIN">RC9_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5386,7 +6294,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_TRIM">RC9_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5394,7 +6302,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_MAX">RC9_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5402,7 +6310,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_REV">RC9_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5410,7 +6318,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC9_DZ">RC9_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 9 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 9 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5418,7 +6326,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_MIN">RC10_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5426,7 +6334,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_TRIM">RC10_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5434,7 +6342,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_MAX">RC10_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5442,7 +6350,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_REV">RC10_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5450,7 +6358,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC10_DZ">RC10_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 10 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 10 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5458,7 +6366,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_MIN">RC11_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5466,7 +6374,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_TRIM">RC11_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5474,7 +6382,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_MAX">RC11_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5482,7 +6390,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_REV">RC11_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5490,7 +6398,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC11_DZ">RC11_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 11 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 11 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5498,7 +6406,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_MIN">RC12_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5506,7 +6414,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_TRIM">RC12_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5514,7 +6422,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_MAX">RC12_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5522,7 +6430,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_REV">RC12_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5530,7 +6438,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC12_DZ">RC12_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 12 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 12 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5538,7 +6446,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_MIN">RC13_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5546,7 +6454,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_TRIM">RC13_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5554,7 +6462,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_MAX">RC13_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5562,7 +6470,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_REV">RC13_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5570,7 +6478,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC13_DZ">RC13_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 13 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 13 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5578,7 +6486,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_MIN">RC14_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5586,7 +6494,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_TRIM">RC14_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5594,7 +6502,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_MAX">RC14_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5602,7 +6510,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_REV">RC14_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5610,7 +6518,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC14_DZ">RC14_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 14 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 14 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5618,7 +6526,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_MIN">RC15_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5626,7 +6534,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_TRIM">RC15_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5634,7 +6542,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_MAX">RC15_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5642,7 +6550,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_REV">RC15_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5650,7 +6558,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC15_DZ">RC15_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 15 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 15 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5658,7 +6566,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_MIN">RC16_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5666,7 +6574,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_TRIM">RC16_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5674,7 +6582,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_MAX">RC16_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5682,7 +6590,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_REV">RC16_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5690,7 +6598,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC16_DZ">RC16_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 16 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 16 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5698,7 +6606,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_MIN">RC17_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5706,7 +6614,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_TRIM">RC17_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5714,7 +6622,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_MAX">RC17_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5722,7 +6630,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_REV">RC17_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5730,7 +6638,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC17_DZ">RC17_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 17 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 17 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5738,7 +6646,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_MIN">RC18_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 Minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 minimum</p><p><strong>Comment:</strong> Minimum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 1500.0 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -5746,7 +6654,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_TRIM">RC18_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 Trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 trim</p><p><strong>Comment:</strong> Mid point value (has to be set to the same as min for throttle channel).</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">800.0 > 2200.0 </td>
  <td style="vertical-align: top;">1500 </td>
@@ -5754,7 +6662,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_MAX">RC18_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 Maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 maximum</p><p><strong>Comment:</strong> Maximum value for this channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">1500.0 > 2200.0 </td>
  <td style="vertical-align: top;">2000 </td>
@@ -5762,7 +6670,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_REV">RC18_REV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 Reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 reverse</p><p><strong>Comment:</strong> Set to -1 to reverse channel.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">-1.0 > 1.0 </td>
  <td style="vertical-align: top;">1.0 </td>
@@ -5770,7 +6678,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC18_DZ">RC18_DZ</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>RC Channel 18 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel 18 dead zone</p><p><strong>Comment:</strong> The +- range of this value around the trim value will be considered as zero.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0.0 > 100.0 </td>
  <td style="vertical-align: top;">0.0 </td>
@@ -5783,30 +6691,15 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>1:</strong> Relay controls DSM power</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="RC_DSM_BIND">RC_DSM_BIND</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>DSM binding trigger</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Inactive</li> 
-
-<li><strong>0:</strong> Start DSM2 bind</li> 
-
-<li><strong>1:</strong> Start DSMX bind</li> 
-</ul>
-   <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">-1 > 1 </td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="RC_CHAN_CNT">RC_CHAN_CNT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>RC channel count</p><p><strong>Comment:</strong> This parameter is used by Ground Station software to save the number of channels which were used during RC calibration. It is only meant for ground station use.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC channel count</p><p><strong>Comment:</strong> This parameter is used by Ground Station software to save the number of channels which were used during RC calibration. It is only meant for ground station use.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -5814,7 +6707,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_TH_USER">RC_TH_USER</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>RC mode switch threshold automatic distribution</p><p><strong>Comment:</strong> This parameter is used by Ground Station software to specify whether the threshold values for flight mode switches were automatically calculated. 0 indicates that the threshold values were set by the user. Any other value indicates that the threshold value where automatically set by the ground station software. It is only meant for ground station use.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>RC mode switch threshold automatic distribution</p><p><strong>Comment:</strong> This parameter is used by Ground Station software to specify whether the threshold values for flight mode switches were automatically calculated. 0 indicates that the threshold values were set by the user. Any other value indicates that the threshold value where automatically set by the ground station software. It is only meant for ground station use.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -5861,7 +6754,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -5908,7 +6801,54 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">0 > 18 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="RC_MAP_FAILSAFE">RC_MAP_FAILSAFE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Failsafe channel mapping</p><p><strong>Comment:</strong> The RC mapping index indicates which channel is used for failsafe If 0, whichever channel is mapped to throttle is used otherwise the value indicates the specific RC channel to use</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Unassigned</li> 
+
+<li><strong>1:</strong> Channel 1</li> 
+
+<li><strong>2:</strong> Channel 2</li> 
+
+<li><strong>3:</strong> Channel 3</li> 
+
+<li><strong>4:</strong> Channel 4</li> 
+
+<li><strong>5:</strong> Channel 5</li> 
+
+<li><strong>6:</strong> Channel 6</li> 
+
+<li><strong>7:</strong> Channel 7</li> 
+
+<li><strong>8:</strong> Channel 8</li> 
+
+<li><strong>9:</strong> Channel 9</li> 
+
+<li><strong>10:</strong> Channel 10</li> 
+
+<li><strong>11:</strong> Channel 11</li> 
+
+<li><strong>12:</strong> Channel 12</li> 
+
+<li><strong>13:</strong> Channel 13</li> 
+
+<li><strong>14:</strong> Channel 14</li> 
+
+<li><strong>15:</strong> Channel 15</li> 
+
+<li><strong>16:</strong> Channel 16</li> 
+
+<li><strong>17:</strong> Channel 17</li> 
+
+<li><strong>18:</strong> Channel 18</li> 
+</ul>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -5955,7 +6895,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6002,7 +6942,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6010,7 +6950,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX1">RC_MAP_AUX1</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX1 Passthrough RC Channel</p><p><strong>Comment:</strong> Default function: Camera pitch</p> <strong>Values:</strong><ul>
+ <td style="vertical-align: top;"><p>AUX1 Passthrough RC channel</p><p><strong>Comment:</strong> Default function: Camera pitch</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Unassigned</li> 
 
 <li><strong>1:</strong> Channel 1</li> 
@@ -6049,7 +6989,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6057,7 +6997,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX2">RC_MAP_AUX2</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX2 Passthrough RC Channel</p><p><strong>Comment:</strong> Default function: Camera roll</p> <strong>Values:</strong><ul>
+ <td style="vertical-align: top;"><p>AUX2 Passthrough RC channel</p><p><strong>Comment:</strong> Default function: Camera roll</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Unassigned</li> 
 
 <li><strong>1:</strong> Channel 1</li> 
@@ -6096,7 +7036,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6104,7 +7044,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX3">RC_MAP_AUX3</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX3 Passthrough RC Channel</p><p><strong>Comment:</strong> Default function: Camera azimuth / yaw</p> <strong>Values:</strong><ul>
+ <td style="vertical-align: top;"><p>AUX3 Passthrough RC channel</p><p><strong>Comment:</strong> Default function: Camera azimuth / yaw</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Unassigned</li> 
 
 <li><strong>1:</strong> Channel 1</li> 
@@ -6143,7 +7083,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6151,7 +7091,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX4">RC_MAP_AUX4</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX4 Passthrough RC Channel</p> <strong>Values:</strong><ul>
+ <td style="vertical-align: top;"><p>AUX4 Passthrough RC channel</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Unassigned</li> 
 
 <li><strong>1:</strong> Channel 1</li> 
@@ -6190,7 +7130,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6198,7 +7138,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_MAP_AUX5">RC_MAP_AUX5</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>AUX5 Passthrough RC Channel</p> <strong>Values:</strong><ul>
+ <td style="vertical-align: top;"><p>AUX5 Passthrough RC channel</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Unassigned</li> 
 
 <li><strong>1:</strong> Channel 1</li> 
@@ -6237,7 +7177,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6284,7 +7224,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6331,7 +7271,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6378,7 +7318,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6386,11 +7326,51 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_FAILS_THR">RC_FAILS_THR</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Failsafe channel PWM threshold</p><p><strong>Comment:</strong> Set to a value slightly above the PWM value assumed by throttle in a failsafe event, but ensure it is below the PWM value assumed by throttle during normal operation.</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Failsafe channel PWM threshold</p><p><strong>Comment:</strong> Set to a value slightly above the PWM value assumed by throttle in a failsafe event, but ensure it is below the PWM value assumed by throttle during normal operation.</p>    <p><b>Module:</b> modules/sensors</p>
 </td>
  <td style="vertical-align: top;">0 > 2200 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;">us</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="RC_FLT_SMP_RATE">RC_FLT_SMP_RATE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Sample rate of the remote control values for the low pass filter on roll,pitch, yaw and throttle</p><p><strong>Comment:</strong> Has an influence on the cutoff frequency precision.</p>    <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">1.0 > ? </td>
+ <td style="vertical-align: top;">50.0 </td>
+ <td style="vertical-align: top;">Hz</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="RC_FLT_CUTOFF">RC_FLT_CUTOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Cutoff frequency for the low pass filter on roll,pitch, yaw and throttle</p><p><strong>Comment:</strong> Does not get set unless below RC_FLT_SMP_RATE/2 because of filter instability characteristics.</p>    <p><b>Module:</b> modules/sensors</p>
+</td>
+ <td style="vertical-align: top;">0.1 > ? </td>
+ <td style="vertical-align: top;">10.0 </td>
+ <td style="vertical-align: top;">Hz</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TRIM_ROLL">TRIM_ROLL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Roll trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> modules/commander</p>
+</td>
+ <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TRIM_PITCH">TRIM_PITCH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Pitch trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> modules/commander</p>
+</td>
+ <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TRIM_YAW">TRIM_YAW</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Yaw trim</p><p><strong>Comment:</strong> The trim value is the actuator control value the system needs for straight and level flight. It can be calibrated by flying manually straight and level using the RC trims and copying them using the GCS.</p>    <p><b>Module:</b> modules/commander</p>
+</td>
+ <td style="vertical-align: top;">-0.25 > 0.25 (0.01)</td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_CHAN">RC_RSSI_PWM_CHAN</strong> (INT32)</td>
@@ -6433,7 +7413,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 
 <li><strong>18:</strong> Channel 18</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sensors</p>
+   <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">0 > 18 </td>
  <td style="vertical-align: top;">0 </td>
@@ -6441,7 +7421,7 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_MAX">RC_RSSI_PWM_MAX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Max input value for RSSI reading</p><p><strong>Comment:</strong> Only used if RC_RSSI_PWM_CHAN > 0</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Max input value for RSSI reading</p><p><strong>Comment:</strong> Only used if RC_RSSI_PWM_CHAN > 0</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">0 > 2000 </td>
  <td style="vertical-align: top;">1000 </td>
@@ -6449,34 +7429,18 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/r
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="RC_RSSI_PWM_MIN">RC_RSSI_PWM_MIN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Min input value for RSSI reading</p><p><strong>Comment:</strong> Only used if RC_RSSI_PWM_CHAN > 0</p>    <p><b>Module:</b> src/modules/sensors</p>
+ <td style="vertical-align: top;"><p>Min input value for RSSI reading</p><p><strong>Comment:</strong> Only used if RC_RSSI_PWM_CHAN > 0</p>    <p><b>Module:</b> drivers/px4io</p>
 </td>
  <td style="vertical-align: top;">0 > 2000 </td>
  <td style="vertical-align: top;">2000 </td>
  <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="RC_FLT_SMP_RATE">RC_FLT_SMP_RATE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Sample rate of the remote control values for the low pass filter on roll,pitch, yaw and throttle</p><p><strong>Comment:</strong> Has an influence on the cutoff frequency precision.</p>    <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">1.0 > ? </td>
- <td style="vertical-align: top;">50.0 </td>
- <td style="vertical-align: top;">Hz</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="RC_FLT_CUTOFF">RC_FLT_CUTOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Cutoff frequency for the low pass filter on roll,pitch, yaw and throttle</p><p><strong>Comment:</strong> Does not get set unless below RC_FLT_SMP_RATE/2 because of filter instability characteristics.</p>    <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">0.1 > ? </td>
- <td style="vertical-align: top;">10.0 </td>
- <td style="vertical-align: top;">Hz</td>
 </tr>
 </tbody></table>
 
 ## Radio Signal Loss
 
 
-The module where these parameters are defined is: *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -6496,7 +7460,7 @@ The module where these parameters are defined is: *src/modules/navigator*.
 ## Radio Switches
 
 
-The module where these parameters are defined is: *src/modules/sensors*.
+The module where these parameters are defined is: *modules/sensors*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -7297,7 +8261,7 @@ The module where these parameters are defined is: *src/modules/sensors*.
 ## Return To Land
 
 
-The module where these parameters are defined is: *src/modules/navigator*.
+The module where these parameters are defined is: *modules/navigator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -7338,7 +8302,7 @@ The module where these parameters are defined is: *src/modules/navigator*.
 ## Runway Takeoff
 
 
-The module where these parameters are defined is: *src/lib/runway_takeoff*.
+The module where these parameters are defined is: *lib/runway_takeoff*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -7431,42 +8395,8 @@ FW_AIRSPD_MIN * RWTO_AIRSPD_SCL</p>    </td>
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="SDLOG_UTC_OFFSET">SDLOG_UTC_OFFSET</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UTC offset (unit: min)</p><p><strong>Comment:</strong> the difference in hours and minutes from Coordinated Universal Time (UTC) for a your place and date. for example, In case of South Korea(UTC+09:00), UTC offset is 540 min (9*60) refer to https://en.wikipedia.org/wiki/List_of_UTC_time_offsets</p>    <p><b>Module:</b> src/modules/logger</p>
-</td>
- <td style="vertical-align: top;">-1000 > 1000 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;">min</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SDLOG_MODE">SDLOG_MODE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Logging Mode</p><p><strong>Comment:</strong> Determines when to start and stop logging. By default, logging is started when arming the system, and stopped when disarming. This parameter is only for the new logger (SYS_LOGGER=1).</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> when armed until disarm (default)</li> 
-
-<li><strong>1:</strong> from boot until disarm</li> 
-
-<li><strong>2:</strong> from boot until shutdown</li> 
-
-<li><strong>3:</strong> from boot until shutdown - IMU and Baro data only (used for thermal calibration)</li> 
-</ul>
-  <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/logger</p>
-</td>
- <td style="vertical-align: top;">0 > 3 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SDLOG_UUID">SDLOG_UUID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Log UUID</p><p><strong>Comment:</strong> If set to 1, add an ID to the log, which uniquely identifies the vehicle</p>    <p><b>Module:</b> src/modules/logger</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="SDLOG_RATE">SDLOG_RATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Logging rate</p><p><strong>Comment:</strong> A value of -1 indicates the commandline argument should be obeyed. A value of 0 sets the minimum rate, any other value is interpreted as rate in Hertz. This parameter is only read out before logging starts (which commonly is before arming).</p>    <p><b>Module:</b> src/modules/sdlog2</p>
+ <td style="vertical-align: top;"><p>Logging rate</p><p><strong>Comment:</strong> A value of -1 indicates the commandline argument should be obeyed. A value of 0 sets the minimum rate, any other value is interpreted as rate in Hertz. This parameter is only read out before logging starts (which commonly is before arming).</p>    <p><b>Module:</b> modules/sdlog2</p>
 </td>
  <td style="vertical-align: top;">-1 > 250 </td>
  <td style="vertical-align: top;">-1 </td>
@@ -7481,7 +8411,7 @@ FW_AIRSPD_MIN * RWTO_AIRSPD_SCL</p>    </td>
 
 <li><strong>1:</strong> Enable</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sdlog2</p>
+   <p><b>Module:</b> modules/sdlog2</p>
 </td>
  <td style="vertical-align: top;">-1 > 1 </td>
  <td style="vertical-align: top;">-1 </td>
@@ -7489,7 +8419,7 @@ FW_AIRSPD_MIN * RWTO_AIRSPD_SCL</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SDLOG_GPSTIME">SDLOG_GPSTIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Use timestamps only if GPS 3D fix is available</p><p><strong>Comment:</strong> Constrain the log folder creation to only use the time stamp if a 3D GPS lock is present.</p>    <p><b>Module:</b> src/modules/sdlog2</p>
+ <td style="vertical-align: top;"><p>Use timestamps only if GPS 3D fix is available</p><p><strong>Comment:</strong> Constrain the log folder creation to only use the time stamp if a 3D GPS lock is present.</p>    <p><b>Module:</b> modules/sdlog2</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -7507,18 +8437,76 @@ This is used for gathering replay logs for the ekf2 module</p><p><strong>Comment
 
 <li><strong>3:</strong> Max priority</li> 
 </ul>
-   <p><b>Module:</b> src/modules/sdlog2</p>
+   <p><b>Module:</b> modules/sdlog2</p>
 </td>
  <td style="vertical-align: top;">0 > 3 </td>
  <td style="vertical-align: top;">2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SDLOG_UTC_OFFSET">SDLOG_UTC_OFFSET</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>UTC offset (unit: min)</p><p><strong>Comment:</strong> the difference in hours and minutes from Coordinated Universal Time (UTC) for a your place and date. for example, In case of South Korea(UTC+09:00), UTC offset is 540 min (9*60) refer to https://en.wikipedia.org/wiki/List_of_UTC_time_offsets</p>    <p><b>Module:</b> modules/logger</p>
+</td>
+ <td style="vertical-align: top;">-1000 > 1000 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;">min</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SDLOG_MODE">SDLOG_MODE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Logging Mode</p><p><strong>Comment:</strong> Determines when to start and stop logging. By default, logging is started when arming the system, and stopped when disarming. This parameter is only for the new logger (SYS_LOGGER=1).</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> when armed until disarm (default)</li> 
+
+<li><strong>1:</strong> from boot until disarm</li> 
+
+<li><strong>2:</strong> from boot until shutdown</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/logger</p>
+</td>
+ <td style="vertical-align: top;">0 > 2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SDLOG_PROFILE">SDLOG_PROFILE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Logging Topic Profile</p><p><strong>Comment:</strong> This is an integer bitmask controlling the set and rates of logged topics. The default allows for general log analysis and estimator replay, while keeping the log file size reasonably small. Enabling multiple sets leads to higher bandwidth requirements and larger log files. Set bits in the following positions to enable: 0 : Set to true to use the default set (used for general log analysis) 1 : Set to true to enable full rate estimator (EKF2) replay topics 2 : Set to true to enable topics for thermal calibration (high rate raw IMU and Baro sensor data) 3 : Set to true to enable topics for system identification (high rate actuator control and IMU data) 4 : Set to true to enable full rates for analysis of fast maneuvers (RC, attitude, rates and actuators) 5 : Set to true to enable debugging topics (debug_*.msg topics, for custom code) 6 : Set to true to enable topics for sensor comparison (low rate raw IMU, Baro and Magnetomer data)</p>  <strong>Bitmask:</strong><ul>  <li><strong>0:</strong> default set (log analysis)</li> 
+  <li><strong>1:</strong> estimator replay (EKF2)</li> 
+  <li><strong>2:</strong> thermal calibration</li> 
+  <li><strong>3:</strong> system identification</li> 
+  <li><strong>4:</strong> high rate</li> 
+  <li><strong>5:</strong> debug</li> 
+  <li><strong>6:</strong> sensor comparison</li> 
+</ul>
+ <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/logger</p>
+</td>
+ <td style="vertical-align: top;">0 > 127 </td>
+ <td style="vertical-align: top;">3 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SDLOG_DIRS_MAX">SDLOG_DIRS_MAX</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Maximum number of log directories to keep</p><p><strong>Comment:</strong> If there are more log directories than this value, the system will delete the oldest directories during startup. In addition, the system will delete old logs if there is not enough free space left. The minimum amount is 300 MB. If this is set to 0, old directories will only be removed if the free space falls below the minimum.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/logger</p>
+</td>
+ <td style="vertical-align: top;">0 > 1000 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SDLOG_UUID">SDLOG_UUID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Log UUID</p><p><strong>Comment:</strong> If set to 1, add an ID to the log, which uniquely identifies the vehicle</p>    <p><b>Module:</b> modules/logger</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
 </tbody></table>
 
-## Sensor Calibration
+## SITL
 
 
-The module where these parameters are defined is: *src/modules/sensors*.
+The module where these parameters are defined is: *modules/simulator*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -7527,59 +8515,51 @@ The module where these parameters are defined is: *src/modules/sensors*.
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="CAL_BOARD_ID">CAL_BOARD_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the board this parameter set was calibrated on</p>    </td>
+ <td style="vertical-align: top;"><strong id="SITL_UDP_PRT">SITL_UDP_PRT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Simulator UDP port</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">14560 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SIM_BAT_DRAIN">SIM_BAT_DRAIN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Simulator Battery drain interval</p>    </td>
+ <td style="vertical-align: top;">1 > 86400 (1)</td>
+ <td style="vertical-align: top;">60 </td>
+ <td style="vertical-align: top;">s</td>
+</tr>
+</tbody></table>
+
+## Sensor Calibration
+
+
+The module where these parameters are defined is: *modules/sensors*.
+
+<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG_PRIME">CAL_MAG_PRIME</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Primary mag ID</p>    </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_ID">CAL_GYRO0_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_XOFF">CAL_GYRO0_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_YOFF">CAL_GYRO0_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_ZOFF">CAL_GYRO0_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-5.0 > 5.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_XSCALE">CAL_GYRO0_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_YSCALE">CAL_GYRO0_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO0_ZSCALE">CAL_GYRO0_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"><strong id="CAL_MAG_SIDES">CAL_MAG_SIDES</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Bitfield selecting mag sides for calibration</p><p><strong>Comment:</strong> DETECT_ORIENTATION_TAIL_DOWN = 1 DETECT_ORIENTATION_NOSE_DOWN = 2 DETECT_ORIENTATION_LEFT = 4 DETECT_ORIENTATION_RIGHT = 8 DETECT_ORIENTATION_UPSIDE_DOWN = 16 DETECT_ORIENTATION_RIGHTSIDE_UP = 32</p> <strong>Values:</strong><ul>
+<li><strong>34:</strong> Two side calibration</li> 
+
+<li><strong>38:</strong> Three side calibration</li> 
+
+<li><strong>63:</strong> Six side calibration</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;">34 > 63 </td>
+ <td style="vertical-align: top;">63 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -7646,7 +8626,8 @@ The module where these parameters are defined is: *src/modules/sensors*.
 
 <li><strong>25:</strong> Pitch 270°</li> 
 </ul>
-   </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">-1 > 30 </td>
  <td style="vertical-align: top;">-1 </td>
  <td style="vertical-align: top;"></td>
@@ -7654,21 +8635,21 @@ The module where these parameters are defined is: *src/modules/sensors*.
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG0_XOFF">CAL_MAG0_XOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG0_YOFF">CAL_MAG0_YOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG0_ZOFF">CAL_MAG0_ZOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
@@ -7690,104 +8671,6 @@ The module where these parameters are defined is: *src/modules/sensors*.
  <td style="vertical-align: top;"><strong id="CAL_MAG0_ZSCALE">CAL_MAG0_ZSCALE</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC0_ID">CAL_ACC0_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the Accelerometer that the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC0_XOFF">CAL_ACC0_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer X-axis offset</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC0_YOFF">CAL_ACC0_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC0_ZOFF">CAL_ACC0_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer Z-axis offset</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC0_XSCALE">CAL_ACC0_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC0_YSCALE">CAL_ACC0_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC0_ZSCALE">CAL_ACC0_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_ID">CAL_GYRO1_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_XOFF">CAL_GYRO1_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_YOFF">CAL_GYRO1_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_ZOFF">CAL_GYRO1_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-5.0 > 5.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_XSCALE">CAL_GYRO1_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_YSCALE">CAL_GYRO1_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO1_ZSCALE">CAL_GYRO1_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
@@ -7855,7 +8738,8 @@ The module where these parameters are defined is: *src/modules/sensors*.
 
 <li><strong>25:</strong> Pitch 270°</li> 
 </ul>
-   </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">-1 > 30 </td>
  <td style="vertical-align: top;">-1 </td>
  <td style="vertical-align: top;"></td>
@@ -7863,21 +8747,21 @@ The module where these parameters are defined is: *src/modules/sensors*.
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG1_XOFF">CAL_MAG1_XOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG1_YOFF">CAL_MAG1_YOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG1_ZOFF">CAL_MAG1_ZOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
@@ -7899,104 +8783,6 @@ The module where these parameters are defined is: *src/modules/sensors*.
  <td style="vertical-align: top;"><strong id="CAL_MAG1_ZSCALE">CAL_MAG1_ZSCALE</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC1_ID">CAL_ACC1_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the Accelerometer that the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC1_XOFF">CAL_ACC1_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer X-axis offset</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC1_YOFF">CAL_ACC1_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC1_ZOFF">CAL_ACC1_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer Z-axis offset</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC1_XSCALE">CAL_ACC1_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC1_YSCALE">CAL_ACC1_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC1_ZSCALE">CAL_ACC1_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Accelerometer Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_ID">CAL_GYRO2_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_XOFF">CAL_GYRO2_XOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_YOFF">CAL_GYRO2_YOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-10.0 > 10.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_ZOFF">CAL_GYRO2_ZOFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
- <td style="vertical-align: top;">-5.0 > 5.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_XSCALE">CAL_GYRO2_XSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_YSCALE">CAL_GYRO2_YSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO2_ZSCALE">CAL_GYRO2_ZSCALE</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
- <td style="vertical-align: top;">-1.5 > 1.5 </td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
@@ -8064,7 +8850,8 @@ The module where these parameters are defined is: *src/modules/sensors*.
 
 <li><strong>25:</strong> Pitch 270°</li> 
 </ul>
-   </td>
+  <p><b>Reboot required:</b> true</p>
+ </td>
  <td style="vertical-align: top;">-1 > 30 </td>
  <td style="vertical-align: top;">-1 </td>
  <td style="vertical-align: top;"></td>
@@ -8072,14 +8859,14 @@ The module where these parameters are defined is: *src/modules/sensors*.
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG2_XOFF">CAL_MAG2_XOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG2_YOFF">CAL_MAG2_YOFF</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
- <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
@@ -8107,6 +8894,415 @@ The module where these parameters are defined is: *src/modules/sensors*.
 <tr>
  <td style="vertical-align: top;"><strong id="CAL_MAG2_ZSCALE">CAL_MAG2_ZSCALE</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_ID">CAL_MAG3_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of Magnetometer the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_ROT">CAL_MAG3_ROT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Rotation of magnetometer 2 relative to airframe</p><p><strong>Comment:</strong> An internal magnetometer will force a value of -1, so a GCS should only attempt to configure the rotation if the value is greater than or equal to zero.</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Internal mag</li> 
+
+<li><strong>0:</strong> No rotation</li> 
+
+<li><strong>1:</strong> Yaw 45°</li> 
+
+<li><strong>2:</strong> Yaw 90°</li> 
+
+<li><strong>3:</strong> Yaw 135°</li> 
+
+<li><strong>4:</strong> Yaw 180°</li> 
+
+<li><strong>5:</strong> Yaw 225°</li> 
+
+<li><strong>6:</strong> Yaw 270°</li> 
+
+<li><strong>7:</strong> Yaw 315°</li> 
+
+<li><strong>8:</strong> Roll 180°</li> 
+
+<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
+
+<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
+
+<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
+
+<li><strong>12:</strong> Pitch 180°</li> 
+
+<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
+
+<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
+
+<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
+
+<li><strong>16:</strong> Roll 90°</li> 
+
+<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
+
+<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
+
+<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
+
+<li><strong>20:</strong> Roll 270°</li> 
+
+<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
+
+<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
+
+<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
+
+<li><strong>24:</strong> Pitch 90°</li> 
+
+<li><strong>25:</strong> Pitch 270°</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">-1 > 30 </td>
+ <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_XOFF">CAL_MAG3_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer X-axis offset</p>    </td>
+ <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_YOFF">CAL_MAG3_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Y-axis offset</p>    </td>
+ <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_ZOFF">CAL_MAG3_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Z-axis offset</p>    </td>
+ <td style="vertical-align: top;">-500.0 > 500.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_XSCALE">CAL_MAG3_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_YSCALE">CAL_MAG3_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_MAG3_ZSCALE">CAL_MAG3_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Magnetometer Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO_PRIME">CAL_GYRO_PRIME</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Primary gyro ID</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_ID">CAL_GYRO0_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_XOFF">CAL_GYRO0_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_YOFF">CAL_GYRO0_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_ZOFF">CAL_GYRO0_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_XSCALE">CAL_GYRO0_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_YSCALE">CAL_GYRO0_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO0_ZSCALE">CAL_GYRO0_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_ID">CAL_GYRO1_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_XOFF">CAL_GYRO1_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_YOFF">CAL_GYRO1_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_ZOFF">CAL_GYRO1_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_XSCALE">CAL_GYRO1_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_YSCALE">CAL_GYRO1_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO1_ZSCALE">CAL_GYRO1_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_ID">CAL_GYRO2_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of the Gyro that the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_XOFF">CAL_GYRO2_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_YOFF">CAL_GYRO2_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_ZOFF">CAL_GYRO2_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_XSCALE">CAL_GYRO2_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_YSCALE">CAL_GYRO2_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_GYRO2_ZSCALE">CAL_GYRO2_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Gyro Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_BARO_PRIME">CAL_BARO_PRIME</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Primary baro ID</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_AIR_PMODEL">CAL_AIR_PMODEL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Airspeed sensor pitot model</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> HB Pitot</li> 
+</ul>
+   </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_AIR_TUBELEN">CAL_AIR_TUBELEN</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Airspeed sensor tube length</p>    </td>
+ <td style="vertical-align: top;">0.01 > 0.5 </td>
+ <td style="vertical-align: top;">0.2 </td>
+ <td style="vertical-align: top;">meter</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_DPRES_OFF">SENS_DPRES_OFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential pressure sensor offset</p><p><strong>Comment:</strong> The offset (zero-reading) in Pascal</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_DPRES_ANSC">SENS_DPRES_ANSC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Differential pressure sensor analog scaling</p><p><strong>Comment:</strong> Pick the appropriate scaling from the datasheet. this number defines the (linear) conversion from voltage to Pascal (pa). For the MPXV7002DP this is 1000. NOTE: If the sensor always registers zero, try switching the static and dynamic tubes.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC_PRIME">CAL_ACC_PRIME</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Primary accel ID</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC0_ID">CAL_ACC0_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of the Accelerometer that the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC0_XOFF">CAL_ACC0_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC0_YOFF">CAL_ACC0_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC0_ZOFF">CAL_ACC0_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC0_XSCALE">CAL_ACC0_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC0_YSCALE">CAL_ACC0_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC0_ZSCALE">CAL_ACC0_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer Z-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC1_ID">CAL_ACC1_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>ID of the Accelerometer that the calibration is for</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC1_XOFF">CAL_ACC1_XOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer X-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC1_YOFF">CAL_ACC1_YOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer Y-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC1_ZOFF">CAL_ACC1_ZOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer Z-axis offset</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC1_XSCALE">CAL_ACC1_XSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer X-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC1_YSCALE">CAL_ACC1_YSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer Y-axis scaling factor</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">1.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="CAL_ACC1_ZSCALE">CAL_ACC1_ZSCALE</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Accelerometer Z-axis scaling factor</p>    </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
@@ -8160,351 +9356,12 @@ The module where these parameters are defined is: *src/modules/sensors*.
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_ACC_PRIME">CAL_ACC_PRIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Primary accel ID</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_GYRO_PRIME">CAL_GYRO_PRIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Primary gyro ID</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG_PRIME">CAL_MAG_PRIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Primary mag ID</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_MAG_SIDES">CAL_MAG_SIDES</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Bitfield selecting mag sides for calibration</p><p><strong>Comment:</strong> DETECT_ORIENTATION_TAIL_DOWN = 1 DETECT_ORIENTATION_NOSE_DOWN = 2 DETECT_ORIENTATION_LEFT = 4 DETECT_ORIENTATION_RIGHT = 8 DETECT_ORIENTATION_UPSIDE_DOWN = 16 DETECT_ORIENTATION_RIGHTSIDE_UP = 32</p> <strong>Values:</strong><ul>
-<li><strong>34:</strong> Two side calibration</li> 
-
-<li><strong>38:</strong> Three side calibration</li> 
-
-<li><strong>63:</strong> Six side calibration</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;">34 > 63 </td>
- <td style="vertical-align: top;">63 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="CAL_BARO_PRIME">CAL_BARO_PRIME</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Primary baro ID</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_DPRES_OFF">SENS_DPRES_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential pressure sensor offset</p><p><strong>Comment:</strong> The offset (zero-reading) in Pascal</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_DPRES_ANSC">SENS_DPRES_ANSC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Differential pressure sensor analog scaling</p><p><strong>Comment:</strong> Pick the appropriate scaling from the datasheet. this number defines the (linear) conversion from voltage to Pascal (pa). For the MPXV7002DP this is 1000. NOTE: If the sensor always registers zero, try switching the static and dynamic tubes.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BARO_QNH">SENS_BARO_QNH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>QNH for barometer</p>    </td>
- <td style="vertical-align: top;">500 > 1500 </td>
- <td style="vertical-align: top;">1013.25 </td>
- <td style="vertical-align: top;">hPa</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BOARD_ROT">SENS_BOARD_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Board rotation</p><p><strong>Comment:</strong> This parameter defines the rotation of the FMU board relative to the platform.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> No rotation</li> 
-
-<li><strong>1:</strong> Yaw 45°</li> 
-
-<li><strong>2:</strong> Yaw 90°</li> 
-
-<li><strong>3:</strong> Yaw 135°</li> 
-
-<li><strong>4:</strong> Yaw 180°</li> 
-
-<li><strong>5:</strong> Yaw 225°</li> 
-
-<li><strong>6:</strong> Yaw 270°</li> 
-
-<li><strong>7:</strong> Yaw 315°</li> 
-
-<li><strong>8:</strong> Roll 180°</li> 
-
-<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
-
-<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
-
-<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
-
-<li><strong>12:</strong> Pitch 180°</li> 
-
-<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
-
-<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
-
-<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
-
-<li><strong>16:</strong> Roll 90°</li> 
-
-<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
-
-<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
-
-<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
-
-<li><strong>20:</strong> Roll 270°</li> 
-
-<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
-
-<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
-
-<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
-
-<li><strong>24:</strong> Pitch 90°</li> 
-
-<li><strong>25:</strong> Pitch 270°</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_FLOW_ROT">SENS_FLOW_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>PX4Flow board rotation</p><p><strong>Comment:</strong> This parameter defines the yaw rotation of the PX4FLOW board relative to the vehicle body frame. Zero rotation is defined as X on flow board pointing towards front of vehicle. The recommneded installation default for the PX4FLOW board is with the Y axis forward (270 deg yaw).</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> No rotation</li> 
-
-<li><strong>1:</strong> Yaw 45°</li> 
-
-<li><strong>2:</strong> Yaw 90°</li> 
-
-<li><strong>3:</strong> Yaw 135°</li> 
-
-<li><strong>4:</strong> Yaw 180°</li> 
-
-<li><strong>5:</strong> Yaw 225°</li> 
-
-<li><strong>6:</strong> Yaw 270°</li> 
-
-<li><strong>7:</strong> Yaw 315°</li> 
-</ul>
-  <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">6 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BOARD_Y_OFF">SENS_BOARD_Y_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Board rotation Y (Pitch) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BOARD_X_OFF">SENS_BOARD_X_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Board rotation X (Roll) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the X (Roll) axis It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_BOARD_Z_OFF">SENS_BOARD_Z_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Board rotation Z (YAW) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the Z (Yaw) axis. It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EXT_MAG_ROT">SENS_EXT_MAG_ROT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>External magnetometer rotation</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> No rotation</li> 
-
-<li><strong>1:</strong> Yaw 45°</li> 
-
-<li><strong>2:</strong> Yaw 90°</li> 
-
-<li><strong>3:</strong> Yaw 135°</li> 
-
-<li><strong>4:</strong> Yaw 180°</li> 
-
-<li><strong>5:</strong> Yaw 225°</li> 
-
-<li><strong>6:</strong> Yaw 270°</li> 
-
-<li><strong>7:</strong> Yaw 315°</li> 
-
-<li><strong>8:</strong> Roll 180°</li> 
-
-<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
-
-<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
-
-<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
-
-<li><strong>12:</strong> Pitch 180°</li> 
-
-<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
-
-<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
-
-<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
-
-<li><strong>16:</strong> Roll 90°</li> 
-
-<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
-
-<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
-
-<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
-
-<li><strong>20:</strong> Roll 270°</li> 
-
-<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
-
-<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
-
-<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
-
-<li><strong>24:</strong> Pitch 90°</li> 
-
-<li><strong>25:</strong> Pitch 270°</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EXT_MAG">SENS_EXT_MAG</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Select primary magnetometer</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Auto-select Mag</li> 
-
-<li><strong>1:</strong> External is primary Mag</li> 
-
-<li><strong>2:</strong> Internal is primary Mag</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;">0 > 2 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="ATT_VIBE_THRESH">ATT_VIBE_THRESH</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Threshold (of RMS) to warn about high vibration levels</p>    </td>
- <td style="vertical-align: top;">0.01 > 10 </td>
- <td style="vertical-align: top;">0.2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-</tbody></table>
-
-## Sensor Enable
-
-
-The module where these parameters are defined is: *src/modules/sensors*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_LL40LS">SENS_EN_LL40LS</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Lidar-Lite (LL40LS) PWM</p>   <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_SF0X">SENS_EN_SF0X</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Lightware laser rangefinder (serial)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li> 
-
-<li><strong>1:</strong> SF02</li> 
-
-<li><strong>2:</strong> SF10/a</li> 
-
-<li><strong>3:</strong> SF10/b</li> 
-
-<li><strong>4:</strong> SF10/c</li> 
-
-<li><strong>5:</strong> SF11/c</li> 
-</ul>
-  <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;">0 > 4 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_MB12XX">SENS_EN_MB12XX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Maxbotix Soanr (mb12xx)</p>   <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_TRONE">SENS_EN_TRONE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>TeraRanger One (trone)</p>   <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_SF1XX">SENS_EN_SF1XX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Lightware SF1xx laser rangefinder (i2c)</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Disabled</li> 
-
-<li><strong>1:</strong> SF10/a</li> 
-
-<li><strong>2:</strong> SF10/b</li> 
-
-<li><strong>3:</strong> SF10/c</li> 
-
-<li><strong>4:</strong> SF11/c</li> 
-</ul>
-  <p><b>Reboot required:</b> true</p>
- </td>
- <td style="vertical-align: top;">0 > 4 </td>
- <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="SENS_EN_THERMAL">SENS_EN_THERMAL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Thermal control of sensor temperature</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Thermal control unavailable</li> 
-
-<li><strong>0:</strong> Thermal control off</li> 
-</ul>
-   </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
 </tbody></table>
 
 ## Sensor Thermal Compensation
 
 
-The module where these parameters are defined is: *src/modules/sensors*.
+The module where these parameters are defined is: *modules/sensors*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -9564,10 +10421,10 @@ The module where these parameters are defined is: *src/modules/sensors*.
 </tr>
 </tbody></table>
 
-## Snapdragon UART ESC
+## Sensors
 
 
-The module where these parameters are defined is: *src/platforms/qurt/fc_addon/uart_esc*.
+The module where these parameters are defined is: *modules/sensors*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -9576,60 +10433,242 @@ The module where these parameters are defined is: *src/platforms/qurt/fc_addon/u
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MODEL">UART_ESC_MODEL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ESC model</p><p><strong>Comment:</strong> See esc_model_t enum definition in uart_esc_dev.h for all supported ESC model enum values.</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> ESC_200QX</li> 
+ <td style="vertical-align: top;"><strong id="SENS_BARO_QNH">SENS_BARO_QNH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>QNH for barometer</p>    </td>
+ <td style="vertical-align: top;">500 > 1500 </td>
+ <td style="vertical-align: top;">1013.25 </td>
+ <td style="vertical-align: top;">hPa</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_BOARD_ROT">SENS_BOARD_ROT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Board rotation</p><p><strong>Comment:</strong> This parameter defines the rotation of the FMU board relative to the platform.</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> No rotation</li> 
 
-<li><strong>1:</strong> ESC_350QX</li> 
+<li><strong>1:</strong> Yaw 45°</li> 
 
-<li><strong>2:</strong> ESC_210QC</li> 
+<li><strong>2:</strong> Yaw 90°</li> 
+
+<li><strong>3:</strong> Yaw 135°</li> 
+
+<li><strong>4:</strong> Yaw 180°</li> 
+
+<li><strong>5:</strong> Yaw 225°</li> 
+
+<li><strong>6:</strong> Yaw 270°</li> 
+
+<li><strong>7:</strong> Yaw 315°</li> 
+
+<li><strong>8:</strong> Roll 180°</li> 
+
+<li><strong>9:</strong> Roll 180°, Yaw 45°</li> 
+
+<li><strong>10:</strong> Roll 180°, Yaw 90°</li> 
+
+<li><strong>11:</strong> Roll 180°, Yaw 135°</li> 
+
+<li><strong>12:</strong> Pitch 180°</li> 
+
+<li><strong>13:</strong> Roll 180°, Yaw 225°</li> 
+
+<li><strong>14:</strong> Roll 180°, Yaw 270°</li> 
+
+<li><strong>15:</strong> Roll 180°, Yaw 315°</li> 
+
+<li><strong>16:</strong> Roll 90°</li> 
+
+<li><strong>17:</strong> Roll 90°, Yaw 45°</li> 
+
+<li><strong>18:</strong> Roll 90°, Yaw 90°</li> 
+
+<li><strong>19:</strong> Roll 90°, Yaw 135°</li> 
+
+<li><strong>20:</strong> Roll 270°</li> 
+
+<li><strong>21:</strong> Roll 270°, Yaw 45°</li> 
+
+<li><strong>22:</strong> Roll 270°, Yaw 90°</li> 
+
+<li><strong>23:</strong> Roll 270°, Yaw 135°</li> 
+
+<li><strong>24:</strong> Pitch 90°</li> 
+
+<li><strong>25:</strong> Pitch 270°</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_FLOW_ROT">SENS_FLOW_ROT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>PX4Flow board rotation</p><p><strong>Comment:</strong> This parameter defines the yaw rotation of the PX4FLOW board relative to the vehicle body frame. Zero rotation is defined as X on flow board pointing towards front of vehicle. The recommneded installation default for the PX4FLOW board is with the Y axis forward (270 deg yaw).</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> No rotation</li> 
+
+<li><strong>1:</strong> Yaw 45°</li> 
+
+<li><strong>2:</strong> Yaw 90°</li> 
+
+<li><strong>3:</strong> Yaw 135°</li> 
+
+<li><strong>4:</strong> Yaw 180°</li> 
+
+<li><strong>5:</strong> Yaw 225°</li> 
+
+<li><strong>6:</strong> Yaw 270°</li> 
+
+<li><strong>7:</strong> Yaw 315°</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">6 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_BOARD_Y_OFF">SENS_BOARD_Y_OFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Board rotation Y (Pitch) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_BOARD_X_OFF">SENS_BOARD_X_OFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Board rotation X (Roll) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the X (Roll) axis It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_BOARD_Z_OFF">SENS_BOARD_Z_OFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Board rotation Z (YAW) offset</p><p><strong>Comment:</strong> This parameter defines a rotational offset in degrees around the Z (Yaw) axis. It allows the user to fine tune the board offset in the event of misalignment.</p>    </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;">deg</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="ATT_VIBE_THRESH">ATT_VIBE_THRESH</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Threshold (of RMS) to warn about high vibration levels</p>    </td>
+ <td style="vertical-align: top;">0.01 > 10 </td>
+ <td style="vertical-align: top;">0.2 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_LL40LS">SENS_EN_LL40LS</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Lidar-Lite (LL40LS)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> PWM</li> 
+
+<li><strong>2:</strong> I2C</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 2 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_SF0X">SENS_EN_SF0X</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Lightware laser rangefinder (serial)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> SF02</li> 
+
+<li><strong>2:</strong> SF10/a</li> 
+
+<li><strong>3:</strong> SF10/b</li> 
+
+<li><strong>4:</strong> SF10/c</li> 
+
+<li><strong>5:</strong> SF11/c</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 4 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_MB12XX">SENS_EN_MB12XX</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Maxbotix Soanr (mb12xx)</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_TRANGER">SENS_EN_TRANGER</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>TeraRanger Rangefinder (i2c)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> Autodetect</li> 
+
+<li><strong>2:</strong> TROne</li> 
+
+<li><strong>3:</strong> TREvo</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 3 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_SF1XX">SENS_EN_SF1XX</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Lightware SF1xx/SF20/LW20 laser rangefinder (i2c)</p> <strong>Values:</strong><ul>
+<li><strong>0:</strong> Disabled</li> 
+
+<li><strong>1:</strong> SF10/a</li> 
+
+<li><strong>2:</strong> SF10/b</li> 
+
+<li><strong>3:</strong> SF10/c</li> 
+
+<li><strong>4:</strong> SF11/c</li> 
+
+<li><strong>5:</strong> SF/LW20</li> 
+</ul>
+  <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">0 > 5 </td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SENS_EN_THERMAL">SENS_EN_THERMAL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Thermal control of sensor temperature</p> <strong>Values:</strong><ul>
+<li><strong>-1:</strong> Thermal control unavailable</li> 
+
+<li><strong>0:</strong> Thermal control off</li> 
 </ul>
    </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">2 </td>
+ <td style="vertical-align: top;">-1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_BAUD">UART_ESC_BAUD</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>ESC UART baud rate</p><p><strong>Comment:</strong> Default rate is 250Kbps, whic is used in off-the-shelf QRP ESC products.</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">250000 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;"><strong id="IMU_GYRO_CUTOFF">IMU_GYRO_CUTOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Driver level cut frequency for gyro</p><p><strong>Comment:</strong> The cut frequency for the 2nd order butterworth filter on the gyro driver. This features is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the controllers, not the estimators. 0 disables the filter.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">5 > 1000 </td>
+ <td style="vertical-align: top;">30.0 </td>
+ <td style="vertical-align: top;">Hz</td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MOTOR1">UART_ESC_MOTOR1</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Motor 1 Mapping</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">4 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MOTOR2">UART_ESC_MOTOR2</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Motor 2 Mapping</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MOTOR3">UART_ESC_MOTOR3</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Motor 3 Mapping</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="UART_ESC_MOTOR4">UART_ESC_MOTOR4</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Motor 4 Mapping</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">3 </td>
- <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;"><strong id="IMU_ACCEL_CUTOFF">IMU_ACCEL_CUTOFF</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Driver level cut frequency for accel</p><p><strong>Comment:</strong> The cut frequency for the 2nd order butterworth filter on the accel driver. This features is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the controllers, not the estimators. 0 disables the filter.</p>   <p><b>Reboot required:</b> true</p>
+ </td>
+ <td style="vertical-align: top;">5 > 1000 </td>
+ <td style="vertical-align: top;">30.0 </td>
+ <td style="vertical-align: top;">Hz</td>
 </tr>
 </tbody></table>
 
 ## Subscriber Example
 
 
-The module where these parameters are defined is: *src/examples/subscriber*.
+The module where these parameters are defined is: *examples/subscriber*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -9656,7 +10695,7 @@ The module where these parameters are defined is: *src/examples/subscriber*.
 ## Syslink
 
 
-The module where these parameters are defined is: *src/modules/syslink*.
+The module where these parameters are defined is: *modules/syslink*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -9703,17 +10742,9 @@ The module where these parameters are defined is: *src/modules/syslink*.
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="LED_RGB_MAXBRT">LED_RGB_MAXBRT</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>RGB Led brightness limit</p><p><strong>Comment:</strong> Set to 0 to disable, 1 for minimum brightness up to 15 (max)</p>    <p><b>Module:</b> src/drivers/rgbled</p>
-</td>
- <td style="vertical-align: top;">0 > 15 </td>
- <td style="vertical-align: top;">15 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="SYS_AUTOSTART">SYS_AUTOSTART</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>Auto-start script index</p><p><strong>Comment:</strong> CHANGING THIS VALUE REQUIRES A RESTART. Defines the auto-start script used to bootstrap the system.</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 99999 </td>
  <td style="vertical-align: top;">0 </td>
@@ -9726,18 +10757,19 @@ The module where these parameters are defined is: *src/modules/syslink*.
 
 <li><strong>1:</strong> Reset parameters</li> 
 </ul>
-   <p><b>Module:</b> src/modules/systemlib</p>
+   <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="SYS_USE_IO">SYS_USE_IO</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Set usage of IO board</p><p><strong>Comment:</strong> Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><strong id="SYS_HITL">SYS_HITL</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Enable HITL mode on next boot</p><p><strong>Comment:</strong> While enabled the system will boot in HITL mode and not enable all sensors and checks. When disabled the same vehicle can be normally flown outdoors.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
- <td style="vertical-align: top;">0 > 1 </td>
- <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -9749,7 +10781,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 
 <li><strong>2:</strong> Data does not survive reset</li> 
 </ul>
-   <p><b>Module:</b> src/modules/systemlib</p>
+   <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 2 </td>
  <td style="vertical-align: top;">2 </td>
@@ -9763,7 +10795,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 <li><strong>2:</strong> ekf2</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">1 > 2 </td>
  <td style="vertical-align: top;">2 </td>
@@ -9799,7 +10831,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 <li><strong>3115200:</strong> Normal Telemetry (115200 baud, 8N1)</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1921600 </td>
  <td style="vertical-align: top;">157600 </td>
@@ -9807,7 +10839,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_PARAM_VER">SYS_PARAM_VER</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Parameter version</p><p><strong>Comment:</strong> This monotonically increasing number encodes the parameter compatibility set. whenever it increases parameters might not be backwards compatible and ground control stations should suggest a fresh configuration.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Parameter version</p><p><strong>Comment:</strong> This monotonically increasing number encodes the parameter compatibility set. whenever it increases parameters might not be backwards compatible and ground control stations should suggest a fresh configuration.</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > ? </td>
  <td style="vertical-align: top;">1 </td>
@@ -9816,20 +10848,20 @@ The module where these parameters are defined is: *src/modules/syslink*.
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_LOGGER">SYS_LOGGER</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>SD logger</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> sdlog2 (default)</li> 
+<li><strong>0:</strong> sdlog2 (legacy)</li> 
 
-<li><strong>1:</strong> new logger</li> 
+<li><strong>1:</strong> logger (default)</li> 
 </ul>
   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/systemlib</p>
+ <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
- <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_STCK_EN">SYS_STCK_EN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable stack checking</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Enable stack checking</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
@@ -9837,7 +10869,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_GYRO">SYS_CAL_GYRO</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable auto start of rate gyro thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Enable auto start of rate gyro thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -9845,7 +10877,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_ACCEL">SYS_CAL_ACCEL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable auto start of accelerometer thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Enable auto start of accelerometer thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -9853,7 +10885,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_BARO">SYS_CAL_BARO</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Enable auto start of barometer thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Enable auto start of barometer thermal calibration at the next power up</p><p><strong>Comment:</strong> 0 : Set to 0 to do nothing 1 : Set to 1 to start a calibration at next boot This parameter is reset to zero when the the temperature calibration starts. default (0, no calibration)</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">0 > 1 </td>
  <td style="vertical-align: top;">0 </td>
@@ -9861,7 +10893,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_TDEL">SYS_CAL_TDEL</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Required temperature rise during thermal calibration</p><p><strong>Comment:</strong> A temperature increase greater than this value is required during calibration. Calibration will complete for each sensor when the temperature increase above the starting temeprature exceeds the value set by SYS_CAL_TDEL. If the temperature rise is insufficient, the calibration will continue indefinitely and the board will need to be repowered to exit.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Required temperature rise during thermal calibration</p><p><strong>Comment:</strong> A temperature increase greater than this value is required during calibration. Calibration will complete for each sensor when the temperature increase above the starting temeprature exceeds the value set by SYS_CAL_TDEL. If the temperature rise is insufficient, the calibration will continue indefinitely and the board will need to be repowered to exit.</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;">10 > ? </td>
  <td style="vertical-align: top;">24 </td>
@@ -9869,7 +10901,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_TMIN">SYS_CAL_TMIN</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Minimum starting temperature for thermal calibration</p><p><strong>Comment:</strong> Temperature calibration for each sensor will ignore data if the temperature is lower than the value set by SYS_CAL_TMIN.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Minimum starting temperature for thermal calibration</p><p><strong>Comment:</strong> Temperature calibration for each sensor will ignore data if the temperature is lower than the value set by SYS_CAL_TMIN.</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">5 </td>
@@ -9877,11 +10909,37 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SYS_CAL_TMAX">SYS_CAL_TMAX</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Maximum starting temperature for thermal calibration</p><p><strong>Comment:</strong> Temperature calibration will not start if the temperature of any sensor is higher than the value set by SYS_CAL_TMAX.</p>    <p><b>Module:</b> src/modules/systemlib</p>
+ <td style="vertical-align: top;"><p>Maximum starting temperature for thermal calibration</p><p><strong>Comment:</strong> Temperature calibration will not start if the temperature of any sensor is higher than the value set by SYS_CAL_TMAX.</p>    <p><b>Module:</b> modules/systemlib</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10 </td>
  <td style="vertical-align: top;">deg C</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SYS_USE_IO">SYS_USE_IO</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Set usage of IO board</p><p><strong>Comment:</strong> Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4io</p>
+</td>
+ <td style="vertical-align: top;">0 > 1 </td>
+ <td style="vertical-align: top;">1 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="LED_RGB_MAXBRT">LED_RGB_MAXBRT</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>RGB Led brightness limit</p><p><strong>Comment:</strong> Set to 0 to disable, 1 for minimum brightness up to 15 (max)</p>    <p><b>Module:</b> drivers/rgbled</p>
+</td>
+ <td style="vertical-align: top;">0 > 15 </td>
+ <td style="vertical-align: top;">15 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="SYS_FMU_TASK">SYS_FMU_TASK</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>Run the FMU as a task to reduce latency</p><p><strong>Comment:</strong> If true, the FMU will run in a separate task instead of on the work queue. Set this if low latency is required, for example for racing. This is a trade-off between RAM usage and latency: running as a task, it requires a separate stack and directly polls on the control topics, whereas running on the work queue, it runs at a fixed update rate.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> drivers/px4fmu</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
 
@@ -9894,8 +10952,48 @@ The module where these parameters are defined is: *src/modules/syslink*.
  </thead>
 <tbody>
 <tr>
+ <td style="vertical-align: top;"><strong id="TEST_1">TEST_1</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">2 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TEST_2">TEST_2</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">4 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TEST_RC_X">TEST_RC_X</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">8 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TEST_RC2_X">TEST_RC2_X</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">16 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="TEST_PARAMS">TEST_PARAMS</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> systemcmds/tests</p>
+</td>
+ <td style="vertical-align: top;"></td>
+ <td style="vertical-align: top;">12345678 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="TEST_MIN">TEST_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">-1.0 </td>
@@ -9903,7 +11001,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_MAX">TEST_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
@@ -9911,7 +11009,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_TRIM">TEST_TRIM</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.5 </td>
@@ -9919,7 +11017,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_HP">TEST_HP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10.0 </td>
@@ -9927,7 +11025,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_LP">TEST_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10.0 </td>
@@ -9935,7 +11033,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_P">TEST_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.2 </td>
@@ -9943,7 +11041,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_I">TEST_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.1 </td>
@@ -9951,7 +11049,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_I_MAX">TEST_I_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
@@ -9959,7 +11057,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_D">TEST_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.01 </td>
@@ -9967,7 +11065,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_D_LP">TEST_D_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10.0 </td>
@@ -9975,7 +11073,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_MEAN">TEST_MEAN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
@@ -9983,18 +11081,10 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="TEST_DEV">TEST_DEV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/controllib_test</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> lib/controllib/controllib_test</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">2.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="TEST_PARAMS">TEST_PARAMS</strong> (INT32)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/systemcmds/tests</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">12345678 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -10012,11 +11102,12 @@ The module where these parameters are defined is: *src/modules/syslink*.
  <td style="vertical-align: top;"><p>UAVCAN mode</p><p><strong>Comment:</strong> 0 - UAVCAN disabled. 1 - Basic support for UAVCAN actuators and sensors. 2 - Full support for dynamic node ID allocation and firmware update. 3 - Sets the motor control outputs to UAVCAN and enables support for dynamic node ID allocation and firmware update.</p> <strong>Values:</strong><ul>
 <li><strong>0:</strong> Disabled</li> 
 
-<li><strong>2:</strong> Sensors Enabled</li> 
+<li><strong>2:</strong> Only Sensors</li> 
 
 <li><strong>3:</strong> Sensors and Motors</li> 
 </ul>
-   <p><b>Module:</b> src/modules/uavcan</p>
+  <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/uavcan</p>
 </td>
  <td style="vertical-align: top;">0 > 3 </td>
  <td style="vertical-align: top;">0 </td>
@@ -10024,7 +11115,8 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="UAVCAN_NODE_ID">UAVCAN_NODE_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> src/modules/uavcan</p>
+ <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/uavcan</p>
 </td>
  <td style="vertical-align: top;">1 > 125 </td>
  <td style="vertical-align: top;">1 </td>
@@ -10032,7 +11124,8 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="UAVCAN_BITRATE">UAVCAN_BITRATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> src/modules/uavcan</p>
+ <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>   <p><b>Reboot required:</b> true</p>
+ <p><b>Module:</b> modules/uavcan</p>
 </td>
  <td style="vertical-align: top;">20000 > 1000000 </td>
  <td style="vertical-align: top;">1000000 </td>
@@ -10041,31 +11134,15 @@ The module where these parameters are defined is: *src/modules/syslink*.
 <tr>
  <td style="vertical-align: top;"><strong id="UAVCAN_ESC_IDLT">UAVCAN_ESC_IDLT</strong> (INT32)</td>
  <td style="vertical-align: top;"><p>UAVCAN ESC will spin at idle throttle when armed, even if the mixer outputs zero setpoints</p>   <p><b>Reboot required:</b> true</p>
- <p><b>Module:</b> src/modules/uavcan</p>
+ <p><b>Module:</b> modules/uavcan</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="ESC_NODE_ID">ESC_NODE_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> src/modules/uavcanesc</p>
-</td>
- <td style="vertical-align: top;">1 > 125 </td>
- <td style="vertical-align: top;">120 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="ESC_BITRATE">ESC_BITRATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> src/modules/uavcanesc</p>
-</td>
- <td style="vertical-align: top;">20000 > 1000000 </td>
- <td style="vertical-align: top;">1000000 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="CANNODE_NODE_ID">CANNODE_NODE_ID</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> src/modules/uavcannode</p>
+ <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> modules/uavcannode</p>
 </td>
  <td style="vertical-align: top;">1 > 125 </td>
  <td style="vertical-align: top;">120 </td>
@@ -10073,7 +11150,23 @@ The module where these parameters are defined is: *src/modules/syslink*.
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="CANNODE_BITRATE">CANNODE_BITRATE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> src/modules/uavcannode</p>
+ <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> modules/uavcannode</p>
+</td>
+ <td style="vertical-align: top;">20000 > 1000000 </td>
+ <td style="vertical-align: top;">1000000 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="ESC_NODE_ID">ESC_NODE_ID</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>UAVCAN Node ID</p><p><strong>Comment:</strong> Read the specs at http://uavcan.org to learn more about Node ID.</p>    <p><b>Module:</b> modules/uavcanesc</p>
+</td>
+ <td style="vertical-align: top;">1 > 125 </td>
+ <td style="vertical-align: top;">120 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="ESC_BITRATE">ESC_BITRATE</strong> (INT32)</td>
+ <td style="vertical-align: top;"><p>UAVCAN CAN bus bitrate</p>    <p><b>Module:</b> modules/uavcanesc</p>
 </td>
  <td style="vertical-align: top;">20000 > 1000000 </td>
  <td style="vertical-align: top;">1000000 </td>
@@ -10084,7 +11177,7 @@ The module where these parameters are defined is: *src/modules/syslink*.
 ## VTOL Attitude Control
 
 
-The module where these parameters are defined is: *src/modules/vtol_att_control*.
+The module where these parameters are defined is: *modules/vtol_att_control*.
 
 <table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
  <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
@@ -10092,29 +11185,6 @@ The module where these parameters are defined is: *src/modules/vtol_att_control*
    <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
  </thead>
 <tbody>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_TRANS_THR">VT_TRANS_THR</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Target throttle value for pusher/puller motor during the transition to fw mode</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
- <td style="vertical-align: top;">0.6 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_DWN_PITCH_MAX">VT_DWN_PITCH_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximum allowed down-pitch the controller is able to demand. This prevents large, negative
-lift values being created when facing strong winds. The vehicle will use the pusher motor
-to accelerate forward if necessary</p>    </td>
- <td style="vertical-align: top;">0.0 > 45.0 </td>
- <td style="vertical-align: top;">5.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_FWD_THRUST_SC">VT_FWD_THRUST_SC</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Fixed wing thrust scale for hover forward flight</p><p><strong>Comment:</strong> Scale applied to fixed wing thrust being used as source for forward acceleration in multirotor mode. This technique can be used to avoid the plane having to pitch down a lot in order to move forward. Setting this value to 0 (default) will disable this strategy.</p>    </td>
- <td style="vertical-align: top;">0.0 > 2.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
 <tr>
  <td style="vertical-align: top;"><strong id="VT_TILT_MC">VT_TILT_MC</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Position of tilt servo in mc mode</p>    </td>
@@ -10270,6 +11340,13 @@ to accelerate forward if necessary</p>    </td>
  <td style="vertical-align: top;">s</td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="VT_B_DEC_MSS">VT_B_DEC_MSS</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Approximate deceleration during back transition</p><p><strong>Comment:</strong> The approximate deceleration during a back transition in m/s/s Used to calculate back transition distance in mission mode. A lower value will make the VTOL transition further from the destination waypoint.</p>    </td>
+ <td style="vertical-align: top;">0.00 > 20.00 (1)</td>
+ <td style="vertical-align: top;">2.0 </td>
+ <td style="vertical-align: top;">m/s/s</td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="VT_ARSP_BLEND">VT_ARSP_BLEND</strong> (FLOAT)</td>
  <td style="vertical-align: top;"><p>Transition blending airspeed</p><p><strong>Comment:</strong> Airspeed at which we can start blending both fw and mc controls. Set to 0 to disable.</p>    </td>
  <td style="vertical-align: top;">0.00 > 30.00 (1)</td>
@@ -10288,13 +11365,6 @@ to accelerate forward if necessary</p>    </td>
  <td style="vertical-align: top;"><p>Optimal recovery strategy for pitch-weak tailsitters</p>    </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="VT_WV_YAWR_SCL">VT_WV_YAWR_SCL</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Weather-vane yaw rate scale</p><p><strong>Comment:</strong> The desired yawrate from the controller will be scaled in order to avoid yaw fighting against the wind.</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
- <td style="vertical-align: top;">0.15 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
@@ -10319,8 +11389,15 @@ to accelerate forward if necessary</p>    </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
+ <td style="vertical-align: top;"><strong id="VT_FW_ALT_ERR">VT_FW_ALT_ERR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Adaptive QuadChute</p><p><strong>Comment:</strong> Maximum negative altitude error, when in fixed wing the altitude drops below this copared to the altitude setpoint the vehicle will transition back to MC mode and enter failsafe RTL</p>    </td>
+ <td style="vertical-align: top;">0.0 > 200.0 </td>
+ <td style="vertical-align: top;">0.0 </td>
+ <td style="vertical-align: top;"></td>
+</tr>
+<tr>
  <td style="vertical-align: top;"><strong id="VT_FW_QC_P">VT_FW_QC_P</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>QuadChute Max Pith</p><p><strong>Comment:</strong> Maximum pitch angle before QuadChute engages Above this the vehicle will transition back to MC mode and enter failsafe RTL</p>    </td>
+ <td style="vertical-align: top;"><p>QuadChute Max Pitch</p><p><strong>Comment:</strong> Maximum pitch angle before QuadChute engages Above this the vehicle will transition back to MC mode and enter failsafe RTL</p>    </td>
  <td style="vertical-align: top;">0 > 180 </td>
  <td style="vertical-align: top;">0 </td>
  <td style="vertical-align: top;"></td>
@@ -10339,314 +11416,67 @@ to accelerate forward if necessary</p>    </td>
  <td style="vertical-align: top;">6.0 </td>
  <td style="vertical-align: top;">seconds</td>
 </tr>
-</tbody></table>
-
-## mTECS
-
-
-The module where these parameters are defined is: *src/modules/fw_pos_control_l1/mtecs*.
-
-<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">
- <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
- <thead>
-   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
- </thead>
-<tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_ENABLED">MT_ENABLED</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>mTECS enabled</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;"><strong id="VT_WV_YAWR_SCL">VT_WV_YAWR_SCL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Weather-vane yaw rate scale</p><p><strong>Comment:</strong> The desired yawrate from the controller will be scaled in order to avoid yaw fighting against the wind.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.15 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_THR_FF">MT_THR_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Rate Control Feedforward
-Maps the total energy rate setpoint to the throttle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.7 </td>
+ <td style="vertical-align: top;"><strong id="VT_TRANS_THR">VT_TRANS_THR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Target throttle value for pusher/puller motor during the transition to fw mode</p>    </td>
+ <td style="vertical-align: top;">0.0 > 1.0 (0.01)</td>
+ <td style="vertical-align: top;">0.6 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_THR_P">MT_THR_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Rate Control P
-Maps the total energy rate error to the throttle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.1 </td>
+ <td style="vertical-align: top;"><strong id="VT_DWN_PITCH_MAX">VT_DWN_PITCH_MAX</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Maximum allowed down-pitch the controller is able to demand. This prevents large, negative
+lift values being created when facing strong winds. The vehicle will use the pusher motor
+to accelerate forward if necessary</p>    </td>
+ <td style="vertical-align: top;">0.0 > 45.0 </td>
+ <td style="vertical-align: top;">5.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_THR_I">MT_THR_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Rate Control I
-Maps the integrated total energy rate to the throttle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.25 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_THR_OFF">MT_THR_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Rate Control Offset (Cruise throttle sp)</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.7 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_FF">MT_PIT_FF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Energy Distribution Rate Control Feedforward
-Maps the energy distribution rate setpoint to the pitch setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.4 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_P">MT_PIT_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Energy Distribution Rate Control P
-Maps the energy distribution rate error to the pitch setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.03 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_I">MT_PIT_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Energy Distribution Rate Control I
-Maps the integrated energy distribution rate error to the pitch setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.03 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_OFF">MT_PIT_OFF</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Total Energy Distribution Offset (Cruise pitch sp)</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
+ <td style="vertical-align: top;"><strong id="VT_FWD_THRUST_SC">VT_FWD_THRUST_SC</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Fixed wing thrust scale for hover forward flight</p><p><strong>Comment:</strong> Scale applied to fixed wing thrust being used as source for forward acceleration in multirotor mode. This technique can be used to avoid the plane having to pitch down a lot in order to move forward. Setting this value to 0 (default) will disable this strategy.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 2.0 </td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_THR_MIN">MT_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal Throttle Setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
+ <td style="vertical-align: top;"><strong id="VT_B_TRANS_RAMP">VT_B_TRANS_RAMP</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Back transition MC motor ramp up time</p><p><strong>Comment:</strong> This sets the duration during wich the MC motors ramp up to the commanded thrust during the back transition stage.</p>    </td>
+ <td style="vertical-align: top;">0.0 > 20.0 </td>
+ <td style="vertical-align: top;">3.0 </td>
+ <td style="vertical-align: top;">s</td>
+</tr>
+<tr>
+ <td style="vertical-align: top;"><strong id="VT_B_REV_OUT">VT_B_REV_OUT</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Output on airbrakes channel during back transition
+Used for airbrakes or with ESCs that have reverse thrust enabled on a seperate channel
+Airbrakes need to be enables for your selected model/mixer</p>    </td>
+ <td style="vertical-align: top;">0 > 1 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_THR_MAX">MT_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal Throttle Setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_MIN">MT_PIT_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal Pitch Setpoint in Degrees</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">-45.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_MAX">MT_PIT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal Pitch Setpoint in Degrees</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">20.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ALT_LP">MT_ALT_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass (cutoff freq.) for altitude</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;">Hz</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_LP">MT_FPA_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass (cutoff freq.) for the flight path angle</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;">Hz</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_P">MT_FPA_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>P gain for the altitude control
-Maps the altitude error to the flight path angle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.3 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_D">MT_FPA_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>D gain for the altitude control
-Maps the change of altitude error to the flight path angle setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
+ <td style="vertical-align: top;"><strong id="VT_B_REV_DEL">VT_B_REV_DEL</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Delay in seconds before applying back transition throttle
+Set this to a value greater than 0 to give the motor time to spin down</p><p><strong>Comment:</strong> unit s</p>    </td>
+ <td style="vertical-align: top;">0 > 10 (1)</td>
  <td style="vertical-align: top;">0.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_D_LP">MT_FPA_D_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass for FPA error derivative calculation (see MT_FPA_D)</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_MIN">MT_FPA_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal flight path angle setpoint</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">-20.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_FPA_MAX">MT_FPA_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal flight path angle setpoint</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">30.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_A_LP">MT_A_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass (cutoff freq.) for airspeed</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_AD_LP">MT_AD_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Airspeed derivative calculation lowpass</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_P">MT_ACC_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>P gain for the airspeed control
-Maps the airspeed error to the acceleration setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">0.3 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_D">MT_ACC_D</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>D gain for the airspeed control
-Maps the change of airspeed error to the acceleration setpoint</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
+ <td style="vertical-align: top;"><strong id="VT_B_TRANS_THR">VT_B_TRANS_THR</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p>Thottle output during back transition
+For ESCs and mixers that support reverse thrust on low PWM values set this to a negative value to apply active breaking
+For ESCs that support thrust reversal with a control channel please set VT_B_REV_OUT and set this to a positive value to apply active breaking</p>    </td>
+ <td style="vertical-align: top;">-1 > 1 (0.01)</td>
  <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_D_LP">MT_ACC_D_LP</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Lowpass for ACC error derivative calculation (see MT_ACC_D)</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.5 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_MIN">MT_ACC_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal acceleration (air)</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-40.0 </td>
- <td style="vertical-align: top;">m/s/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_ACC_MAX">MT_ACC_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal acceleration (air)</p>    </td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">40.0 </td>
- <td style="vertical-align: top;">m/s/s</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_TKF_THR_MIN">MT_TKF_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal throttle during takeoff</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_TKF_THR_MAX">MT_TKF_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal throttle during takeoff</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_TKF_PIT_MIN">MT_TKF_PIT_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal pitch during takeoff</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_TKF_PIT_MAX">MT_TKF_PIT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal pitch during takeoff</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">45.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_USP_THR_MIN">MT_USP_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal throttle in underspeed mode</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_USP_THR_MAX">MT_USP_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal throttle in underspeed mode</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">1.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_USP_PIT_MIN">MT_USP_PIT_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal pitch in underspeed mode</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">-45.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_USP_PIT_MAX">MT_USP_PIT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal pitch in underspeed mode</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_LND_THR_MIN">MT_LND_THR_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal throttle in landing mode (only last phase of landing)</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_LND_THR_MAX">MT_LND_THR_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal throttle in landing mode (only last phase of landing)</p>    </td>
- <td style="vertical-align: top;">0.0 > 1.0 </td>
- <td style="vertical-align: top;">0.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_LND_PIT_MIN">MT_LND_PIT_MIN</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Minimal pitch in landing mode</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">-5.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_LND_PIT_MAX">MT_LND_PIT_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Maximal pitch in landing mode</p>    </td>
- <td style="vertical-align: top;">-90.0 > 90.0 </td>
- <td style="vertical-align: top;">15.0 </td>
- <td style="vertical-align: top;">deg</td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_THR_I_MAX">MT_THR_I_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integrator Limit for Total Energy Rate Control</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">10.0 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="MT_PIT_I_MAX">MT_PIT_I_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p>Integrator Limit for Energy Distribution Rate Control</p>    </td>
- <td style="vertical-align: top;">0.0 > 10.0 </td>
- <td style="vertical-align: top;">10.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>
@@ -10660,40 +11490,8 @@ Maps the change of airspeed error to the acceleration setpoint</p>    </td>
  </thead>
 <tbody>
 <tr>
- <td style="vertical-align: top;"><strong id="EXFW_HDNG_P">EXFW_HDNG_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/fixedwing_control</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="EXFW_ROLL_P">EXFW_ROLL_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/fixedwing_control</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="EXFW_PITCH_P">EXFW_PITCH_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/fixedwing_control</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.2 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="RV_YAW_P">RV_YAW_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/rover_steering_control</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">0.1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
  <td style="vertical-align: top;"><strong id="SEG_TH2V_P">SEG_TH2V_P</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/segway</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/segway</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">10.0 </td>
@@ -10701,7 +11499,7 @@ Maps the change of airspeed error to the acceleration setpoint</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SEG_TH2V_I">SEG_TH2V_I</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/segway</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/segway</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
@@ -10709,7 +11507,7 @@ Maps the change of airspeed error to the acceleration setpoint</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SEG_TH2V_I_MAX">SEG_TH2V_I_MAX</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/segway</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/segway</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">0.0 </td>
@@ -10717,287 +11515,42 @@ Maps the change of airspeed error to the acceleration setpoint</p>    </td>
 </tr>
 <tr>
  <td style="vertical-align: top;"><strong id="SEG_Q2V">SEG_Q2V</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/examples/segway</p>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/segway</p>
 </td>
  <td style="vertical-align: top;"></td>
  <td style="vertical-align: top;">1.0 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_RC_STICK_OV">COM_RC_STICK_OV</strong> (FLOAT)</td>
- <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><strong id="EXFW_HDNG_P">EXFW_HDNG_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/fixedwing_control</p>
 </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">12.0 </td>
+ <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE1">COM_FLTMODE1</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>First flightmode slot (1000-1160)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li> 
-
-<li><strong>0:</strong> Manual</li> 
-
-<li><strong>1:</strong> Altitude</li> 
-
-<li><strong>2:</strong> Position</li> 
-
-<li><strong>3:</strong> Mission</li> 
-
-<li><strong>4:</strong> Hold</li> 
-
-<li><strong>5:</strong> Return</li> 
-
-<li><strong>6:</strong> Acro</li> 
-
-<li><strong>7:</strong> Offboard</li> 
-
-<li><strong>8:</strong> Stabilized</li> 
-
-<li><strong>9:</strong> Rattitude</li> 
-
-<li><strong>10:</strong> Takeoff</li> 
-
-<li><strong>11:</strong> Land</li> 
-
-<li><strong>12:</strong> Follow Me</li> 
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><strong id="EXFW_ROLL_P">EXFW_ROLL_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/fixedwing_control</p>
 </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE2">COM_FLTMODE2</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Second flightmode slot (1160-1320)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li> 
-
-<li><strong>0:</strong> Manual</li> 
-
-<li><strong>1:</strong> Altitude</li> 
-
-<li><strong>2:</strong> Position</li> 
-
-<li><strong>3:</strong> Mission</li> 
-
-<li><strong>4:</strong> Hold</li> 
-
-<li><strong>5:</strong> Return</li> 
-
-<li><strong>6:</strong> Acro</li> 
-
-<li><strong>7:</strong> Offboard</li> 
-
-<li><strong>8:</strong> Stabilized</li> 
-
-<li><strong>9:</strong> Rattitude</li> 
-
-<li><strong>10:</strong> Takeoff</li> 
-
-<li><strong>11:</strong> Land</li> 
-
-<li><strong>12:</strong> Follow Me</li> 
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><strong id="EXFW_PITCH_P">EXFW_PITCH_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/fixedwing_control</p>
 </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
+ <td style="vertical-align: top;">0.2 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 <tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE3">COM_FLTMODE3</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Third flightmode slot (1320-1480)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li> 
-
-<li><strong>0:</strong> Manual</li> 
-
-<li><strong>1:</strong> Altitude</li> 
-
-<li><strong>2:</strong> Position</li> 
-
-<li><strong>3:</strong> Mission</li> 
-
-<li><strong>4:</strong> Hold</li> 
-
-<li><strong>5:</strong> Return</li> 
-
-<li><strong>6:</strong> Acro</li> 
-
-<li><strong>7:</strong> Offboard</li> 
-
-<li><strong>8:</strong> Stabilized</li> 
-
-<li><strong>9:</strong> Rattitude</li> 
-
-<li><strong>10:</strong> Takeoff</li> 
-
-<li><strong>11:</strong> Land</li> 
-
-<li><strong>12:</strong> Follow Me</li> 
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
+ <td style="vertical-align: top;"><strong id="RV_YAW_P">RV_YAW_P</strong> (FLOAT)</td>
+ <td style="vertical-align: top;"><p></p>    <p><b>Module:</b> examples/rover_steering_control</p>
 </td>
  <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE4">COM_FLTMODE4</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Fourth flightmode slot (1480-1640)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li> 
-
-<li><strong>0:</strong> Manual</li> 
-
-<li><strong>1:</strong> Altitude</li> 
-
-<li><strong>2:</strong> Position</li> 
-
-<li><strong>3:</strong> Mission</li> 
-
-<li><strong>4:</strong> Hold</li> 
-
-<li><strong>5:</strong> Return</li> 
-
-<li><strong>6:</strong> Acro</li> 
-
-<li><strong>7:</strong> Offboard</li> 
-
-<li><strong>8:</strong> Stabilized</li> 
-
-<li><strong>9:</strong> Rattitude</li> 
-
-<li><strong>10:</strong> Takeoff</li> 
-
-<li><strong>11:</strong> Land</li> 
-
-<li><strong>12:</strong> Follow Me</li> 
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE5">COM_FLTMODE5</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Fifth flightmode slot (1640-1800)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li> 
-
-<li><strong>0:</strong> Manual</li> 
-
-<li><strong>1:</strong> Altitude</li> 
-
-<li><strong>2:</strong> Position</li> 
-
-<li><strong>3:</strong> Mission</li> 
-
-<li><strong>4:</strong> Hold</li> 
-
-<li><strong>5:</strong> Return</li> 
-
-<li><strong>6:</strong> Acro</li> 
-
-<li><strong>7:</strong> Offboard</li> 
-
-<li><strong>8:</strong> Stabilized</li> 
-
-<li><strong>9:</strong> Rattitude</li> 
-
-<li><strong>10:</strong> Takeoff</li> 
-
-<li><strong>11:</strong> Land</li> 
-
-<li><strong>12:</strong> Follow Me</li> 
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="COM_FLTMODE6">COM_FLTMODE6</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Sixth flightmode slot (1800-2000)</p><p><strong>Comment:</strong> If the main switch channel is in this range the selected flight mode will be applied.</p> <strong>Values:</strong><ul>
-<li><strong>-1:</strong> Unassigned</li> 
-
-<li><strong>0:</strong> Manual</li> 
-
-<li><strong>1:</strong> Altitude</li> 
-
-<li><strong>2:</strong> Position</li> 
-
-<li><strong>3:</strong> Mission</li> 
-
-<li><strong>4:</strong> Hold</li> 
-
-<li><strong>5:</strong> Return</li> 
-
-<li><strong>6:</strong> Acro</li> 
-
-<li><strong>7:</strong> Offboard</li> 
-
-<li><strong>8:</strong> Stabilized</li> 
-
-<li><strong>9:</strong> Rattitude</li> 
-
-<li><strong>10:</strong> Takeoff</li> 
-
-<li><strong>11:</strong> Land</li> 
-
-<li><strong>12:</strong> Follow Me</li> 
-</ul>
-   <p><b>Module:</b> src/modules/commander</p>
-</td>
- <td style="vertical-align: top;"></td>
- <td style="vertical-align: top;">-1 </td>
- <td style="vertical-align: top;"></td>
-</tr>
-<tr>
- <td style="vertical-align: top;"><strong id="RC_MAP_FAILSAFE">RC_MAP_FAILSAFE</strong> (INT32)</td>
- <td style="vertical-align: top;"><p>Failsafe channel mapping</p><p><strong>Comment:</strong> The RC mapping index indicates which channel is used for failsafe If 0, whichever channel is mapped to throttle is used otherwise the value indicates the specific rc channel to use</p> <strong>Values:</strong><ul>
-<li><strong>0:</strong> Unassigned</li> 
-
-<li><strong>1:</strong> Channel 1</li> 
-
-<li><strong>2:</strong> Channel 2</li> 
-
-<li><strong>3:</strong> Channel 3</li> 
-
-<li><strong>4:</strong> Channel 4</li> 
-
-<li><strong>5:</strong> Channel 5</li> 
-
-<li><strong>6:</strong> Channel 6</li> 
-
-<li><strong>7:</strong> Channel 7</li> 
-
-<li><strong>8:</strong> Channel 8</li> 
-
-<li><strong>9:</strong> Channel 9</li> 
-
-<li><strong>10:</strong> Channel 10</li> 
-
-<li><strong>11:</strong> Channel 11</li> 
-
-<li><strong>12:</strong> Channel 12</li> 
-
-<li><strong>13:</strong> Channel 13</li> 
-
-<li><strong>14:</strong> Channel 14</li> 
-
-<li><strong>15:</strong> Channel 15</li> 
-
-<li><strong>16:</strong> Channel 16</li> 
-
-<li><strong>17:</strong> Channel 17</li> 
-
-<li><strong>18:</strong> Channel 18</li> 
-</ul>
-   <p><b>Module:</b> src/modules/sensors</p>
-</td>
- <td style="vertical-align: top;">0 > 18 </td>
- <td style="vertical-align: top;">0 </td>
+ <td style="vertical-align: top;">0.1 </td>
  <td style="vertical-align: top;"></td>
 </tr>
 </tbody></table>

--- a/zh/tutorials/land_detector.md
+++ b/zh/tutorials/land_detector.md
@@ -22,7 +22,7 @@ translated_sha: 5d3a4b74ed78490309ad921f2a6a78fd092d196d
 
 * [MPC_THR_HOVER](../advanced/parameter_reference.md#MPC_THR_HOVER) - 系统的悬停油门（以百分比表示，默认为50％）。 重要的是正确设置，因为它不仅使高度控制更准确，而且确保正确的着陆检测。 无负载安装的竞赛手或大型航拍无人机可能需要低得多的设置（例如35％）。
 * [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - 整个系统的最小油门。设置此项以启用受控下降。
-* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - 这是一个缩放因子，用于定义最小和悬停油门之间可被接受作为着陆油门的范围。例如：如果最小油门是0.1，悬停油门是0.5并且范围为0.2\(20%\)，那么用于着陆的最高油门可通过最小油门加上\(0.5 - 0.1\) \* 0.2 = 0.08来计算，因此总油门量为0.18.
+* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - 这是一个缩放因子，用于定义最小和悬停油门之间可被接受作为着陆油门的范围。Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is: `0.1 + (0.5 - 0.1) * 0.2 = 0.18`.
 
 The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
 

--- a/zh/tutorials/land_detector.md
+++ b/zh/tutorials/land_detector.md
@@ -24,9 +24,6 @@ translated_sha: 5d3a4b74ed78490309ad921f2a6a78fd092d196d
 * [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - 整个系统的最小油门。设置此项以启用受控下降。
 * [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - 这是一个缩放因子，用于定义最小和悬停油门之间可被接受作为着陆油门的范围。Example: If the minimum throttle is 0.1, the hover throttle is 0.5 and the range is 0.2 \(20%\), then the highest throttle value that counts as landed is: `0.1 + (0.5 - 0.1) * 0.2 = 0.18`.
 
-The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
-
-
 
 ## 固定翼着陆探测器配置
 

--- a/zh/tutorials/land_detector.md
+++ b/zh/tutorials/land_detector.md
@@ -12,7 +12,7 @@ translated_sha: 5d3a4b74ed78490309ad921f2a6a78fd092d196d
 ## 自动上锁配置
 
 
-默认情况下，着陆探测器会检测到着陆，但不会自动上锁。如果滞后参数`COM_DISARM_LAND`设置为非零值，系统将在N秒后自动上锁（N为设定值）。
+默认情况下，着陆探测器会检测到着陆，但不会自动上锁。如果滞后参数[COM_DISARM_LAND](../advanced/parameter_reference.md#COM_DISARM_LAND)设置为非零值，系统将在N秒后自动上锁（N为设定值）。
 
 
 ## 多旋翼着陆探测器配置
@@ -20,11 +20,11 @@ translated_sha: 5d3a4b74ed78490309ad921f2a6a78fd092d196d
 
 完整的参数集可以在QGroundControl地面站的参数编辑器中找到，以`LNDMC`为前缀。每个机身可能不同的关键参数有：
 
-* `LNDMC_MAN_DWNTHR` - 阈值（以百分比表示，默认值15%）手动油门的多少要考虑到落地状态。 具有非常高的推力重量比的系统如竞赛手可能需要较低的设置（例如8％）。
-* `MPC_THR_HOVER` - 系统的悬停油门（以百分比表示，默认为50％）。 重要的是正确设置，因为它不仅使高度控制更准确，而且确保正确的着陆检测。 无负载安装的竞赛手或大型航拍无人机可能需要低得多的设置（例如35％）。
-* `MPC_THR_MIN` - 整个系统的最小油门。设置此项以启用受控下降。
-* `LNDMC_THR_RANGE` - 这是一个缩放因子，用于定义最小和悬停油门之间可被接受作为着陆油门的范围。例如：如果最小油门是0.1，悬停油门是0.5并且范围为0.2\(20%\)，那么用于着陆的最高油门可通过最小油门加上\(0.5 - 0.1\) \* 0.2 = 0.08来计算，因此总油门量为0.18.
-* `LNDMC_POS_UPTHR` - 油门水平触发起飞（以百分比表示，默认为65％）。 如果飞手升高超过该阈值，系统将试图起飞。 该值应大于悬停油门。
+* [MPC_THR_HOVER](../advanced/parameter_reference.md#MPC_THR_HOVER) - 系统的悬停油门（以百分比表示，默认为50％）。 重要的是正确设置，因为它不仅使高度控制更准确，而且确保正确的着陆检测。 无负载安装的竞赛手或大型航拍无人机可能需要低得多的设置（例如35％）。
+* [MPC_THR_MIN](../advanced/parameter_reference.md#MPC_THR_MIN) - 整个系统的最小油门。设置此项以启用受控下降。
+* [LNDMC_THR_RANGE](../advanced/parameter_reference.md#LNDMC_THR_RANGE) - 这是一个缩放因子，用于定义最小和悬停油门之间可被接受作为着陆油门的范围。例如：如果最小油门是0.1，悬停油门是0.5并且范围为0.2\(20%\)，那么用于着陆的最高油门可通过最小油门加上\(0.5 - 0.1\) \* 0.2 = 0.08来计算，因此总油门量为0.18.
+
+The throttle level to trigger takeoff is hard-coded to 62.5%. If the pilot raises above this threshold the system will attempt to take off. This value should be greater than the hover throttle.
 
 
 
@@ -32,6 +32,6 @@ translated_sha: 5d3a4b74ed78490309ad921f2a6a78fd092d196d
 
 可用以`LNDFW`为前缀的完整参数集。下列两个用户参数有时需要进行调整：
 
-* `LNDFW_AIRSPD_MAX` - 降落时仍然要考虑系统允许的最大空速。 默认的8 m / s是空速感测精度和足够快的触发之间可靠的折衷。 更好的空速传感器应允许较低的参数值。
+* [LNDFW_AIRSPD_MAX](../advanced/parameter_reference.md#LNDFW_AIRSPD_MAX) - 降落时仍然要考虑系统允许的最大空速。 默认的8 m / s是空速感测精度和足够快的触发之间可靠的折衷。 更好的空速传感器应允许较低的参数值。
 
-* `LNDFW_VELI_MAX` - 降落时仍然要考虑系统的最大速度。 可以调整此参数，以确保在投掷机身时进行手动启动的着陆检测。
+* [LNDFW_VELI_MAX](../advanced/parameter_reference.md#LNDFW_VELI_MAX) - 降落时仍然要考虑系统的最大速度。 可以调整此参数，以确保在投掷机身时进行手动启动的着陆检测。


### PR DESCRIPTION
This updates dev guide to catch up with this change https://github.com/PX4/Firmware/commit/7229ec2a378758350a9a4121c511c480550f7e15#diff-b2da8c756b49a745c8f649f0d57567c7 which removed LNDMC_POS_UPTHR and LNDMC_MAN_DWNTHR params.

The change updates the chinese and korean trees to use latest paramater_reference, and removes mention of the params from land detector docs. I also took time to add param links to other parameters in the land detector doc. 

