### PR TITLE
Update PX4 Porting Guide organization for clarity

### DIFF
--- a/en/debug/porting-guide.md
+++ b/en/debug/porting-guide.md
@@ -2,55 +2,67 @@
 
 This topic is for developers who want to port PX4 to work with *new* flight controller hardware.
 
-## Architecture
+## PX4 Architecture
 
-PX4 consists of two main layers: The board support and middleware layer on top of the host OS (NuttX, Linux or any other POSIX platform like Mac OS). And the applications (Flight Stack in [src/modules](https://github.com/PX4/Firmware/tree/master/src/modules)\).
+PX4 consists of two main layers: The [board support and middleware layer](https://dev.px4.io/en/middleware/) on top of the host OS (NuttX, Linux or any other POSIX platform like Mac OS), and the applications (Flight Stack in [src/modules](https://github.com/PX4/Firmware/tree/master/src/modules)\).  Please reference the [PX4 Architectural Overview](../concept/architecture.md) for more information.
 
-This guide is focused only on the middleware as the applications will run on any board target.
+This guide is focused only on the host OS and middleware as the applications/flight stack will run on any board target.
 
-## NuttX Boards
+## Flight Controller Configuration File Layout
 
-The location of the main files for a NuttX board are:
+In addition to the host operating system specific configuration files described below, there are several groups of configuration files for each board located throughout the code base:
+* Board startup and configuration files are located in: [src/drivers/boards](https://github.com/PX4/Firmware/tree/master/src/drivers/boards).
+  * This folder contains bus mappings, GPIO mappings, and the initialization code for each board.
+  * FMUv5 example: [src/drivers/boards/px4fmu-v5](https://github.com/PX4/Firmware/tree/master/src/drivers/boards/px4fmu-v5).
+* The boot file system (startup script) is located in: [ROMFS/px4fmu\_common](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common)
+* The board specific build configurations are located in: [cmake/configs/](https://github.com/PX4/Firmware/blob/master/cmake/configs/).
+* Driver files are located in: [src/drivers](https://github.com/PX4/Firmware/tree/master/src/drivers).
 
-* Board startup and PX4 board configuration: [src/drivers/boards](https://github.com/PX4/Firmware/tree/master/src/drivers/boards). It contains bus and GPIO mappings and the board initialization code. 
-  * FMUv5 example: [src/drivers/boards/px4fmu-v5](https://github.com/PX4/Firmware/tree/master/src/drivers/boards/px4fmu-v5). 
-* NuttX board config: [nuttx-configs](https://github.com/PX4/Firmware/tree/master/nuttx-configs). The OS gets loaded as part of the application build. 
-  * FMUv5 example: [nuttx-configs/px4fmu-v5/include/board.h](https://github.com/PX4/Firmware/blob/master/nuttx-configs/px4fmu-v5/include/board.h).
-* NuttX OS config (created with menuconfig): [nuttx-configs/px4fmu-v5/nsh/defconfig](https://github.com/PX4/Firmware/blob/master/nuttx-configs/px4fmu-v5/nsh/defconfig).
-* Linker scripts and other required settings: [nuttx-configs](https://github.com/PX4/Firmware/tree/master/nuttx-configs). 
-  * FMUv5 example: [nuttx-configs/px4fmu-v5](https://github.com/PX4/Firmware/tree/master/nuttx-configs/px4fmu-v5).
-* Boot file system (startup script): [ROMFS/px4fmu\_common](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common)
-* Board build configuration: [cmake/configs/nuttx\_px4fmu-v5\_default.cmake](https://github.com/PX4/Firmware/blob/master/cmake/configs/nuttx_px4fmu-v5_default.cmake).
-* Drivers: [src/drivers](https://github.com/PX4/Firmware/tree/master/src/drivers).
-* Reference config: Running `make px4fmu-v4_default` builds the FMUv4 config, which is the current NuttX reference configuration.
+## Host Operating System Configuration
 
+This section describes the purpose and location of the configuration files required for each supported host operating system to port them to new flight controller hardware.
 
-### NuttX Menuconfig
+### NuttX
 
-If you need to modify the NuttX [menuconfig](https://bitbucket.org/nuttx/nuttx) you can do this using the PX4 shortcuts:
+In order to port PX4 on NuttX to a new hardware target, that hardware target must be supported by NuttX.  The NuttX project maintains an excellent [porting guide](http://www.nuttx.org/Documentation/NuttxPortingGuide.html) for porting NuttX to a new computing platform.
+
+For all NuttX based flight controllers (e.g. the Pixhawk series) the OS is loaded as part of the application build.
+
+The configuration files for NuttX based boards, including linker scripts and other required settings are located under [platforms/nuttx/nuttx-configs](https://github.com/PX4/Firmware/tree/master/platforms/nuttx/nuttx-configs).
+
+The following example uses FMUv5 as it is the current [reference configuration](./reference-design.md) for NuttX based flight controllers:
+* Running `make px4fmu-v5_default` from the `src/Firmware` directory will build the FMUv5 config
+* The base FMUv5 configuration files are located in: [platforms/nuttx/nuttx-configs/px4fmu-v5](https://github.com/PX4/Firmware/tree/master/platforms/nuttx/nuttx-configs/px4fmu-v5).
+* Board specific header: [platforms/nuttx/nuttx-configs/px4fmu-v5/include/board.h](https://github.com/PX4/Firmware/blob/master/platforms/nuttx/nuttx-configs/px4fmu-v5/include/board.h).
+* NuttX OS config (created with Nuttx menuconfig): [nuttx-configs/px4fmu-v5/nsh/defconfig](https://github.com/PX4/Firmware/blob/master/platforms/nuttx/nuttx-configs/px4fmu-v5/nsh/defconfig).
+* Build configuration: [cmake/configs/nuttx\_px4fmu-v5\_default.cmake](https://github.com/PX4/Firmware/blob/master/cmake/configs/nuttx_px4fmu-v5_default.cmake).
+
+The function of each of these files, and perhaps more, will need to be duplicated for a new flight controller board.
+
+#### NuttX Menuconfig
+If you need to modify the NuttX OS configuration, you can do this via [menuconfig](https://bitbucket.org/nuttx/nuttx) using the PX4 shortcuts:
 ```sh
-make px4fmu-v2_default menuconfig
-make px4fmu-v2_default qconfig
+make px4fmu-v5_default menuconfig
+make px4fmu-v5_default qconfig
 ```
 
-## QuRT / Hexagon
+### Linux
+
+Linux boards do not include the OS and kernel configuration. These are already provided by the Linux image available for the board (which needs to support the inertial sensors out of the box).
+
+* [cmake/configs/posix\_rpi\_cross.cmake](https://github.com/PX4/Firmware/blob/master/cmake/configs/posix_rpi_cross.cmake) - RPI cross-compilation.
+
+## Middleware Components and Configuration
+
+This section describes the various middleware components, and the configuration file updates needed to port them to new flight controller hardware.
+
+### QuRT / Hexagon
 
 * The start script is located in [posix-configs/](https://github.com/PX4/Firmware/tree/master/posix-configs).
 * The OS configuration is part of the default Linux image (TODO: Provide location of LINUX IMAGE and flash instructions).
 * The PX4 middleware configuration is located in [src/drivers/boards](https://github.com/PX4/Firmware/tree/master/src/drivers/boards). TODO: ADD BUS CONFIG
 * Drivers: [DriverFramework](https://github.com/px4/DriverFramework).
 * Reference config: Running `make qurt_eagle_release` builds the Snapdragon Flight reference config.
-
-
-## Linux Boards
-
-Linux boards do not include the OS and kernel configuration. These are already provided by the Linux image available for the board (which needs to support the inertial sensors out of the box).
-
-* [cmake/configs/posix\_rpi\_cross.cmake](https://github.com/PX4/Firmware/blob/master/cmake/configs/posix_rpi_cross.cmake) - RPI cross-compilation.
-
-
-
-
 
 ## Related Information
 

--- a/en/debug/porting-guide.md
+++ b/en/debug/porting-guide.md
@@ -4,7 +4,7 @@ This topic is for developers who want to port PX4 to work with *new* flight cont
 
 ## PX4 Architecture
 
-PX4 consists of two main layers: The [board support and middleware layer](https://dev.px4.io/en/middleware/) on top of the host OS (NuttX, Linux or any other POSIX platform like Mac OS), and the applications (Flight Stack in [src/modules](https://github.com/PX4/Firmware/tree/master/src/modules)\).  Please reference the [PX4 Architectural Overview](../concept/architecture.md) for more information.
+PX4 consists of two main layers: The [board support and middleware layer](../middleware/README.md) on top of the host OS (NuttX, Linux or any other POSIX platform like Mac OS), and the applications (Flight Stack in [src/modules](https://github.com/PX4/Firmware/tree/master/src/modules)\).  Please reference the [PX4 Architectural Overview](../concept/architecture.md) for more information.
 
 This guide is focused only on the host OS and middleware as the applications/flight stack will run on any board target.
 
@@ -30,7 +30,7 @@ For all NuttX based flight controllers (e.g. the Pixhawk series) the OS is loade
 
 The configuration files for NuttX based boards, including linker scripts and other required settings are located under [platforms/nuttx/nuttx-configs](https://github.com/PX4/Firmware/tree/master/platforms/nuttx/nuttx-configs).
 
-The following example uses FMUv5 as it is the current [reference configuration](./reference-design.md) for NuttX based flight controllers:
+The following example uses FMUv5 as it is a recent [reference configuration](../debug/reference-design.md) for NuttX based flight controllers:
 * Running `make px4fmu-v5_default` from the `src/Firmware` directory will build the FMUv5 config
 * The base FMUv5 configuration files are located in: [platforms/nuttx/nuttx-configs/px4fmu-v5](https://github.com/PX4/Firmware/tree/master/platforms/nuttx/nuttx-configs/px4fmu-v5).
 * Board specific header: [platforms/nuttx/nuttx-configs/px4fmu-v5/include/board.h](https://github.com/PX4/Firmware/blob/master/platforms/nuttx/nuttx-configs/px4fmu-v5/include/board.h).
@@ -62,7 +62,7 @@ This section describes the various middleware components, and the configuration 
 * The OS configuration is part of the default Linux image (TODO: Provide location of LINUX IMAGE and flash instructions).
 * The PX4 middleware configuration is located in [src/drivers/boards](https://github.com/PX4/Firmware/tree/master/src/drivers/boards). TODO: ADD BUS CONFIG
 * Drivers: [DriverFramework](https://github.com/px4/DriverFramework).
-* Reference config: Running `make qurt_eagle_release` builds the Snapdragon Flight reference config.
+* Reference config: Running `make eagle_default` builds the Snapdragon Flight reference config.
 
 ## Related Information
 


### PR DESCRIPTION
Attempted to group information in a more consistent (and easily expandable) manner. Updated language in various locations to add clarity and be more consistent within the porting guide and with respect to other documentation files.  Added links and references in a few locations to other PX4 documentation as appropriate.  Corrected multiple dead links.