### PR TITLE
Add notation from@bresch

### DIFF
--- a/book.json
+++ b/book.json
@@ -12,6 +12,7 @@
         "bulk-redirect@git+https://github.com/Dronecode/gitbook-plugin-bulk-redirect.git",
         "toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git",
         "validate-links",
+        "mathjax",
         "-stub-out-blocks@git+https://github.com/hamishwillee/gitbook-plugin-stub-out-blocks.git",
         "theme-dronecode@git+https://github.com/dronecode/theme-dronecode.git"
 

--- a/en/contribute/notation.md
+++ b/en/contribute/notation.md
@@ -1,6 +1,11 @@
-# Terminology/Notation
+# Terminology
 
 The following terms, symbols, and decorators are used in text and diagrams throughout this guide.
+
+## Notation
+- Bold face variables indicate vectors or matrices and non-bold face variables represent scalars. 
+- The default frame for each variable is the local frame $$\ell$$. Right superscripts represent the coordinate frame. If no right superscript is present, then the default frame $$\ell$$ is assumed. An exception is given by Rotation Matrices, where the lower right subscripts indicates the current frame and the right superscripts the target frame.
+- Variables and subscripts can share the same letter, but they always have different meaning.
 
 ## Acronyms
 
@@ -18,39 +23,55 @@ PID | Controller with Proportional, Integral and Derivative actions.
 
 ## Symbols
 
-Symbol | Description
+Variable | Description
 --- | ---
-$$\boldsymbol{\mathrm{a}}$$ | Acceleration vector. $$\boldsymbol{\mathrm{a}} = \boldsymbol{\mathrm{\dot{v}}} = \boldsymbol{\mathrm{\ddot{r}}} = [a_x \quad a_y \quad a_z]^T$$.
-$$\alpha$$ | Angle of attack (AOA).
-$$AR$$ | Aspect ratio. $$AR = b^2/S$$.
-$$b$$ | Wing span (from tip to tip).
-$$\beta$$ | Angle of sideslip (AOS).
-$$\bar{c}$$ | Mean aerodynamic chord (mac).
-$$c$$ | Wing chord length.
-$$\delta_{a,e,r}$$ | Aerodynamic control surface angular deflection. Subscripts $$a$$, $$e$$ and $$r$$ stand for *aileron*, *elevator* and *rudder*, respectively. A positive deflection generates a negative moment.
-$$\Psi$$ | Attitude vector. $$\Psi = [\phi \quad \theta \quad \psi]^T$$.
-$$\phi$$ | Roll euler angle. Also named *Bank angle* in aviation.
-$$\psi$$ | Yaw euler angle. Also named *Heading*.
-$$\theta$$ | Pitch euler angle.
-$$\boldsymbol{\mathrm{F}}$$ | Force vector. $$\boldsymbol{\mathrm{F}} = [X \quad Y \quad Z]^T$$.
-$$\boldsymbol{\mathrm{F}}_{Aero}^w$$ | Aerodynamic forces in wind frame. *Lift* $$L$$, *drag* $$D$$ and *cross-wind force* $$C$$. $$\boldsymbol{\mathrm{F}}_{Aero}^w = [-D \quad -C \quad -L]^T$$.
-$$\boldsymbol{\mathrm{F}}_T^b$$ | Thrust force in body frame. $$\boldsymbol{\mathrm{F}}_T^b = [X_T^b \quad Y_T^b \quad Z_T^b]^T$$.
-$$\boldsymbol{\mathrm{g}}$$ | Gravity vector.
-$$\boldsymbol{\mathrm{M}}_{Aero}^b$$ | Body aerodynamic moments. $$\boldsymbol{\mathrm{M}}_{Aero}^b = [\ell \quad m \quad n]^T$$.
-$$\boldsymbol{\mathrm{M}}_T^b$$ | Body thrust moments. $$\boldsymbol{\mathrm{M}}_T^b = [\ell_T \quad m_T \quad n_T]^T$$.
-$$M$$ | Mach number. Can be neglected for scale aircrafts.
-$$\boldsymbol{\mathrm{\tilde{q}}}$$ | Hamiltonian attitude quaternion. $$\boldsymbol{\mathrm{\tilde{q}}} = (q_0, q_1, q_2, q_3) = (q_0, \boldsymbol{\mathrm{q}})$$.<br>A vector in the local NED frame $$\ell$$ can be represented in the body frame $$b$$ using $$\boldsymbol{\mathrm{\tilde{v}}}^b = \boldsymbol{\mathrm{\tilde{q}}} \, \boldsymbol{\mathrm{\tilde{v}}}^\ell \, \boldsymbol{\mathrm{\tilde{q}}}^*$$ (or $$\boldsymbol{\mathrm{\tilde{q}}}^{-1}$$ instead of $$\boldsymbol{\mathrm{\tilde{q}}}^*$$ if $$\boldsymbol{\mathrm{\tilde{q}}}$$ is not unitary).  $$\boldsymbol{\mathrm{\tilde{v}}}$$ represents a *quaternionized* vector: $$\boldsymbol{\mathrm{\tilde{v}}} = (0,\boldsymbol{\mathrm{v}})$$.
+$$x,y,z$$ | Translation along coordinate axis x,y and z respectively.
 $$\boldsymbol{\mathrm{r}}$$ | Position vector $$\boldsymbol{\mathrm{r}} = [x \quad y \quad z]^{T}$$.
