### PR TITLE
Add a note about rebooting Sapog ESCs after enumeration

### DIFF
--- a/en/uavcan/node_enumeration.md
+++ b/en/uavcan/node_enumeration.md
@@ -4,6 +4,6 @@
 
 Use [QGroundControl](../qgc/README.md) and switch to the Setup view. Select the Power Configuration on the left. Click on the 'start assignment' button.
 
-After the first beep, turn the propeller on the first ESC swiftly into the correct turn direction. The ESCs will all beep each time one is enumerated. Repeat this step for all motor controllers in the order as shown on the [motor map](../airframes/airframe_reference.md). This step has to be performed only once and does not need to be repeated after firmware upgrades.
+After the first beep, turn the propeller on the first ESC swiftly into the correct turn direction. The ESCs will all beep each time one is enumerated. Repeat this step for all motor controllers in the order as shown on the [motor map](../airframes/airframe_reference.md). ESCs running the Sapog firmware will need to be rebooted after enumeration for the new enumeration ID to be applied. This step has to be performed only once and does not need to be repeated after firmware upgrades.
 
 ![UAVCAN Enumeration Controls (bottom right of image)](../../assets/uavcan-qgc-setup.png)


### PR DESCRIPTION
Just a quick note clarifying that Sapog firmware CAN ESCs need to be rebooted after enumeration.