### PR TITLE
Adds description for using out-of-tree message definition

### DIFF
--- a/en/advanced/out_of_tree_modules.md
+++ b/en/advanced/out_of_tree_modules.md
@@ -38,9 +38,43 @@ px4_add_module(
 	)
 
 ```
+
+
+# Out-of-tree uORB Message Definitions
+
+uORB messages can also be defined out-of-tree. For this, the
+`$EXTERNAL_MODULES_LOCATION/msg` needs to exist.
+
+- Place all new message definitions within the `$EXTERNAL_MODULES_LOCATION/msg`
+  directory. The format of these new out-of-tree message definitions are the same
+  as for any other [uORB message definition](../middleware/uorb.md#adding-a-new-topic).
+- Add a file `$EXTERNAL_MODULES_LOCATION/msg/CMakeLists.txt` with content:
+
+```
+set(config_msg_list_external
+    <message1>.msg
+    <message2>.msg
+    <message3>.msg
+    PARENT_SCOPE
+    )
+
+```
+where `<message#>.msg` is the name of the uORB message definition file to be processed 
+and used for uORB message generation.
+
+The out-of-tree uORB messages will be generated in the same locations as the normal uORB messages.
+The uORB topic headers are generated in `<build_dir>/uORB/topics/`, and the message source files are
+generated in `<build_dir>/msg/topics_sources/`.
+
+The new uORB messages can be used like any other uORB message as described [here](../middleware/uorb.md#adding-a-new-topic).
+
+> **Warning** The out-of-tree uORB message definitions cannot have the same name as any of the normal uORB
+messages.
+
+# Building Out-of-tree modules and uORB Messages
+
 - Execute `make posix EXTERNAL_MODULES_LOCATION=<path>`. Any other build target
   can be used, but the build directory must not yet exist. If it already exists,
   you can also just set the cmake variable in the build folder.
   For the following incremental builds `EXTERNAL_MODULES_LOCATION` does not need
   to be specified anymore.
-

--- a/en/middleware/uorb.md
+++ b/en/middleware/uorb.md
@@ -12,6 +12,10 @@ It is started with `uorb start`. Unit tests can be started with `uorb_tests`.
 
 ## Adding a new topic
 
+New uORB topics can be added either within the main PX4/Firmware repository, or can be added
+in an out-of-tree message definitions. For information on adding out-of-tree uORB message 
+definitions, please see [this section](../advanced/out_of_tree_modules.md#out-of-tree-uorb-message-definitions).
+
 To add a new topic, you need to create a new `.msg` file in the `msg/`
 directory and add the file name to the `msg/CMakeLists.txt` list. From this,
 the needed C/C++ code is automatically generated.


### PR DESCRIPTION
Related to PR PX4/Firmware#9073.

I wonder whether we should possibly rename this page from out_of_tree_modules.md to something that now represents that it now also includes the out-of-tree uORB message definitions?

@hamishwillee : Do you think it is necessary for me to explain that the new uORB headers and sources will be generated in the same location as the normal uORB messages?