-$$\boldsymbol{\mathrm{R}}_a^b$$ | Rotation matrix. Rotates a vector from frame $a$ to frame $b$. $$\boldsymbol{\mathrm{v}}^b = \boldsymbol{\mathrm{R}}_a^b \boldsymbol{\mathrm{v}}^a$$.
+$$\boldsymbol{\mathrm{v}}$$ | Velocity vector $$\boldsymbol{\mathrm{v}} = \boldsymbol{\mathrm{\dot{r}}}$$.
+$$\boldsymbol{\mathrm{a}}$$ | Acceleration vector $$\boldsymbol{\mathrm{a}} = \boldsymbol{\mathrm{\dot{v}}} = \boldsymbol{\mathrm{\ddot{r}}}$$.
+$$\alpha$$ | Angle of attack (AOA).
+$$b$$ | Wing span (from tip to tip).
+$$S$$ | Wing area.
+$$AR$$ | Aspect ratio. $$AR = b^2/S$$.
+$$\beta$$ | Angle of sideslip (AOS).
+$$c$$ | Wing chord length.
+$$\delta$$ | Aerodynamic control surface angular deflection. A positive deflection generates a negative moment.
+$$\phi,\psi,\theta$$ | Euler angles roll (=Bank), pitch and yaw (=Heading).
+$$\Psi$$ | Attitude vector. $$\Psi = [\phi \quad \theta \quad \psi]^T$$.
+$$X,Y,Z$$ | Forces along coordinate axis x,y and z.
+$$\boldsymbol{\mathrm{F}}$$| Force vector $$\boldsymbol{\mathrm{F}}= [X \quad Y \quad Z]^T$$ . 
+$$D$$ | Drag force.
+$$C$$ | Cross-wind force.
+$$L$$ | Lift force.
+$$g$$ | Gravity.
+$$l,m,n$$ | Moments around coordinate axis x,y and z.
+$$\boldsymbol{\mathrm{M}}$$ | Moment vector $$\boldsymbol{\mathrm{M}} = [l \quad m \quad n]^T$$.
+$$M$$ | Mach number. Can be neglected for scale aircrafts.
+$$\boldsymbol{\mathrm{\tilde{q}}}$$ | Hamiltonian attitude quaternion. $$\boldsymbol{\mathrm{\tilde{q}}} = (q_0, q_1, q_2, q_3) = (q_0, \boldsymbol{\mathrm{q}})$$.<br> $$\boldsymbol{\mathrm{\tilde{q}}}$$ describes the attitude relative to the local frame $$\ell$$. To represent a vector in local frame given a vector in body frame, the following operation can be used:  $$\boldsymbol{\mathrm{\tilde{v}}}^\ell = \boldsymbol{\mathrm{\tilde{q}}} \, \boldsymbol{\mathrm{\tilde{v}}}^b \, \boldsymbol{\mathrm{\tilde{q}}}^*$$ (or $$\boldsymbol{\mathrm{\tilde{q}}}^{-1}$$ instead of $$\boldsymbol{\mathrm{\tilde{q}}}^*$$ if $$\boldsymbol{\mathrm{\tilde{q}}}$$ is not unitary).  $$\boldsymbol{\mathrm{\tilde{v}}}$$ represents a *quaternionized* vector: $$\boldsymbol{\mathrm{\tilde{v}}} = (0,\boldsymbol{\mathrm{v}})$$.
+$$\boldsymbol{\mathrm{R}}_\ell^b$$ | Rotation matrix. Rotates a vector from frame $$\ell$$ to frame $$b$$. $$\boldsymbol{\mathrm{v}}^b = \boldsymbol{\mathrm{R}}_\ell^b \boldsymbol{\mathrm{v}}^\ell$$.
 $$\Lambda$$ | Leading-edge sweep angle.
 $$\lambda$$ | Taper ratio $$\lambda = c_{tip}/c_{root}$$.
