### PR TITLE
Rename bus section to I/O and add explanation of section

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -39,7 +39,7 @@
   * [Device Drivers](middleware/drivers.md)
   * [Telemetry Radio](data_links/telemetry.md)
     * [SiK Radio](data_links/sik_radio.md)
-  * [Sensor and Actuator Buses](sensor_bus/README.md)
+  * [Sensor and Actuator I/O](sensor_bus/README.md)
     * [I2C Bus](sensor_bus/i2c.md)
     * [UAVCAN Bus](uavcan/README.md)
       * [UAVCAN Bootloader](uavcan/bootloader_installation.md)

--- a/en/sensor_bus/README.md
+++ b/en/sensor_bus/README.md
@@ -1,3 +1,3 @@
 # Sensor and Actuator I/O
 
-This section contains topics about integrating sensors and actuators into PX4. It covers both sensor busses ([I2C](../sensor_bus/i2c.md), [UAVCAN ](../uavcan/README.md), [UART](../sensor_bus/uart.md), SPI) and also the main PWM outputs.
+This section contains topics about integrating sensors and actuators into PX4. It covers both sensor busses ([I2C](../sensor_bus/i2c.md), [UAVCAN ](../uavcan/README.md), [UART](../sensor_bus/uart.md), SPI) and also the main PWM ports.

--- a/en/sensor_bus/README.md
+++ b/en/sensor_bus/README.md
@@ -1,1 +1,3 @@
-# Sensor and Actuator Busses
+# Sensor and Actuator I/O
+
+This section contains topics about integrating sensors and actuators into PX4. It covers both sensor busses ([I2C](../sensor_bus/i2c.md), [UAVCAN ](../uavcan/README.md), [UART](../sensor_bus/uart.md), SPI) and also the main PWM outputs.


### PR DESCRIPTION
Make it clear sensor section covers both bus and main PWM port. Do this by renaming to I/O in topic name and also adding explanation of the purpose of the section.