### PR TITLE
Update building_px4.md

### DIFF
--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -176,7 +176,7 @@ The "px4" executable file is in the directory **build/posix_rpi_native/src/firmw
 Run it directly with:
 
 ```sh
-sudo ./build/posix_rpi_native/src/firmware/posix/px4 ./posix-configs/rpi/px4.config
+sudo ./build/posix_rpi_native/px4 ./posix-configs/rpi/px4.config
 ```
 
 A successful build followed by executing px4 will give you something like this:


### PR DESCRIPTION
The Native Build section needs to be updated with the new location of the px4 file. In newer release of the flight stack, it is located just under ./build/posix_rpi_native/px4