-$$\boldsymbol{\mathrm{v}}$$ | Velocity vector. $$\boldsymbol{\mathrm{v}} = \boldsymbol{\mathrm{\dot{r}}} = [v_x \quad v_y \quad v_z]^T$$.
-$$\boldsymbol{\mathrm{v}}^\ell$$ | Velocity vector in local frame. $$\boldsymbol{\mathrm{v}}^\ell = \boldsymbol{\mathrm{v}}_w^\ell + \boldsymbol{\mathrm{w}}^\ell$$.
-$$\boldsymbol{\mathrm{v}}_w^b$$ | Relative airspeed velocity vector in body frame. $$\boldsymbol{\mathrm{v}}_w^b = [u \quad v \quad w]^T$$.
-$$\boldsymbol{\mathrm{w}}^\ell$$ | Wind velocity vector in local frame. $$\boldsymbol{\mathrm{w}}^\ell = [w_N \quad w_E \quad w_D]^T$$. Usually $$w_D$$ is assumed to be null.
-$$\boldsymbol{\omega}^b$$ | Body rates vector. $$\boldsymbol{\omega}^b = [p \quad q \quad r]^T$$.
+$$w$$ | Wind velocity.
+$$p,q,r$$ | Angular rates around body axis x,y and z.
+$$\boldsymbol{\omega}^b$$ | Angular rate vector in body frame $$\boldsymbol{\omega}^b = [p \quad q \quad r]^T$$.
 $$\boldsymbol{\mathrm{x}}$$ | General state vector.
 
+Indices / Subscripts | Description
+--- | ---
+$$a$$ | Aileron.
+$$e$$ | Elevator.
+$$r$$ | Rudder.
+$$Aero$$ | Aerodynamic.
+$$T$$ | Thrust force.
+$$w$$ | Relative airspeed.
+$$x,y,z$$ | Component of vector along coordinate axis x, y and z.
+$$N,E,D$$ | Component of vector along global north, east and down direction.
+
+Indices / Superscripts | Description
+--- | ---
+$$\ell$$ | Local-frame. Default for PX4 related variables.
+$$b$$ | Body-frame.
+$$w$$ | Wind-frame.
 
 ## Decorators
 
@@ -58,9 +79,8 @@ Decorator | Description
 --- | ---
 $$()^*$$ | Complex conjugate.
 $$\dot{()}$$ | Time derivative.
-$$()^b$$ | Resolved in the body FRD frame.
-$$()^\ell$$ | Resolved in the local NED frame.
-$$()^w$$ | Resolved in the wind frame.
 $$\hat{()}$$ | Estimate.
+$$\bar{()}$$ | Mean.
 $$()^{-1}$$ | Matrix inverse.
 $$()^T$$ | Matrix transpose.
+$$\tilde{()}$$ | Quadruple vector.

--- a/en/contribute/notation.md
+++ b/en/contribute/notation.md
@@ -3,8 +3,9 @@
 The following terms, symbols, and decorators are used in text and diagrams throughout this guide.
 
 ## Notation
+
 - Bold face variables indicate vectors or matrices and non-bold face variables represent scalars. 
