### PR TITLE
Add Nuttx menuconfig shortcut info

### DIFF
--- a/en/debug/porting-guide.md
+++ b/en/debug/porting-guide.md
@@ -25,6 +25,14 @@ The location of the main files for a NuttX board are:
 * Reference config: Running `make px4fmu-v4_default` builds the FMUv4 config, which is the current NuttX reference configuration.
 
 
+### NuttX Menuconfig
+
+If you need to modify the NuttX [menuconfig](https://bitbucket.org/nuttx/nuttx) you can do this using the PX4 shortcuts:
+```sh
+make px4fmu-v2_default menuconfig
+make px4fmu-v2_default qconfig
+```
+
 ## QuRT / Hexagon
 
 * The start script is located in [posix-configs/](https://github.com/PX4/Firmware/tree/master/posix-configs).
@@ -39,6 +47,9 @@ The location of the main files for a NuttX board are:
 Linux boards do not include the OS and kernel configuration. These are already provided by the Linux image available for the board (which needs to support the inertial sensors out of the box).
 
 * [cmake/configs/posix\_rpi\_cross.cmake](https://github.com/PX4/Firmware/blob/master/cmake/configs/posix_rpi_cross.cmake) - RPI cross-compilation.
+
+
+
 
 
 ## Related Information


### PR DESCRIPTION
Adds info about the shortcuts. It links to more info about menuconfig but does not explain why you might use this - as discussed with @dagar this is quite a specialised use case, where readers that need the information will probably already understand how it should be used (so we're just providing a pointer).

@dagar Note that the location of this section in the porting guide isn't ideal (it is under "Porting Guide > *Architecture* > NuttX > "). This is the only NuttX topic in current structure, so the best place "for now". When we have a more complete porting guide it probably makes sense to have a structure that divides first by board - we will see.