### PR TITLE
Tidy up EKF warnings

### DIFF
--- a/en/tutorials/pre_flight_checks.md
+++ b/en/tutorials/pre_flight_checks.md
@@ -1,59 +1,70 @@
 # Preflight Sensor and EKF Checks
-The commander module performs a number of preflight sensor quality and EKF checks which are controlled by the COM_ARM<> parameters. If these checks fail, the motors are prevented from arming and the following error messages are produced:
+
+The commander module performs a number of preflight sensor quality and EKF checks which are controlled by the [COM_ARM_](../advanced/parameter_reference.md#commander) parameters. If these checks fail, the motors are prevented from arming and the following error messages are produced:
 
 * PREFLIGHT FAIL: EKF HGT ERROR
- * This error is produced when the IMU and height measurement data are inconsistent.
- * Perform an accel and gyro calibration and restart the vehicle. If the error persists, check the height sensor data for problems.
- * The check is controlled by the COM_ARM_EKF_HGT parameter.
+  * This error is produced when the IMU and height measurement data are inconsistent.
+  * Perform an accel and gyro calibration and restart the vehicle. If the error persists, check the height sensor data for problems.
+  * The check is controlled by the [COM_ARM_EKF_HGT](#COM_ARM_EKF_HGT) parameter.
 * PREFLIGHT FAIL: EKF VEL ERROR
- * This error is produced when the IMU and GPS velocity measurement data are inconsistent. 
- * Check the GPS velocity data for un-realistic data jumps. If GPS quality looks OK, perform an accel and gyro calibration and restart the vehicle.
- * The check is controlled by the COM_ARM_EKF_VEL parameter.
+  * This error is produced when the IMU and GPS velocity measurement data are inconsistent. 
+  * Check the GPS velocity data for un-realistic data jumps. If GPS quality looks OK, perform an accel and gyro calibration and restart the vehicle.
+  * The check is controlled by the [COM_ARM_EKF_VEL](#COM_ARM_EKF_VEL) parameter.
 * PREFLIGHT FAIL: EKF HORIZ POS ERROR
- * This error is produced when the IMU and position measurement data (either GPS or external vision) are inconsistent. 
- * Check the position sensor data for un-realistic data jumps. If data quality looks OK, perform an accel and gyro calibration and restart the vehicle.
- * The check is controlled by the COM_ARM_EKF_POS parameter.
+  * This error is produced when the IMU and position measurement data (either GPS or external vision) are inconsistent. 
+  * Check the position sensor data for un-realistic data jumps. If data quality looks OK, perform an accel and gyro calibration and restart the vehicle.
+  * The check is controlled by the [COM_ARM_EKF_POS](#COM_ARM_EKF_POS) parameter.
 * PREFLIGHT FAIL: EKF YAW ERROR
- * This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
- * Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
- * The check is controlled by the COM_ARM_EKF_POS parameter
+  * This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
+  * Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
+  * The check is controlled by the [COM_ARM_EKF_POS](#COM_ARM_EKF_POS) parameter
 * PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS
- * This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
- * The check is controlled by the COM_ARM_EKF_AB parameter.
+  * This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
+  * The check is controlled by the [COM_ARM_EKF_AB](#COM_ARM_EKF_AB) parameter.
 * PREFLIGHT FAIL: EKF HIGH IMU GYRO BIAS
- * This error is produced when the IMU gyro bias estimated by the EKF is excessive. 
- * The check is controlled by the COM_ARM_EKF_GB parameter.
+  * This error is produced when the IMU gyro bias estimated by the EKF is excessive. 
+  * The check is controlled by the [COM_ARM_EKF_GB](#COM_ARM_EKF_GB) parameter.
 * PREFLIGHT FAIL: ACCEL SENSORS INCONSISTENT - CHECK CALIBRATION
- * This error message is produced when the acceleration measurements from different IMU units are inconsistent.
- * This check only applies to boards with more than one IMU.
- * The check is controlled by the COM_ARM_IMU_ACC parameter.
+  * This error message is produced when the acceleration measurements from different IMU units are inconsistent.
+  * This check only applies to boards with more than one IMU.
+  * The check is controlled by the [COM_ARM_IMU_ACC](#COM_ARM_IMU_ACC) parameter.
 * PREFLIGHT FAIL: GYRO SENSORS INCONSISTENT - CHECK CALIBRATION
- * This error message is produced when the angular rate measurements from different IMU units are inconsistent.
- * This check only applies to boards with more than one IMU.
- * The check is controlled by the COM_ARM_IMU_GYR parameter.
+  * This error message is produced when the angular rate measurements from different IMU units are inconsistent.
+  * This check only applies to boards with more than one IMU.
+  * The check is controlled by the [COM_ARM_IMU_GYR](#COM_ARM_IMU_GYR) parameter.
 
-##COM_ARM_WO_GPS
-The COM_ARM_WO_GPS parameter controls whether arming is allowed without a GPS signal. This parameter must be set to 0 to allow arming when there is no GPS signal present. Arming without GPS is only allowed if the flight mode selected does not require GPS.
-##COM_ARM_EKF_POS
-The COM_ARM_EKF_POS parameter controls the maximum allowed inconsistency between the EKF inertial measurements and position reference (GPS or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-##COM_ARM_EKF_VEL
-The COM_ARM_EKF_VEL parameter controls the maximum allowed inconsistency between the EKF inertial measurements and GPS velocity measurements. The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-##COM_ARM_EKF_HGT
-The COM_ARM_EKF_HGT parameter controls the maximum allowed inconsistency between the EKF inertial measurements and height measurement (Baro, GPS, range finder or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-##COM_ARM_EKF_YAW
-The COM_ARM_EKF_YAW parameter controls the maximum allowed inconsistency between the EKF inertial measurements and yaw measurement (magnetometer or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-##COM_ARM_EKF_AB
-The COM_ARM_EKF_AB parameter controls the maximum allowed EKF estimated IMU accelerometer bias. The default value of 0.005 allows for up to 0.5 m/s/s of accelerometer bias.
-##COM_ARM_EKF_GB
-The COM_ARM_EKF_GB parameter controls the maximum allowed EKF estimated IMU gyro bias. The default value of 0.00087 allows for up to 5 deg/sec of switch on gyro bias.
-##COM_ARM_IMU_ACC
-The COM_ARM_IMU_ACC parameter controls the maximum allowed inconsistency in acceleration measurements between the default IMU used for flight control and other IMU units if fitted. 
-##COM_ARM_IMU_GYR
-The COM_ARM_IMU_GYR parameter controls the maximum allowed inconsistency in angular rate measurements between the default IMU used for flight control and other IMU units if fitted.
+## COM_ARM_WO_GPS
 
+The [COM_ARM_WO_GPS](../advanced/parameter_reference.md#COM_ARM_WO_GPS) parameter controls whether arming is allowed without a GPS signal. This parameter must be set to 0 to allow arming when there is no GPS signal present. Arming without GPS is only allowed if the flight mode selected does not require GPS.
 
+## COM_ARM_EKF_POS
 
+The [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and position reference (GPS or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
 
+## COM_ARM_EKF_VEL
 
+The [COM_ARM_EKF_VEL](../advanced/parameter_reference.md#COM_ARM_EKF_VEL) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and GPS velocity measurements. The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
 
+## COM_ARM_EKF_HGT
 
+The [COM_ARM_EKF_HGT](../advanced/parameter_reference.md#COM_ARM_EKF_HGT) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and height measurement (Baro, GPS, range finder or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
+
+## COM_ARM_EKF_YAW
+
+The [COM_ARM_EKF_YAW](../advanced/parameter_reference.md#COM_ARM_EKF_YAW) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and yaw measurement (magnetometer or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
+
+## COM_ARM_EKF_AB
+
+The [COM_ARM_EKF_AB](../advanced/parameter_reference.md#COM_ARM_EKF_AB) parameter controls the maximum allowed EKF estimated IMU accelerometer bias. The default value of 0.005 allows for up to 0.5 m/s/s of accelerometer bias.
+
+## COM_ARM_EKF_GB
+
+The [COM_ARM_EKF_GB](../advanced/parameter_reference.md#COM_ARM_EKF_GB) parameter controls the maximum allowed EKF estimated IMU gyro bias. The default value of 0.00087 allows for up to 5 deg/sec of switch on gyro bias.
+
+## COM_ARM_IMU_ACC
+
+The [COM_ARM_IMU_ACC](../advanced/parameter_reference.md#COM_ARM_IMU_ACC) parameter controls the maximum allowed inconsistency in acceleration measurements between the default IMU used for flight control and other IMU units if fitted.
+
+## COM_ARM_IMU_GYR
+
+The [COM_ARM_IMU_GYR](../advanced/parameter_reference.md#COM_ARM_IMU_GYR) parameter controls the maximum allowed inconsistency in angular rate measurements between the default IMU used for flight control and other IMU units if fitted.


### PR DESCRIPTION
This tidies up the doc so that:
1. Descriptions of parameters in text are linked to the headings below
2. Descriptions of parameters in sections are also linked to "official" documentation.
3. Bullets are indented 2 spaces. This merely tidies the rendering in github - things always worked in final gitbook version
4. Headings have space between text and heading marker (just improves rendering).

@priseborough A few questions:
1. Should we delete the descriptions of each of the parameters and instead just link to the official parameter docs (as I have done in the lower sections). The advantage of leaving text there is that it can be read "in context". Disadvantage is duplication and possibility of things getting out of sync.
1. We have a report of someone getting error "Preflight fail: EKF internal Checks", but this is not documented. Is there any way for someone to interpret this/what should they do? [Note, users says manual mode, RC input is there. battery is calibrated. Sensor *say* they are calibrated.]
1. These look like public messages (ie displayed/played in QGC). Shouldn't this information be in the user guide? The only problem is that I don't think those users need to know about the commander. I'd assume this would go along side https://docs.px4.io/en/flying/led_meanings.html

Thoughts?
 