-- The default frame for each variable is the local frame $$\ell$$. Right superscripts represent the coordinate frame. If no right superscript is present, then the default frame $$\ell$$ is assumed. An exception is given by Rotation Matrices, where the lower right subscripts indicates the current frame and the right superscripts the target frame.
+- The default frame for each variable is the local frame $$\ell$$. Right [superscripts](#superscripts) represent the coordinate frame. If no right superscript is present, then the default frame $$\ell$$ is assumed. An exception is given by Rotation Matrices, where the lower right subscripts indicates the current frame and the right superscripts the target frame.
 - Variables and subscripts can share the same letter, but they always have different meaning.
 
 ## Acronyms
@@ -56,7 +57,9 @@ $$p,q,r$$ | Angular rates around body axis x,y and z.
 $$\boldsymbol{\omega}^b$$ | Angular rate vector in body frame $$\boldsymbol{\omega}^b = [p \quad q \quad r]^T$$.
 $$\boldsymbol{\mathrm{x}}$$ | General state vector.
 
-Indices / Subscripts | Description
+### Subscripts / Indices
+
+Subscripts / Indices | Description
 --- | ---
 $$a$$ | Aileron.
 $$e$$ | Elevator.
@@ -67,11 +70,14 @@ $$w$$ | Relative airspeed.
 $$x,y,z$$ | Component of vector along coordinate axis x, y and z.
 $$N,E,D$$ | Component of vector along global north, east and down direction.
 
-Indices / Superscripts | Description
+### Superscripts / Indices {#superscripts}
+
+Superscripts / Indices | Description
 --- | ---
 $$\ell$$ | Local-frame. Default for PX4 related variables.
 $$b$$ | Body-frame.
 $$w$$ | Wind-frame.
+
 
 ## Decorators
 

--- a/en/contribute/notation.md
+++ b/en/contribute/notation.md
@@ -1,5 +1,12 @@
 # Terminology
 
+<!-- Fixes page load bug in notation, courtesy https://github.com/GitbookIO/plugin-mathjax/issues/34#issuecomment-349453673 -->
+<script>
+gitbook.events.bind("page.change", function() {
+    MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+}
+</script>
+
 The following terms, symbols, and decorators are used in text and diagrams throughout this guide.
 
 ## Notation

--- a/en/contribute/notation.md
+++ b/en/contribute/notation.md
@@ -2,11 +2,65 @@
 
 The following terms, symbols, and decorators are used in text and diagrams throughout this guide.
 
-## Terms
+## Acronyms
+
+Acronym | Expansion
+--- | ---
+AOA | Angle Of Attack. Also named *alpha*.
+AOS | Angle Of Sideslip. Also named *beta*.
+FRD | Coordinate system where the X-axis is pointing towards the Front of the vehicle, the Y-axis is pointing Right and the Z-axis is pointing Down, completing the right-hand rule.
+FW | Fixed-Wing.
+MC | MultiCopter.
+MPC or MCPC | MultiCopter Position Controller. MPC is also used for Model Predictive Control.
+NED | Coordinate system where the X-axis is pointing towards the true North, the Y-axis is pointing East and the Z-axis is pointing Down, completing the right-hand rule.
+PID | Controller with Proportional, Integral and Derivative actions.
 
 
 ## Symbols
 
+Symbol | Description
+--- | ---
+$$\boldsymbol{\mathrm{a}}$$ | Acceleration vector. $$\boldsymbol{\mathrm{a}} = \boldsymbol{\mathrm{\dot{v}}} = \boldsymbol{\mathrm{\ddot{r}}} = [a_x \quad a_y \quad a_z]^T$$.
+$$\alpha$$ | Angle of attack (AOA).
+$$AR$$ | Aspect ratio. $$AR = b^2/S$$.
+$$b$$ | Wing span (from tip to tip).
+$$\beta$$ | Angle of sideslip (AOS).
+$$\bar{c}$$ | Mean aerodynamic chord (mac).
+$$c$$ | Wing chord length.
+$$\delta_{a,e,r}$$ | Aerodynamic control surface angular deflection. Subscripts $$a$$, $$e$$ and $$r$$ stand for *aileron*, *elevator* and *rudder*, respectively. A positive deflection generates a negative moment.
+$$\Psi$$ | Attitude vector. $$\Psi = [\phi \quad \theta \quad \psi]^T$$.
+$$\phi$$ | Roll euler angle. Also named *Bank angle* in aviation.
+$$\psi$$ | Yaw euler angle. Also named *Heading*.
+$$\theta$$ | Pitch euler angle.
+$$\boldsymbol{\mathrm{F}}$$ | Force vector. $$\boldsymbol{\mathrm{F}} = [X \quad Y \quad Z]^T$$.
+$$\boldsymbol{\mathrm{F}}_{Aero}^w$$ | Aerodynamic forces in wind frame. *Lift* $$L$$, *drag* $$D$$ and *cross-wind force* $$C$$. $$\boldsymbol{\mathrm{F}}_{Aero}^w = [-D \quad -C \quad -L]^T$$.
+$$\boldsymbol{\mathrm{F}}_T^b$$ | Thrust force in body frame. $$\boldsymbol{\mathrm{F}}_T^b = [X_T^b \quad Y_T^b \quad Z_T^b]^T$$.
+$$\boldsymbol{\mathrm{g}}$$ | Gravity vector.
+$$\boldsymbol{\mathrm{M}}_{Aero}^b$$ | Body aerodynamic moments. $$\boldsymbol{\mathrm{M}}_{Aero}^b = [\ell \quad m \quad n]^T$$.
+$$\boldsymbol{\mathrm{M}}_T^b$$ | Body thrust moments. $$\boldsymbol{\mathrm{M}}_T^b = [\ell_T \quad m_T \quad n_T]^T$$.
+$$M$$ | Mach number. Can be neglected for scale aircrafts.
+$$\boldsymbol{\mathrm{\tilde{q}}}$$ | Hamiltonian attitude quaternion. $$\boldsymbol{\mathrm{\tilde{q}}} = (q_0, q_1, q_2, q_3) = (q_0, \boldsymbol{\mathrm{q}})$$.<br>A vector in the local NED frame $$\ell$$ can be represented in the body frame $$b$$ using $$\boldsymbol{\mathrm{\tilde{v}}}^b = \boldsymbol{\mathrm{\tilde{q}}} \, \boldsymbol{\mathrm{\tilde{v}}}^\ell \, \boldsymbol{\mathrm{\tilde{q}}}^*$$ (or $$\boldsymbol{\mathrm{\tilde{q}}}^{-1}$$ instead of $$\boldsymbol{\mathrm{\tilde{q}}}^*$$ if $$\boldsymbol{\mathrm{\tilde{q}}}$$ is not unitary).  $$\boldsymbol{\mathrm{\tilde{v}}}$$ represents a *quaternionized* vector: $$\boldsymbol{\mathrm{\tilde{v}}} = (0,\boldsymbol{\mathrm{v}})$$.
+$$\boldsymbol{\mathrm{r}}$$ | Position vector $$\boldsymbol{\mathrm{r}} = [x \quad y \quad z]^{T}$$.
+$$\boldsymbol{\mathrm{R}}_a^b$$ | Rotation matrix. Rotates a vector from frame $a$ to frame $b$. $$\boldsymbol{\mathrm{v}}^b = \boldsymbol{\mathrm{R}}_a^b \boldsymbol{\mathrm{v}}^a$$.
+$$\Lambda$$ | Leading-edge sweep angle.
+$$\lambda$$ | Taper ratio $$\lambda = c_{tip}/c_{root}$$.
+$$\boldsymbol{\mathrm{v}}$$ | Velocity vector. $$\boldsymbol{\mathrm{v}} = \boldsymbol{\mathrm{\dot{r}}} = [v_x \quad v_y \quad v_z]^T$$.
+$$\boldsymbol{\mathrm{v}}^\ell$$ | Velocity vector in local frame. $$\boldsymbol{\mathrm{v}}^\ell = \boldsymbol{\mathrm{v}}_w^\ell + \boldsymbol{\mathrm{w}}^\ell$$.
+$$\boldsymbol{\mathrm{v}}_w^b$$ | Relative airspeed velocity vector in body frame. $$\boldsymbol{\mathrm{v}}_w^b = [u \quad v \quad w]^T$$.
+$$\boldsymbol{\mathrm{w}}^\ell$$ | Wind velocity vector in local frame. $$\boldsymbol{\mathrm{w}}^\ell = [w_N \quad w_E \quad w_D]^T$$. Usually $$w_D$$ is assumed to be null.
+$$\boldsymbol{\omega}^b$$ | Body rates vector. $$\boldsymbol{\omega}^b = [p \quad q \quad r]^T$$.
+$$\boldsymbol{\mathrm{x}}$$ | General state vector.
+
 
 ## Decorators
 
+Decorator | Description
+--- | ---
+$$()^*$$ | Complex conjugate.
+$$\dot{()}$$ | Time derivative.
+$$()^b$$ | Resolved in the body FRD frame.
+$$()^\ell$$ | Resolved in the local NED frame.
+$$()^w$$ | Resolved in the wind frame.
+$$\hat{()}$$ | Estimate.
+$$()^{-1}$$ | Matrix inverse.
+$$()^T$$ | Matrix transpose.

--- a/en/contribute/notation.md
+++ b/en/contribute/notation.md
@@ -55,6 +55,7 @@ $$g$$ | Gravity.
 $$l,m,n$$ | Moments around coordinate axis x,y and z.
 $$\boldsymbol{\mathrm{M}}$$ | Moment vector $$\boldsymbol{\mathrm{M}} = [l \quad m \quad n]^T$$.
 $$M$$ | Mach number. Can be neglected for scale aircrafts.
+$$\boldsymbol{\mathrm{q}}$$ | Vector part of Quaternion.
 $$\boldsymbol{\mathrm{\tilde{q}}}$$ | Hamiltonian attitude quaternion. $$\boldsymbol{\mathrm{\tilde{q}}} = (q_0, q_1, q_2, q_3) = (q_0, \boldsymbol{\mathrm{q}})$$.<br> $$\boldsymbol{\mathrm{\tilde{q}}}$$ describes the attitude relative to the local frame $$\ell$$. To represent a vector in local frame given a vector in body frame, the following operation can be used:  $$\boldsymbol{\mathrm{\tilde{v}}}^\ell = \boldsymbol{\mathrm{\tilde{q}}} \, \boldsymbol{\mathrm{\tilde{v}}}^b \, \boldsymbol{\mathrm{\tilde{q}}}^*$$ (or $$\boldsymbol{\mathrm{\tilde{q}}}^{-1}$$ instead of $$\boldsymbol{\mathrm{\tilde{q}}}^*$$ if $$\boldsymbol{\mathrm{\tilde{q}}}$$ is not unitary).  $$\boldsymbol{\mathrm{\tilde{v}}}$$ represents a *quaternionized* vector: $$\boldsymbol{\mathrm{\tilde{v}}} = (0,\boldsymbol{\mathrm{v}})$$.
 $$\boldsymbol{\mathrm{R}}_\ell^b$$ | Rotation matrix. Rotates a vector from frame $$\ell$$ to frame $$b$$. $$\boldsymbol{\mathrm{v}}^b = \boldsymbol{\mathrm{R}}_\ell^b \boldsymbol{\mathrm{v}}^\ell$$.
 $$\Lambda$$ | Leading-edge sweep angle.
@@ -96,4 +97,4 @@ $$\hat{()}$$ | Estimate.
 $$\bar{()}$$ | Mean.
 $$()^{-1}$$ | Matrix inverse.
 $$()^T$$ | Matrix transpose.
-$$\tilde{()}$$ | Quadruple vector.
+$$\tilde{()}$$ | Quaternion.


### PR DESCRIPTION
Add notation, kindly donated by @bresch - https://github.com/bresch/Glossary. This is rendered using the mathjax plugin.

This originates from https://github.com/PX4/Devguide/pull/400

[Rendered view here](https://hamishwillee.gitbooks.io/havdevguide/content/v/ba86638ccf23a93527fab26ae21562dd3190c641/en/contribute/notation.html). I had to refresh page to get the maths to display - anyone else see the same thing?

@Stifael @bresch anything to add/remove? Otherwise I'll merge in the next day or so.