### PR TITLE
Move mavlink message links to mavlink.io docs (plus minor fixes)

### DIFF
--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -1,18 +1,20 @@
 # MAVLink Messaging
-An overview of all messages can be found [here](http://mavlink.org/messages/common).
+
+An overview of all messages can be found [here](https://mavlink.io/en/messages/).
+
 ## Create Custom MAVLink Messages
+
 This tutorial assumes you have a [custom uORB](../middleware/uorb.md) `ca_trajectory`
-message in `msg/ca_trajectory.msg` and a custom mavlink
-`ca_trajectory` message in
+message in `msg/ca_trajectory.msg` and a custom MAVLink `ca_trajectory` message in
 `mavlink/include/mavlink/v1.0/custom_messages/mavlink_msg_ca_trajectory.h` (see
 [here](http://qgroundcontrol.org/mavlink/create_new_mavlink_message) how to
-create a custom mavlink message and header).
+create a custom MAVLink message and header).
 
 ## Sending Custom MAVLink Messages
-This section explains how to use a custom uORB message and send it as a mavlink
-message.
 
-Add the headers of the mavlink and uORB messages to
+This section explains how to use a custom uORB message and send it as a MAVLink message.
+
+Add the headers of the MAVLink and uORB messages to
 [mavlink_messages.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_messages.cpp)
 
 ```C
@@ -27,56 +29,56 @@ class MavlinkStreamCaTrajectory : public MavlinkStream
 {
 public:
     const char *get_name() const
-	{
-		return MavlinkStreamCaTrajectory::get_name_static();
-	}
-	static const char *get_name_static()
-	{
-		return "CA_TRAJECTORY";
-	}
-	uint8_t get_id()
-	{
-		return MAVLINK_MSG_ID_CA_TRAJECTORY;
-	}
-	static MavlinkStream *new_instance(Mavlink *mavlink)
-	{
-		return new MavlinkStreamCaTrajectory(mavlink);
-	}
-	unsigned get_size()
-	{
-		return MAVLINK_MSG_ID_CA_TRAJECTORY_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
-	}
+    {
+        return MavlinkStreamCaTrajectory::get_name_static();
+    }
+    static const char *get_name_static()
+    {
+        return "CA_TRAJECTORY";
+    }
+    uint8_t get_id()
+    {
+        return MAVLINK_MSG_ID_CA_TRAJECTORY;
+    }
+    static MavlinkStream *new_instance(Mavlink *mavlink)
+    {
+        return new MavlinkStreamCaTrajectory(mavlink);
+    }
+    unsigned get_size()
+    {
+        return MAVLINK_MSG_ID_CA_TRAJECTORY_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+    }
 
 private:
-	MavlinkOrbSubscription *_sub;
-	uint64_t _ca_traj_time;
+    MavlinkOrbSubscription *_sub;
+    uint64_t _ca_traj_time;
 
-	/* do not allow top copying this class */
-	MavlinkStreamCaTrajectory(MavlinkStreamCaTrajectory &);
-	MavlinkStreamCaTrajectory& operator = (const MavlinkStreamCaTrajectory &);
+    /* do not allow top copying this class */
+    MavlinkStreamCaTrajectory(MavlinkStreamCaTrajectory &);
+    MavlinkStreamCaTrajectory& operator = (const MavlinkStreamCaTrajectory &);
 
 protected:
-	explicit MavlinkStreamCaTrajectory(Mavlink *mavlink) : MavlinkStream(mavlink),
-		_sub(_mavlink->add_orb_subscription(ORB_ID(ca_trajectory))),  // make sure you enter the name of your uORB topic here
-		_ca_traj_time(0)
-	{}
+    explicit MavlinkStreamCaTrajectory(Mavlink *mavlink) : MavlinkStream(mavlink),
+        _sub(_mavlink->add_orb_subscription(ORB_ID(ca_trajectory))),  // make sure you enter the name of your uORB topic here
+        _ca_traj_time(0)
+    {}
 
-	void send(const hrt_abstime t)
-	{
-		struct ca_traj_struct_s _ca_trajectory;    //make sure ca_traj_struct_s is the definition of your uORB topic
+    void send(const hrt_abstime t)
+    {
+        struct ca_traj_struct_s _ca_trajectory;    //make sure ca_traj_struct_s is the definition of your uORB topic
 
-		if (_sub->update(&_ca_traj_time, &_ca_trajectory)) {
-			mavlink_ca_trajectory_t _msg_ca_trajectory;  //make sure mavlink_ca_trajectory_t is the definition of your custom mavlink message
+        if (_sub->update(&_ca_traj_time, &_ca_trajectory)) {
+            mavlink_ca_trajectory_t _msg_ca_trajectory;  //make sure mavlink_ca_trajectory_t is the definition of your custom MAVLink message
 
-			_msg_ca_trajectory.timestamp = _ca_trajectory.timestamp;
-			_msg_ca_trajectory.time_start_usec = _ca_trajectory.time_start_usec;
-			_msg_ca_trajectory.time_stop_usec  = _ca_trajectory.time_stop_usec;
-			_msg_ca_trajectory.coefficients =_ca_trajectory.coefficients;
-			_msg_ca_trajectory.seq_id = _ca_trajectory.seq_id;
+            _msg_ca_trajectory.timestamp = _ca_trajectory.timestamp;
+            _msg_ca_trajectory.time_start_usec = _ca_trajectory.time_start_usec;
+            _msg_ca_trajectory.time_stop_usec  = _ca_trajectory.time_stop_usec;
+            _msg_ca_trajectory.coefficients =_ca_trajectory.coefficients;
+            _msg_ca_trajectory.seq_id = _ca_trajectory.seq_id;
 
-			_mavlink->send_message(MAVLINK_MSG_ID_CA_TRAJECTORY, &_msg_ca_trajectory);
-		}
-	}
+            _mavlink->send_message(MAVLINK_MSG_ID_CA_TRAJECTORY, &_msg_ca_trajectory);
+        }
+    }
 };
 ```
 
@@ -93,7 +95,7 @@ nullptr
 
 Then make sure to enable the stream, for example by adding the following line to
 the startup script (`-r` configures the streaming rate, `-u` identifies the
-mavlink channel on UDP port 14556):
+MAVLink channel on UDP port 14556):
 
 ```
 mavlink stream -r 50 -s CA_TRAJECTORY -u 14556
@@ -101,10 +103,10 @@ mavlink stream -r 50 -s CA_TRAJECTORY -u 14556
 
 
 ## Receiving Custom MAVLink Messages
-This section explains how to receive a message over mavlink and publish it to
-uORB.
 
-Add a function that handles the incoming mavlink message in
+This section explains how to receive a message over MAVLink and publish it to uORB.
+
+Add a function that handles the incoming MAVLink message in
 [mavlink_receiver.h](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_receiver.h#L77)
 
 ```C
@@ -112,8 +114,7 @@ Add a function that handles the incoming mavlink message in
 #include <v1.0/custom_messages/mavlink_msg_ca_trajectory.h>
 ```
 
-Add a function that handles the incoming mavlink message in the
-`MavlinkReceiver` class in
+Add a function that handles the incoming MAVLink message in the `MavlinkReceiver` class in
 [mavlink_receiver.h](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_receiver.h#L140)
 
 ```C
@@ -129,28 +130,27 @@ orb_advert_t _ca_traj_msg_pub;
 Implement the `handle_message_ca_trajectory_msg` function in [mavlink_receiver.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_receiver.cpp)
 
 ```C
-void
-MavlinkReceiver::handle_message_ca_trajectory_msg(mavlink_message_t *msg)
+void MavlinkReceiver::handle_message_ca_trajectory_msg(mavlink_message_t *msg)
 {
-	mavlink_ca_trajectory_t traj;
-	mavlink_msg_ca_trajectory_decode(msg, &traj);
+    mavlink_ca_trajectory_t traj;
+    mavlink_msg_ca_trajectory_decode(msg, &traj);
 
-	struct ca_traj_struct_s f;
-	memset(&f, 0, sizeof(f));
+    struct ca_traj_struct_s f;
+    memset(&f, 0, sizeof(f));
 
-	f.timestamp = hrt_absolute_time();
-	f.seq_id = traj.seq_id;
-	f.time_start_usec = traj.time_start_usec;
-	f.time_stop_usec = traj.time_stop_usec;
-	for(int i=0;i<28;i++)
-		f.coefficients[i] = traj.coefficients[i];
+    f.timestamp = hrt_absolute_time();
+    f.seq_id = traj.seq_id;
+    f.time_start_usec = traj.time_start_usec;
+    f.time_stop_usec = traj.time_stop_usec;
+    for(int i=0;i<28;i++)
+        f.coefficients[i] = traj.coefficients[i];
 
-	if (_ca_traj_msg_pub == nullptr) {
-		_ca_traj_msg_pub = orb_advertise(ORB_ID(ca_trajectory), &f);
+    if (_ca_traj_msg_pub == nullptr) {
+        _ca_traj_msg_pub = orb_advertise(ORB_ID(ca_trajectory), &f);
 
-	} else {
-		orb_publish(ORB_ID(ca_trajectory), _ca_traj_msg_pub, &f);
-	}
+    } else {
+        orb_publish(ORB_ID(ca_trajectory), _ca_traj_msg_pub, &f);
+    }
 }
 ```
 
@@ -159,34 +159,37 @@ and finally make sure it is called in [MavlinkReceiver::handle_message()](https:
 ```C
 MavlinkReceiver::handle_message(mavlink_message_t *msg)
  {
- 	switch (msg->msgid) {
+    switch (msg->msgid) {
         ...
-	case MAVLINK_MSG_ID_CA_TRAJECTORY:
-		handle_message_ca_trajectory_msg(msg);
-		break;
-		...
- 	}
+    case MAVLINK_MSG_ID_CA_TRAJECTORY:
+        handle_message_ca_trajectory_msg(msg);
+        break;
+        ...
+    }
 ```
 
 ## Alternative to Creating Custom MAVLink Messages
+
 Sometimes there is the need for a custom MAVLink message with content that is not fully defined.
 
 For example when using MAVLink to interface PX4 with an embedded device, the messages that are exchanged between the autopilot and the device may go through several iterations before they are stabilized.
-In this case, it can be time-consumming and error-prone to regenerate the MAVLink headers, and make sure both devices use the same version of the protocol.
+In this case, it can be time-consuming and error-prone to regenerate the MAVLink headers, and make sure both devices use the same version of the protocol.
 
-An alternative - and temporary - solution is to repurpose debug messages. 
+An alternative - and temporary - solution is to re-purpose debug messages. 
 Instead of creating a custom MAVLink message `CA_TRAJECTORY`, you can send a message `DEBUG_VECT` with the string key `CA_TRAJ` and data in the `x`, `y` and `z` fields.
 See [this tutorial](../debug/debug_values.md). for an example usage of debug messages.
 
 > **Note** This solution is not efficient as it sends character string over the network and involves comparison of strings. It should be used for development only!
 
 ## General
+
 ### Set streaming rate
+
 Sometimes it is useful to increase the streaming rate of individual topics (e.g. for inspection in QGC). This can be achieved by the following line
 ```sh
 mavlink stream -u <port number> -s <mavlink topic name> -r <rate>
 ```
-You can get the port number with ```mavlink status``` which will output (amongst others) ```transport protocol: UDP (<port number>)```. An example would be
+You can get the port number with `mavlink status` which will output (amongst others) `transport protocol: UDP (<port number>)`. An example would be
 ```sh
 mavlink stream -u 14556 -s OPTICAL_FLOW_RAD -r 300
 ```

--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -1,4 +1,4 @@
-# Using Vision or Motion Capture systems
+# Using Vision or Motion Capture Systems
 
 > **Info** Before following the instructions below, ensure that your autopilot has a firmware version with the LPE modules enabled. The LPE version of the PX4 firmware can be found inside the zip file of the latest PX4 release or it can be built from source using a build command such as `make px4fmu-v2_lpe`. See [Building the Code](../setup/building_px4.md) for more details.
 
@@ -8,15 +8,16 @@ Position estimates can be sent both from an onboard computer as well as from off
 
 The system can then be used for applications such as position hold indoors or waypoint navigation based on vision.
 
-For vision, the mavlink message used to send the pose data is [VISION_POSITION_ESTIMATE](http://mavlink.org/messages/common#VISION_POSITION_ESTIMATE) and the message for all motion capture systems is [ATT_POS_MOCAP](http://mavlink.org/messages/common#ATT_POS_MOCAP) messages.
+For vision, the MAVLink message used to send the pose data is [VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE) and the message for all motion capture systems is [ATT_POS_MOCAP](https://mavlink.io/en/messages/common.html#ATT_POS_MOCAP) messages.
 
-The mavros ROS-Mavlink interface has default implementations to send these messages. They can also be sent using pure C/C++ code and direct use of the MAVLink library. The ROS topics are: `mocap_pose_estimate` for mocap systems and `vision_pose_estimate` for vision. Check [mavros_extras](http://wiki.ros.org/mavros_extras) for further info.
+The mavros ROS-MAVLink interface has default implementations to send these messages. They can also be sent using pure C/C++ code and direct use of the MAVLink library. The ROS topics are: `mocap_pose_estimate` for mocap systems and `vision_pose_estimate` for vision. Check [mavros_extras](http://wiki.ros.org/mavros_extras) for further info.
 
 **This feature has only been tested to work with the LPE estimator.**
 
 ## LPE Tuning for Vision or Mocap
 
 ### Enabling external pose input
+
 You need to set a few parameters (from QGroundControl or the NSH shell) to enable or disable vision/mocap usage in the system.
 
 Set the system parameter `ATT_EXT_HDG_M` to 1 or 2 to enable external heading integration. Setting it to 1 will cause vision to be used, while 2 enables mocap heading use. 
@@ -24,17 +25,19 @@ Set the system parameter `ATT_EXT_HDG_M` to 1 or 2 to enable external heading in
 Vision integration is enabled by default in LPE. You can control this using the`LPE_FUSION` parameter in QGroundControl. Make sure that "fuse vision position" is checked.
 
 #### Disabling barometer fusion
+
 If a highly accurate altitude is already available from vision or mocap information, it may be useful to disable the baro correction in LPE to reduce drift on the Z axis.
 
 There is a bit field for this in the parameter `LPE_FUSION`, which you can set from QGroundControl. Just uncheck "fuse baro".
 
-#### Tuning noise parameters
+#### Tuning Noise Parameters
 
 If your vision or mocap data is highly accurate, and you just want the estimator to track it tightly, you should reduce the standard deviation parameters, `LPE_VIS_XY` and `LPE_VIS_Z` (for vision) or `LPE_VIC_P` (for motion capture). Reducing them will cause the estimator to trust the incoming pose estimate more. You may need to set them lower than the allowed minimum and force-save. 
 
 > **Tip**If performance is still poor, try increasing the `LPE_PN_V` parameter. This will cause the estimator to trust measurements more during velocity estimation..
 
-## Asserting on reference frames
+## Asserting on Reference Frames
+
 This section shows how to setup the system with the proper reference frames. There are various representations but we will use two of them: ENU and NED. 
 
 * ENU has a ground-fixed frame where *x* axis points East, *y* points North and *z* up. Robot frame is *x* towards the front, *z* up and *y* accordingly.
@@ -42,6 +45,7 @@ This section shows how to setup the system with the proper reference frames. The
 * NED has *x* towards North, *y* East and *z* down. Robot frame is *x* towards the front, *z* down and *y* accordingly.
 
 Frames are shown in the image below: NED on the left while ENU on the right.
+
 ![Reference frames](../../assets/lpe/ref_frames.png)
 
 With the external heading estimation, however, magnetic North is ignored and faked with a vector corresponding to world *x* axis (which can be placed freely at mocap calibration); yaw angle will be given respect to local *x*.
@@ -53,11 +57,12 @@ With the external heading estimation, however, magnetic North is ignored and fak
 With MAVROS this operation is straightforward. ROS uses ENU frames as convention, therefore position feedback must be provided in ENU. If you have an Optitrack system you can use [mocap_optitrack](https://github.com/ros-drivers/mocap_optitrack) node which streams the object pose on a ROS topic already in ENU. With a remapping you can directly publish it on `mocap_pose_estimate` as it is without any transformation and mavros will take care of NED conversions.
 
 ### Without Mavros
-If you do not use MAVROS or ROS in general, you need to stream data over Mavlink with `ATT_POS_MOCAP` message. In this case you will need to apply a custom transformation depending on the system in order to obtain NED convention.
+
+If you do not use MAVROS or ROS in general, you need to stream data over MAVLink with `ATT_POS_MOCAP` message. In this case you will need to apply a custom transformation depending on the system in order to obtain NED convention.
 
 Let us take as an example the Optitrack framework; in this case the local frame has $$x$$ and $$z$$ on the horizontal plane (*x* front and *z* right) while *y* axis is vertical and pointing up. A simple trick is swapping axis in order to obtained NED convention. 
 
-We call *x_{mav}*, *y_{mav}* and *z_{mav}* the coordinates that are sent through Mavlink as position feedback, then we obtain:
+We call *x_{mav}*, *y_{mav}* and *z_{mav}* the coordinates that are sent through MAVLink as position feedback, then we obtain:
 
 *x_{mav}* = *x_{mocap}*
 *y_{mav}* = *z_{mocap}*
@@ -65,39 +70,30 @@ We call *x_{mav}*, *y_{mav}* and *z_{mav}* the coordinates that are sent through
 
 Regarding the orientation, keep w the same and swap quaternion x y and z in the same way. You can apply this trick with every system; you need to obtain a NED frame, look at your mocap output and swap axis accordingly.
 
-## First flight
+## First Flight
+
 At this point, if you followed those steps, you are ready to test your setup. 
 
 Be sure to perform the following checks:
 
 * **Before** creating the rigid body, align the robot with world x axis
-
-* Stream over Mavlink and check the Mavlink inspector with Qgroundcontrol, the local pose topic should be in NED
-
+* Stream over MAVLink and check the MAVLink inspector with QGroundControl, the local pose topic should be in NED
 * Move the robot around by hand and see if the estimated local position is consistent (always in NED)
-
-* Rotate the robot on the vertical axis and check the yaw with the Mavlink inspector
+* Rotate the robot on the vertical axis and check the yaw with the MAVLink inspector
 
 If those steps are consistent, you can try your first flight.
 
 Put the robot on the ground and start streaming mocap feedback. Lower your left stick and arm the motors.
 
-At this point, with the left stick at the lowest position, switch to position control. You should have a green light. The green light tells you that position feedback is available and position control is now activated. 
+At this point, with the left stick at the lowest position, switch to position control. 
+You should have a green light. The green light tells you that position feedback is available and position control is now activated. 
 
-Put your left stick at the middle, this is the dead zone. With this stick value, the robot maintain its altitude; rising the stick will increase the reference altitude while lowering the value will decrease it. Same for right stick on x and y. 
+Put your left stick at the middle, this is the dead zone. 
+With this stick value, the robot maintains its altitude; 
+raising the stick will increase the reference altitude while lowering the value will decrease it. 
+Same for right stick on x and y. 
 
-Increase the value of the left stick and the robot will take off, put it back to the middle right after. Check if it is able to keep its position.
+Increase the value of the left stick and the robot will take off, 
+put it back to the middle right after. Check if it is able to keep its position.
 
-If it works, you may want to set up an [offboard](offboard_control.md) experiment by sending position-setpoint form a remote ground station.
-
-
-
-
-
-
-
-
-
-
-
-
+If it works, you may want to set up an [offboard](offboard_control.md) experiment by sending position-setpoint from a remote ground station.

--- a/en/ros/offboard_control.md
+++ b/en/ros/offboard_control.md
@@ -1,18 +1,21 @@
 # Offboard Control
 
-> **Warning** Offboard control is dangerous. It is the responsibility of the developer to ensure adequate preparation, testing and safety precautions are taken before offboard flights.
+> **Warning** [Offboard control](https://docs.px4.io/en/flight_modes/offboard.html) is dangerous. It is the responsibility of the developer to ensure adequate preparation, testing and safety precautions are taken before offboard flights.
 
-The idea behind off-board control is to be able to control the px4 flight stack using software running outside of the autopilot. This is done through the Mavlink protocol, specifically the [SET_POSITION_TARGET_LOCAL_NED](http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED) and the [SET_ATTITUDE_TARGET](http://mavlink.org/messages/common#SET_ATTITUDE_TARGET) messages.
+The idea behind off-board control is to be able to control the PX4 flight stack using software running outside of the autopilot. This is done through the Mavlink protocol, specifically the [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED) and the [SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET) messages.
 
 ## Offboard Control Firmware Setup
+
 There are two things you want to setup on the firmware side before starting offboard development.
 
 ### 1. Map an RC switch to offboard mode activation
-To do this, load up the parameters in qGroundcontrol and look for the RC_MAP_OFFB_SW parameter to which you can assign the RC channel you want to use to activate offboard mode. It can be useful to map things in such a way that when you fall out of offboard mode you go into position control.
+
+To do this, load up the parameters in *QGroundControl* and look for the RC_MAP_OFFB_SW parameter to which you can assign the RC channel you want to use to activate offboard mode. It can be useful to map things in such a way that when you fall out of offboard mode you go into position control.
 
 Although this step isn't mandatory since you can activate offboard mode using a MAVLink message. We consider this method much safer.
 
 ### 2. Enable the companion computer interface
+
 Look for the [SYS_COMPANION](../advanced/parameter_reference.md#SYS_COMPANION) parameter and set it to either 921600 (Recommended) or 57600. This parameter will activate a MAVLink stream on the Telem2 port with data streams specific to onboard mode with the appropriate baud rate (921600 8N1 or 57600 8N1). 
 
 For more information on these data streams, look for "MAVLINK_MODE_ONBOARD" in the [source code](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_main.cpp).
@@ -22,10 +25,11 @@ For more information on these data streams, look for "MAVLINK_MODE_ONBOARD" in t
 Usually, there are three ways of setting up offboard communication.
 
 ### 1. Serial radios
+
 1. One connected to a UART port of the autopilot
 2. One connected to a ground station computer
 
-Example radios include
+Example radios include:
 * [Lairdtech RM024](http://www.lairdtech.com/products/rm024)
 * [Digi International XBee Pro](http://www.digi.com/products/xbee-rf-solutions/modules)
 
@@ -37,14 +41,16 @@ graph TD;
 {% endmermaid %}
 
 ### 2. On-board processor
-A small computer mounted onto the vehicle connected to the autopilot through a UART to USB adapter. There are many possibilities here and it will depend on what kind of additional on-board processing you want to do in addition to sending commands to the autopilot.
+
+A small computer mounted onto the vehicle connected to the autopilot through a UART to USB adapter. 
+There are many possibilities here and it will depend on what kind of additional on-board processing you want to do in addition to sending commands to the autopilot.
 
 Small low power examples:
 * [Odroid C1+](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G143703355573) or [Odroid XU4](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G143452239825)
 * [Raspberry Pi](https://www.raspberrypi.org/)
 * [Intel Edison](http://www.intel.com/content/www/us/en/do-it-yourself/edison.html)
 
-Larger high power examples
+Larger high power examples:
 * [Intel NUC](http://www.intel.com/content/www/us/en/nuc/overview.html)
 * [Gigabyte Brix](http://www.gigabyte.com/products/list.aspx?s=47&ck=104)
 * [Nvidia Jetson TK1](https://developer.nvidia.com/jetson-tk1)
@@ -56,7 +62,10 @@ graph TD;
 {% endmermaid %}
 
 ### 3. On-board processor and wifi link to ROS (***Recommended***)
-A small computer mounted onto the vehicle connected to the autopilot through a UART to USB adapter while also having a WiFi link to a ground station running ROS. This can be any of the computers from the above section coupled with a WiFi adapter. For example, the Intel NUC D34010WYB has a PCI Express Half-Mini connector which can accomodate an [Intel Wifi Link 5000](http://www.intel.com/products/wireless/adapters/5000/) adapter.
+
+A small computer mounted onto the vehicle connected to the autopilot through a UART to USB adapter while also having a WiFi link to a ground station running ROS. 
+This can be any of the computers from the above section coupled with a WiFi adapter. 
+For example, the Intel NUC D34010WYB has a PCI Express Half-Mini connector which can accommodate an [Intel Wifi Link 5000](http://www.intel.com/products/wireless/adapters/5000/) adapter.
 
 
 {% mermaid %}

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -39,16 +39,16 @@ The messages are described below (see links for specific detail).
 
 Message | Direction | Description
 --- | --- | ---
-[MAV_MODE:MAV_MODE_FLAG_HIL_ENABLED](http://mavlink.org/messages/common#MAV_MODE_FLAG_HIL_ENABLED) | NA | Mode flag when using simulation. All motors/actuators are blocked, but internal software is fully operational.
-[HIL_ACTUATOR_CONTROLS](http://mavlink.org/messages/common#HIL_ACTUATOR_CONTROLS) | PX4 to Sim | PX4 control outputs (to motors, actuators).
-[HIL_SENSOR](http://mavlink.org/messages/common#HIL_SENSOR) | Sim to PX4 | Simulated IMU readings in SI units in NED body frame.
-[HIL_GPS](http://mavlink.org/messages/common#HIL_GPS) | Sim to PX4 | The simulated GPS RAW sensor value.
-[HIL_OPTICAL_FLOW](http://mavlink.org/messages/common#HIL_OPTICAL_FLOW) | Sim to PX4 | Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)
-[HIL_STATE_QUATERNION](http://mavlink.org/messages/common#HIL_STATE_QUATERNION) | Sim to PX4 | Contains the actual "simulated" vehicle position, attitude, speed etc. This can be logged and compared to PX4's estimates for analysis and debugging (for example, checking how well an estimator works for noisy (simulated) sensor inputs).
-[HIL_RC_INPUTS_RAW](http://mavlink.org/messages/common#HIL_RC_INPUTS_RAW) | Sim to PX4 | The RAW values of the RC channels received.
+[MAV_MODE:MAV_MODE_FLAG_HIL_ENABLED](https://mavlink.io/en/messages/common.html#MAV_MODE_FLAG_HIL_ENABLED) | NA | Mode flag when using simulation. All motors/actuators are blocked, but internal software is fully operational.
+[HIL_ACTUATOR_CONTROLS](https://mavlink.io/en/messages/common.html#HIL_ACTUATOR_CONTROLS) | PX4 to Sim | PX4 control outputs (to motors, actuators).
+[HIL_SENSOR](https://mavlink.io/en/messages/common.html#HIL_SENSOR) | Sim to PX4 | Simulated IMU readings in SI units in NED body frame.
+[HIL_GPS](https://mavlink.io/en/messages/common.html#HIL_GPS) | Sim to PX4 | The simulated GPS RAW sensor value.
+[HIL_OPTICAL_FLOW](https://mavlink.io/en/messages/common.html#HIL_OPTICAL_FLOW) | Sim to PX4 | Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)
+[HIL_STATE_QUATERNION](https://mavlink.io/en/messages/common.html#HIL_STATE_QUATERNION) | Sim to PX4 | Contains the actual "simulated" vehicle position, attitude, speed etc. This can be logged and compared to PX4's estimates for analysis and debugging (for example, checking how well an estimator works for noisy (simulated) sensor inputs).
+[HIL_RC_INPUTS_RAW](https://mavlink.io/en/messages/common.html#HIL_RC_INPUTS_RAW) | Sim to PX4 | The RAW values of the RC channels received.
 
 
-## Default PX4 MAVLink UDP ports
+## Default PX4 MAVLink UDP Ports
 
 By default, PX4 uses commonly established UDP ports for MAVLink communication with ground control stations (e.g. *QGroundControl*), Offboard APIs (e.g. DroneCore, MAVROS) and simulator APIs (e.g. Gazebo). These ports are:
 
@@ -237,7 +237,7 @@ The diagram below shows a typical HITL simulation environment:
 
 ## Joystick/Gamepad Integration
 
-*QGroundControl* desktop versions can connect to a USB Joystick/Gamepad and send its movement commands and button presses to PX4 over MAVLink. This works on both SITL and HITL simulations, and allows you to directly control the simulated vehicle. If you don't have a joystick you can alternatively control the vehicle using QGroundControl's onscreen virtual thumbsticks.  
+*QGroundControl* desktop versions can connect to a USB Joystick/Gamepad and send its movement commands and button presses to PX4 over MAVLink. This works on both SITL and HITL simulations, and allows you to directly control the simulated vehicle. If you don't have a joystick you can alternatively control the vehicle using QGroundControl's onscreen virtual thumbsticks.
 
 For setup information see the *QGroundControl User Guide*:
 * [Joystick Setup](https://docs.qgroundcontrol.com/en/SetupView/Joystick.html)

--- a/en/tutorials/motion-capture-vicon-optitrack.md
+++ b/en/tutorials/motion-capture-vicon-optitrack.md
@@ -5,7 +5,7 @@
 Indoor motion capture systems like VICON and Optitrack can be used to provide position and attitude data for vehicle state estimation, orto serve as ground-truth for analysis.
 The motion capture data can be used to update PX4's local position estimate relative to the local origin. Heading (yaw) from the motion capture system can also be optionally integrated by the attitude estimator.
 
-Pose (position and orientation) data from the motion capture system is sent to the autopilot over MAVLink, using the [ATT_POS_MOCAP](http://mavlink.org/messages/common#ATT_POS_MOCAP) message. See the section below on coordinate frames for data representation conventions. The [mavros](../ros/mavros_installation.md) ROS-Mavlink interface has a default plugin to send this message. They can also be sent using pure C/C++ code and direct use of the MAVLink library.
+Pose (position and orientation) data from the motion capture system is sent to the autopilot over MAVLink, using the [ATT_POS_MOCAP](https://mavlink.io/en/messages/common.html#ATT_POS_MOCAP) message. See the section below on coordinate frames for data representation conventions. The [mavros](../ros/mavros_installation.md) ROS-Mavlink interface has a default plugin to send this message. They can also be sent using pure C/C++ code and direct use of the MAVLink library.
 
 ## Computing Architecture
 
@@ -18,15 +18,14 @@ Most standard telemetry links like 3DR/SiK radios are **not** suitable for high-
 This section shows how to setup the system with the proper reference frames. There are various representations but we will use two of them: ENU and NED. 
 
 * ENU is a ground-fixed frame where **X** axis points East, **Y** points North and **Z** up. The robot/vehicle body frame is **X** towards the front, **Z** up and **Y** towards the left.
-
 * NED has **X** towards North, **Y** East and **Z** down. The robot/vehicle body frame has **X** towards the front, **Z** down and **Y** accordingly.
 
-Frames are shown in the image below. NED on the left, ENU on the right :
+Frames are shown in the image below. NED on the left, ENU on the right:
 ![Reference frames](../../assets/lpe/ref_frames.png)
 
 With the external heading estimation, however, magnetic North is ignored and faked with a vector corresponding to world *x* axis (which can be placed freely at mocap calibration); yaw angle will be given respect to local *x*.
 
-> **Important : ** When creating the rigid body in the motion capture software, remember to first align the robot with the world **X** axis otherwise yaw estimation will have an initial offset.
+> **Warning** When creating the rigid body in the motion capture software, remember to first align the robot with the world **X** axis otherwise yaw estimation will have an initial offset.
 
 
 ## Estimator choice

--- a/en/tutorials/optical_flow.md
+++ b/en/tutorials/optical_flow.md
@@ -1,8 +1,10 @@
 # Optical Flow
+
 Optical Flow uses a downward facing camera and a downward facing distance sensor for position estimation. Optical Flow based navigation is supported by all three estimators: EKF2, LPE and INAV (see below).
 
 ## Setup
-As mentioned above, an Optical Flow setup requires a downward facing camera which publishes to the [`OPTICAL_FLOW_RAD` topic](http://mavlink.org/messages/common#OPTICAL_FLOW_RAD) and a distance sensor (preferably a LiDAR) publishing messages to the [`DISANCE_SENSOR` topic](http://mavlink.org/messages/common#DISTANCE_SENSOR).
+
+As mentioned above, an Optical Flow setup requires a downward facing camera which publishes to the [`OPTICAL_FLOW_RAD` topic](https://mavlink.io/en/messages/common.html#OPTICAL_FLOW_RAD) and a distance sensor (preferably a LiDAR) publishing messages to the [`DISANCE_SENSOR` topic](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR).
 
 The output of the flow has to be as follows
 
@@ -13,20 +15,22 @@ The output of the flow has to be as follows
 | Right | - X |
 | Left | + X |
 
-And for pure rotations, the integraded_xgyro and integraded_x (respectively integraded_ygyro and integraded_y) have to be the same.
+And for pure rotations, the `integraded_xgyro` and `integraded_x` (respectively `integraded_ygyro` and `integraded_y`) have to be the same.
 
 An exemplary setup is the PX4Flow and LIDAR-Lite (see picture).
 
-![](../../assets/hardware/optical_flow/flow_lidar_attached.jpg)
+![Optical flog lidar attached](../../assets/hardware/optical_flow/flow_lidar_attached.jpg)
 
 ### Cameras
 
 #### PX4Flow
+
 The easiest way to calculate the optical flow is to use the PX4Flow board. In order to use the PX4Flow board, just connect it with I2C. The recommended way of mounting it is with the Sonar side facing forwards (see image). In this configuration the parameter `SENS_FLOW_ROT` should be 270 degrees (which is the default). Make sure the the PX4Flow board is well dampened.
 
 ![](../../assets/hardware/optical_flow/px4flowalignwithpixhawk.jpg)
 
-##### Custom I2C address
+##### Custom I2C Address
+
 The default I2C address of the PX4Flow is 0x42, but it can be incremented using the three solder jumpers labeled "I2C BUS ADDR" on the picture above. This is useful if another device has the same address.
 The address increment is equal to the 3-bit value encoded by the jumpers. For example if jumper 0 and 1 are soldered and jumper 2 is unsoldered, the address is incremented by 1\*1 + 1\*2 + 0\*4 = 3, which gives address 0x45.
 If all jumpers are unsoldered, the camera will be automatically discovered by the autopilot firmware.
@@ -37,10 +41,11 @@ px4flow stop
 px4flow start -a 0x45          # address=0x45
 ```
 
-##### Focusing the lens
+##### Focusing the Lens
+
 In order to ensure good optical flow quality, it is important to focus the camera on the PX4Flow to the desired height of flight. To focus the camera, put an object with text on (e. g. a book) and plug in the PX4Flow into USB and run QGroundControl. Under the settings menu, select the PX4Flow and you should see a camera image. Focus the lens by unscrewing the set screw and loosening and tightening the lens to find where it is in focus.
 
-**Note: If you fly above 3m, the camera will be focused at infinity and won't need to be changed for higher flight.**
+> **Note** If you fly above 3m, the camera will be focused at infinity and won't need to be changed for higher flight.
 
 ![](../../assets/flow/flow_focus_book.png)
 
@@ -52,11 +57,12 @@ In order to ensure good optical flow quality, it is important to focus the camer
 *Figure: The px4flow interface in QGroundControl that can be used for focusing the camera*
 
 
+#### Other Cameras
 
-#### Other cameras
 It is also possible to use a board/quad that has an integrated camera (Bebop2, Snapdragon Flight). For this the [Optical Flow repo](https://github.com/PX4/OpticalFlow) can be used (see also [snap_cam](https://github.com/PX4/snap_cam)).
 
 ### Range Finder
+
 We recommend using a LIDAR over a Sonar, because of robustness and accuracy. One possibility is the [LIDAR-Lite](https://pixhawk.org/peripherals/rangefinder).
 
 ## Estimators
@@ -72,20 +78,23 @@ The INAV has a fixed gain matrix for correction and can be viewed as a steady st
 
 
 #### Flight Video Indoor
+
 {% youtube %}https://www.youtube.com/watch?v=MtmWYCEEmS8{% endyoutube %}
 
 #### Flight Video Outdoor
+
 {% youtube %}https://www.youtube.com/watch?v=4MEEeTQiWrQ{% endyoutube %}
 
 
 #### Parameters
+
 * `INAV_LIDAR_EST` Set to 1 to enable altitude estimation based on distance measurements
 * `INAV_FLOW_DIST_X` and `INAV_FLOW_DIST_Y`
-	These two values (in meters) are used for yaw compensation.
-	The offset has to be measured according to Figure 1 above.
-	In the above example the offset of the PX4Flow (red dot) would have a negative X offset and a negative Y offset.
+   These two values (in meters) are used for yaw compensation.
+   The offset has to be measured according to Figure 1 above.
+   In the above example the offset of the PX4Flow (red dot) would have a negative X offset and a negative Y offset.
 * `INAV_LIDAR_OFF`
-	Set a calibration offset for the lidar-lite in meters. The value will be added to the measured distance.
+   Set a calibration offset for the lidar-lite in meters. The value will be added to the measured distance.
 
 
 #### Advanced Parameters
@@ -93,6 +102,6 @@ The INAV has a fixed gain matrix for correction and can be viewed as a steady st
 For advanced usage/development the following parameters can be changed as well. Do NOT change them if you do not know what you are doing!
 
 * `INAV_FLOW_W`
-	Sets the weight for the flow estimation/update
+   Sets the weight for the flow estimation/update
 * `INAV_LIDAR_ERR`
-	Sets the threshold for altitude estimation/update in meters. If the correction term is bigger than this value, it will not be used for the update. -->
+   Sets the threshold for altitude estimation/update in meters. If the correction term is bigger than this value, it will not be used for the update. -->

--- a/kr/middleware/mavlink.md
+++ b/kr/middleware/mavlink.md
@@ -1,5 +1,5 @@
 # MAVLink Messaging
-전체 메시지에 대한 개요는 다음 링크를 참고하세요. [여기](http://mavlink.org/messages/common).
+전체 메시지에 대한 개요는 다음 링크를 참고하세요. [여기](https://mavlink.io/en/messages/).
 ## 커스텀 MAVLink Messages 생성
 여기 튜터리얼에서는 `msg/ca_trajectory.msg`에 있는 [custom uORB](../middleware/uorb.md) `ca_trajectory`와 `mavlink/include/mavlink/v1.0/custom_messages/mavlink_msg_ca_trajectory.h`에 있는 커스텀 mavlink `ca_trajectory` 메시지를 가지고 있다고 가정합니다. (
 [여기](http://qgroundcontrol.org/mavlink/create_new_mavlink_message)에서 커스텀 mavlink 메시지와 헤더 생성하는 방법을 참고).

--- a/kr/ros/external_position_estimation.md
+++ b/kr/ros/external_position_estimation.md
@@ -8,7 +8,7 @@ position estimate는 오프보드(예로 VICON) 뿐만 아니라 온보드 컴�
 
 시스템은 실내 position hold나 비젼 기반 waypoint 네비게이션과 같은 어플리케이션으로 사용될 수 있습니다.
 
-비전에 관해서 pose data를 보내는데 사용하는 mavlink 메시지는 [VISION_POSITION_ESTIMATE](http://mavlink.org/messages/common#VISION_POSITION_ESTIMATE)와 모션 캡쳐 시스템에 관한 모든 메시지는 [ATT_POS_MOCAP](http://mavlink.org/messages/common#ATT_POS_MOCAP) 메시지입니다.
+비전에 관해서 pose data를 보내는데 사용하는 mavlink 메시지는 [VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE)와 모션 캡쳐 시스템에 관한 모든 메시지는 [ATT_POS_MOCAP](https://mavlink.io/en/messages/common.html#ATT_POS_MOCAP) 메시지입니다.
 
 mavros ROS-Mavlink 인터페이스는 기본적으로 이런 메시지를 보내는 구현을 가지고 있습니다. 이 메시지는 순수 C/C++ 코드와 MAVLink 라이브러리를 직접 사용하는 방식으로 전달할 수 있습니다.
 

--- a/kr/ros/offboard_control.md
+++ b/kr/ros/offboard_control.md
@@ -2,7 +2,7 @@
 
 > ** Warning ** 오프보드 제어는 위험합니다. 오프보드 비행 전에 안전을 위해 준비, 테스팅, 안전에 관해 예방책을 마련하는 것은 개발자의 몫입니다.
 
-오프보드 제어의 기반 아이디어는 autopilot 외부에서 실행되는 소프트웨어로 px4 flight stack을 제어할 수 있다는 것입니다. Mavlink 프로토콜을 통해 이뤄지며 특별히 [SET_POSITION_TARGET_LOCAL_NED](http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED)와 [SET_ATTITUDE_TARGET](http://mavlink.org/messages/common#SET_ATTITUDE_TARGET) 메시지와 관련이 있습니다.
+오프보드 제어의 기반 아이디어는 autopilot 외부에서 실행되는 소프트웨어로 px4 flight stack을 제어할 수 있다는 것입니다. Mavlink 프로토콜을 통해 이뤄지며 특별히 [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)와 [SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET) 메시지와 관련이 있습니다.
 
 ## 오프보드 제어 펌웨어 셋업
 오프보드 개발을 시작하기 전에 펌웨어 쪽에 필요한 셋업 2가지

--- a/kr/simulation/README.md
+++ b/kr/simulation/README.md
@@ -39,13 +39,13 @@ The messages are described below (see links for specific detail).
 
 Message | Direction | Description
 --- | --- | ---
-[MAV_MODE:MAV_MODE_FLAG_HIL_ENABLED](http://mavlink.org/messages/common#MAV_MODE_FLAG_HIL_ENABLED) | NA | Mode flag when using simulation. All motors/actuators are blocked, but internal software is fully operational.
-[HIL_ACTUATOR_CONTROLS](http://mavlink.org/messages/common#HIL_ACTUATOR_CONTROLS) | PX4 to Sim | PX4 control outputs (to motors, actuators).
-[HIL_SENSOR](http://mavlink.org/messages/common#HIL_SENSOR) | Sim to PX4 | Simulated IMU readings in SI units in NED body frame.
-[HIL_GPS](http://mavlink.org/messages/common#HIL_GPS) | Sim to PX4 | The simulated GPS RAW sensor value.
-[HIL_OPTICAL_FLOW](http://mavlink.org/messages/common#HIL_OPTICAL_FLOW) | Sim to PX4 | Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)
-[HIL_STATE_QUATERNION](http://mavlink.org/messages/common#HIL_STATE_QUATERNION) | Sim to PX4 | Contains the actual "simulated" vehicle position, attitude, speed etc. This can be logged and compared to PX4's estimates for analysis and debugging (for example, checking how well an estimator works for noisy (simulated) sensor inputs).
-[HIL_RC_INPUTS_RAW](http://mavlink.org/messages/common#HIL_RC_INPUTS_RAW) | Sim to PX4 | The RAW values of the RC channels received.
+[MAV_MODE:MAV_MODE_FLAG_HIL_ENABLED](https://mavlink.io/en/messages/common.html#MAV_MODE_FLAG_HIL_ENABLED) | NA | Mode flag when using simulation. All motors/actuators are blocked, but internal software is fully operational.
+[HIL_ACTUATOR_CONTROLS](https://mavlink.io/en/messages/common.html#HIL_ACTUATOR_CONTROLS) | PX4 to Sim | PX4 control outputs (to motors, actuators).
+[HIL_SENSOR](https://mavlink.io/en/messages/common.html#HIL_SENSOR) | Sim to PX4 | Simulated IMU readings in SI units in NED body frame.
+[HIL_GPS](https://mavlink.io/en/messages/common.html#HIL_GPS) | Sim to PX4 | The simulated GPS RAW sensor value.
+[HIL_OPTICAL_FLOW](https://mavlink.io/en/messages/common.html#HIL_OPTICAL_FLOW) | Sim to PX4 | Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)
+[HIL_STATE_QUATERNION](https://mavlink.io/en/messages/common.html#HIL_STATE_QUATERNION) | Sim to PX4 | Contains the actual "simulated" vehicle position, attitude, speed etc. This can be logged and compared to PX4's estimates for analysis and debugging (for example, checking how well an estimator works for noisy (simulated) sensor inputs).
+[HIL_RC_INPUTS_RAW](https://mavlink.io/en/messages/common.html#HIL_RC_INPUTS_RAW) | Sim to PX4 | The RAW values of the RC channels received.
 
 
 ## Standard MAVLink UDP Ports

--- a/kr/tutorials/motion-capture-vicon-optitrack.md
+++ b/kr/tutorials/motion-capture-vicon-optitrack.md
@@ -5,7 +5,7 @@
 Indoor motion capture systems like VICON and Optitrack can be used to provide position and attitude data for vehicle state estimation, orto serve as ground-truth for analysis.
 The motion capture data can be used to update PX4's local position estimate relative to the local origin. Heading (yaw) from the motion capture system can also be optionally integrated by the attitude estimator.
 
-Pose (position and orientation) data from the motion capture system is sent to the autopilot over MAVLink, using the [ATT_POS_MOCAP](http://mavlink.org/messages/common#ATT_POS_MOCAP) message. See the section below on coordinate frames for data representation conventions. The [mavros](../ros/mavros_installation.md) ROS-Mavlink interface has a default plugin to send this message. They can also be sent using pure C/C++ code and direct use of the MAVLink library.
+Pose (position and orientation) data from the motion capture system is sent to the autopilot over MAVLink, using the [ATT_POS_MOCAP](https://mavlink.io/en/messages/common.html#ATT_POS_MOCAP) message. See the section below on coordinate frames for data representation conventions. The [mavros](../ros/mavros_installation.md) ROS-Mavlink interface has a default plugin to send this message. They can also be sent using pure C/C++ code and direct use of the MAVLink library.
 
 ## Computing Architecture
 

--- a/kr/tutorials/optical_flow.md
+++ b/kr/tutorials/optical_flow.md
@@ -2,7 +2,7 @@
 position estimation을 위해서 아래를 향하는 카메라와 거리 센서를 사용합니다. Optical Flow 기반 네비게이션은 모두 3개 estimator에서 지원합니다. : EKF2, LPE 그리고 INAV (아래 참고)
 
 ## 셋업
-위에서 언급한 것처럼 Optical Flow 셋업에는 아래를 향하는 카메라와 거리 센서(LiDAR 선호)가 필요합니다. 각각은 [`OPTICAL_FLOW_RAD` topic](http://mavlink.org/messages/common#OPTICAL_FLOW_RAD) 메시지와 [`DISANCE_SENSOR` topic](http://mavlink.org/messages/common#DISTANCE_SENSOR) 메시지를 publish합니다.
+위에서 언급한 것처럼 Optical Flow 셋업에는 아래를 향하는 카메라와 거리 센서(LiDAR 선호)가 필요합니다. 각각은 [`OPTICAL_FLOW_RAD` topic](https://mavlink.io/en/messages/common.html#OPTICAL_FLOW_RAD) 메시지와 [`DISANCE_SENSOR` topic](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR) 메시지를 publish합니다.
 
 출력은 다음과 같습니다
 

--- a/zh/middleware/mavlink.md
+++ b/zh/middleware/mavlink.md
@@ -5,7 +5,7 @@ translated_sha: 95b39d747851dd01c1fe5d36b24e59ec865e323e
 
 # MAVLink消息
 
-所有消息的概述可以在[这里](http://mavlink.org/messages/common)找到.
+所有消息的概述可以在[这里](https://mavlink.io/en/messages/)找到.
 
 ## 创建自定义MAVLink消息
 

--- a/zh/ros/external_position_estimation.md
+++ b/zh/ros/external_position_estimation.md
@@ -13,7 +13,7 @@ translated_sha: 95b39d747851dd01c1fe5d36b24e59ec865e323e
 
 现在，这个系统被用来进行室内位置控制或者基于视觉的路径点导航。
 
-对于视觉，用来发送位姿数据的MAVLink消息是[VISION_POSITION_ESTIMATE](http://mavlink.org/messages/common#VISION_POSITION_ESTIMATE)。对于运动捕捉系统，相应的则为[ATT_POS_MOCAP](http://mavlink.org/messages/common#ATT_POS_MOCAP)。
+对于视觉，用来发送位姿数据的MAVLink消息是[VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE)。对于运动捕捉系统，相应的则为[ATT_POS_MOCAP](https://mavlink.io/en/messages/common.html#ATT_POS_MOCAP)。
 
 默认发送这些消息的应用是ROS-Mavlink接口MAVROS，当然，也可以直接使用纯C/C++代码或者MAVLink()库来发送它们。
 

--- a/zh/ros/offboard_control.md
+++ b/zh/ros/offboard_control.md
@@ -9,7 +9,7 @@ translated_sha: 95b39d747851dd01c1fe5d36b24e59ec865e323e
 > **警告：** 外部控制是很危险的。在进行外部控制飞行之前，开发者需要保证有充分的准备、测试以及安全预防措施。
 
 
-外部控制允许使用运行在飞控板外部的软件去控制px4飞行控制栈。通过MAVLink协议完成这些操作，特别是[SET_POSITION_TARGET_LOCAL_NED](http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED)和[SET_ATTITUDE_TARGET](http://mavlink.org/messages/common#SET_ATTITUDE_TARGET)消息.
+外部控制允许使用运行在飞控板外部的软件去控制px4飞行控制栈。通过MAVLink协议完成这些操作，特别是[SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)和[SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET)消息.
 
 ## 外部控制固件设置
 

--- a/zh/simulation/README.md
+++ b/zh/simulation/README.md
@@ -41,13 +41,13 @@ The messages are described below (see links for specific detail).
 
 | Message                                  | Direction  | Description                              |
 | ---------------------------------------- | ---------- | ---------------------------------------- |
-| [MAV_MODE:MAV_MODE_FLAG_HIL_ENABLED](http://mavlink.org/messages/common#MAV_MODE_FLAG_HIL_ENABLED) | NA         | Mode flag when using simulation. All motors/actuators are blocked, but internal software is fully operational. |
-| [HIL_ACTUATOR_CONTROLS](http://mavlink.org/messages/common#HIL_ACTUATOR_CONTROLS) | PX4 to Sim | PX4 control outputs (to motors, actuators). |
-| [HIL_SENSOR](http://mavlink.org/messages/common#HIL_SENSOR) | Sim to PX4 | Simulated IMU readings in SI units in NED body frame. |
-| [HIL_GPS](http://mavlink.org/messages/common#HIL_GPS) | Sim to PX4 | The simulated GPS RAW sensor value.      |
-| [HIL_OPTICAL_FLOW](http://mavlink.org/messages/common#HIL_OPTICAL_FLOW) | Sim to PX4 | Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor) |
-| [HIL_STATE_QUATERNION](http://mavlink.org/messages/common#HIL_STATE_QUATERNION) | Sim to PX4 | Contains the actual "simulated" vehicle position, attitude, speed etc. This can be logged and compared to PX4's estimates for analysis and debugging (for example, checking how well an estimator works for noisy (simulated) sensor inputs). |
-| [HIL_RC_INPUTS_RAW](http://mavlink.org/messages/common#HIL_RC_INPUTS_RAW) | Sim to PX4 | The RAW values of the RC channels received. |
+| [MAV_MODE:MAV_MODE_FLAG_HIL_ENABLED](https://mavlink.io/en/messages/common.html#MAV_MODE_FLAG_HIL_ENABLED) | NA         | Mode flag when using simulation. All motors/actuators are blocked, but internal software is fully operational. |
+| [HIL_ACTUATOR_CONTROLS](https://mavlink.io/en/messages/common.html#HIL_ACTUATOR_CONTROLS) | PX4 to Sim | PX4 control outputs (to motors, actuators). |
+| [HIL_SENSOR](https://mavlink.io/en/messages/common.html#HIL_SENSOR) | Sim to PX4 | Simulated IMU readings in SI units in NED body frame. |
+| [HIL_GPS](https://mavlink.io/en/messages/common.html#HIL_GPS) | Sim to PX4 | The simulated GPS RAW sensor value.      |
+| [HIL_OPTICAL_FLOW](https://mavlink.io/en/messages/common.html#HIL_OPTICAL_FLOW) | Sim to PX4 | Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor) |
+| [HIL_STATE_QUATERNION](https://mavlink.io/en/messages/common.html#HIL_STATE_QUATERNION) | Sim to PX4 | Contains the actual "simulated" vehicle position, attitude, speed etc. This can be logged and compared to PX4's estimates for analysis and debugging (for example, checking how well an estimator works for noisy (simulated) sensor inputs). |
+| [HIL_RC_INPUTS_RAW](https://mavlink.io/en/messages/common.html#HIL_RC_INPUTS_RAW) | Sim to PX4 | The RAW values of the RC channels received. |
 
 
 ## SITL Simulation Environment

--- a/zh/tutorials/optical_flow.md
+++ b/zh/tutorials/optical_flow.md
@@ -7,7 +7,7 @@ translated_sha: 95b39d747851dd01c1fe5d36b24e59ec865e323e
 Optical Flow uses a downward facing camera and a downward facing distance sensor for position estimation. Optical Flow based navigation is supported by all three estimators: EKF2, LPE and INAV (see below).
 
 ## 设置
-As mentioned above, an Optical Flow setup requires a downward facing camera which publishes to the [`OPTICAL_FLOW_RAD` topic](http://mavlink.org/messages/common#OPTICAL_FLOW_RAD) and a distance sensor (preferably a LiDAR) publishing messages to the [`DISANCE_SENSOR` topic](http://mavlink.org/messages/common#DISTANCE_SENSOR).
+As mentioned above, an Optical Flow setup requires a downward facing camera which publishes to the [`OPTICAL_FLOW_RAD` topic](https://mavlink.io/en/messages/common.html#OPTICAL_FLOW_RAD) and a distance sensor (preferably a LiDAR) publishing messages to the [`DISANCE_SENSOR` topic](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR).
 
 The output of the flow has to be as follows
 


### PR DESCRIPTION
This makes sense now that the mavlink messages are automatically updated in the mavlink.io gitbook.