### PR TITLE
Add info about simulating cameras

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -237,3 +237,20 @@ For setup information see the *QGroundControl User Guide*:
 * [Virtual Joystick](https://docs.qgroundcontrol.com/en/SettingsView/VirtualJoystick.html)
 
 <!-- FYI Airsim info on this setting up remote controls: https://github.com/Microsoft/AirSim/blob/master/docs/remote_controls.md -->
+
+
+## Camera Simulation
+
+PX4 supports capture of both still images and video from within the [Gazebo](../simulation/gazebo.md) simulated environment. This can be enabled/set up as described in [Gazebo > Video Streaming](../simulation/gazebo.md#video-streaming).
+
+The simulated camera is a gazebo plugin that implements the [MAVLink Camera Protocol](https://mavlink.io/en/protocol/camera.html)<!-- **Firmware/Tools/sitl_gazebo/src/gazebo_geotagged_images_plugin.cpp -->. PX4 connects/integrates with this camera in *exactly the same way* as it would with any other MAVLink camera:
+1. [TRIG_INTERFACE](../advanced/parameter_reference.md#TRIG_INTERFACE) must be set to `3` to configure the camera trigger driver for use with a MAVLink camera
+   > **Tip** In this mode the driver just sends a [CAMERA_TRIGGER](https://mavlink.io/en/messages/common.html#CAMERA_TRIGGER) message whenever an image capture is requested. For more information see [Camera Trigger](../tutorials/camera_trigger.md).
+1. PX4 must forward all camera commands between the GCS and the (simulator) MAVLink Camera. You can do this by starting [mavlink](middleware/modules_communication.md#mavlink) with the `-f` flag as shown, specifying the UDP ports for the new connection.
+   ```
+   mavlink start -u 14558 -o 14530 -r 4000 -f -m camera 
+   ```
+   > **Note** More than just the camera MAVLink messages will be forwarded, but the camera will ignore those that it doesn't consider relevant.
+
+The same approach can be used by other simulators to implement camera support.
+


### PR DESCRIPTION
Adds a section on camera simulation to the parent simulation doc. It includes information aboutwhat simulators support camera (Gazebo) and how that works (including the correct trigger mode). I believe it answers the original question in https://github.com/PX4/Firmware/pull/8775#issuecomment-361844985 about how camera information should be shared with a simulator. 

This probably could be improved. My intention in future is to have a more detailed guide doc on mavlink cameras that this would then link to. 

@LorenzMeier - is this sufficient in your opinion? I am aware that there is a lot more that could be said about the architecture of a MAVLink camera - e.g. to support video streaming, but I don't know to write that yet, so this is a good half way point.