### PR TITLE
Added link to the example ported to python

### DIFF
--- a/en/ros/mavros_offboard.md
+++ b/en/ros/mavros_offboard.md
@@ -195,3 +195,5 @@ while(ros::ok()){
 The rest of the code is pretty self explanatory. We attempt to switch to *Offboard* mode, after which we arm the quad to allow it to fly. We space out the service calls by 5 seconds so to not flood the autopilot with the requests. In the same loop, we continue sending the requested pose at the appropriate rate.
 
 > **Tip** This code has been simplified to the bare minimum for illustration purposes. In larger systems, it is often useful to create a new thread which will be in charge of periodically publishing the setpoints.
+
+The same example in python can be found at https://github.com/nkhedekar/offb_py


### PR DESCRIPTION
This request is to add a link to the python version of the offboard example (webpage : https://dev.px4.io/en/ros/mavros_offboard.html) 

The main purpose is to provide python developers an example to help them start working with PX4, Gazebo and ROS