### PR TITLE
RaPi uart doc clarification

### DIFF
--- a/en/middleware/micrortps.md
+++ b/en/middleware/micrortps.md
@@ -261,7 +261,7 @@ For UART transport on Raspberry Pi you will have to enable the serial port:
   sudo usermod -a -G dialout pi
   ```
 
-2. You need to stop the already running on the GPIO serial console:
+2. You need to stop the GPIO serial console that using the port:
 
   ```sh
   sudo raspi-config

--- a/en/middleware/micrortps.md
+++ b/en/middleware/micrortps.md
@@ -261,7 +261,7 @@ For UART transport on Raspberry Pi you will have to enable the serial port:
   sudo usermod -a -G dialout pi
   ```
 
-2. You need to stop the GPIO serial console that using the port:
+2. You need to stop the GPIO serial console that is using the port:
 
   ```sh
   sudo raspi-config


### PR DESCRIPTION
The textin [Enable UART on RaPi](https://dev.px4.io/en/middleware/micrortps.html#enable-uart-on-raspberry-pi) is not clear: “You need to stop the already running on the GPIO serial console:”

I think this is a typo - you're basically saying that we need to stop the  GPIO serial console.
