### PR TITLE
Tidy up EKF warnings v2

### DIFF
--- a/en/tutorials/pre_flight_checks.md
+++ b/en/tutorials/pre_flight_checks.md
@@ -1,59 +1,70 @@
 # Preflight Sensor and EKF Checks
-The commander module performs a number of preflight sensor quality and EKF checks which are controlled by the COM_ARM<> parameters. If these checks fail, the motors are prevented from arming and the following error messages are produced:
+
+The commander module performs a number of preflight sensor quality and EKF checks which are controlled by the [COM_ARM_](../advanced/parameter_reference.md#commander) parameters. If these checks fail, the motors are prevented from arming and the following error messages are produced:
 
 * PREFLIGHT FAIL: EKF HGT ERROR
- * This error is produced when the IMU and height measurement data are inconsistent.
- * Perform an accel and gyro calibration and restart the vehicle. If the error persists, check the height sensor data for problems.
- * The check is controlled by the COM_ARM_EKF_HGT parameter.
+  * This error is produced when the IMU and height measurement data are inconsistent.
+  * Perform an accel and gyro calibration and restart the vehicle. If the error persists, check the height sensor data for problems.
+  * The check is controlled by the [COM_ARM_EKF_HGT](#COM_ARM_EKF_HGT) parameter.
 * PREFLIGHT FAIL: EKF VEL ERROR
- * This error is produced when the IMU and GPS velocity measurement data are inconsistent. 
- * Check the GPS velocity data for un-realistic data jumps. If GPS quality looks OK, perform an accel and gyro calibration and restart the vehicle.
- * The check is controlled by the COM_ARM_EKF_VEL parameter.
+  * This error is produced when the IMU and GPS velocity measurement data are inconsistent. 
+  * Check the GPS velocity data for un-realistic data jumps. If GPS quality looks OK, perform an accel and gyro calibration and restart the vehicle.
+  * The check is controlled by the [COM_ARM_EKF_VEL](#COM_ARM_EKF_VEL) parameter.
 * PREFLIGHT FAIL: EKF HORIZ POS ERROR
- * This error is produced when the IMU and position measurement data (either GPS or external vision) are inconsistent. 
- * Check the position sensor data for un-realistic data jumps. If data quality looks OK, perform an accel and gyro calibration and restart the vehicle.
- * The check is controlled by the COM_ARM_EKF_POS parameter.
+  * This error is produced when the IMU and position measurement data (either GPS or external vision) are inconsistent. 
+  * Check the position sensor data for un-realistic data jumps. If data quality looks OK, perform an accel and gyro calibration and restart the vehicle.
+  * The check is controlled by the [COM_ARM_EKF_POS](#COM_ARM_EKF_POS) parameter.
 * PREFLIGHT FAIL: EKF YAW ERROR
- * This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
- * Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
- * The check is controlled by the COM_ARM_EKF_POS parameter
+  * This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
+  * Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
+  * The check is controlled by the [COM_ARM_EKF_POS](#COM_ARM_EKF_POS) parameter
 * PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS
- * This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
- * The check is controlled by the COM_ARM_EKF_AB parameter.
+  * This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
+  * The check is controlled by the [COM_ARM_EKF_AB](#COM_ARM_EKF_AB) parameter.
 * PREFLIGHT FAIL: EKF HIGH IMU GYRO BIAS
- * This error is produced when the IMU gyro bias estimated by the EKF is excessive. 
- * The check is controlled by the COM_ARM_EKF_GB parameter.
+  * This error is produced when the IMU gyro bias estimated by the EKF is excessive. 
+  * The check is controlled by the [COM_ARM_EKF_GB](#COM_ARM_EKF_GB) parameter.
 * PREFLIGHT FAIL: ACCEL SENSORS INCONSISTENT - CHECK CALIBRATION
- * This error message is produced when the acceleration measurements from different IMU units are inconsistent.
- * This check only applies to boards with more than one IMU.
- * The check is controlled by the COM_ARM_IMU_ACC parameter.
+  * This error message is produced when the acceleration measurements from different IMU units are inconsistent.
+  * This check only applies to boards with more than one IMU.
+  * The check is controlled by the [COM_ARM_IMU_ACC](#COM_ARM_IMU_ACC) parameter.
 * PREFLIGHT FAIL: GYRO SENSORS INCONSISTENT - CHECK CALIBRATION
- * This error message is produced when the angular rate measurements from different IMU units are inconsistent.
- * This check only applies to boards with more than one IMU.
- * The check is controlled by the COM_ARM_IMU_GYR parameter.
+  * This error message is produced when the angular rate measurements from different IMU units are inconsistent.
+  * This check only applies to boards with more than one IMU.
+  * The check is controlled by the [COM_ARM_IMU_GYR](#COM_ARM_IMU_GYR) parameter.
 
-##COM_ARM_WO_GPS
-The COM_ARM_WO_GPS parameter controls whether arming is allowed without a GPS signal. This parameter must be set to 0 to allow arming when there is no GPS signal present. Arming without GPS is only allowed if the flight mode selected does not require GPS.
-##COM_ARM_EKF_POS
-The COM_ARM_EKF_POS parameter controls the maximum allowed inconsistency between the EKF inertial measurements and position reference (GPS or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-##COM_ARM_EKF_VEL
-The COM_ARM_EKF_VEL parameter controls the maximum allowed inconsistency between the EKF inertial measurements and GPS velocity measurements. The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-##COM_ARM_EKF_HGT
-The COM_ARM_EKF_HGT parameter controls the maximum allowed inconsistency between the EKF inertial measurements and height measurement (Baro, GPS, range finder or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-##COM_ARM_EKF_YAW
-The COM_ARM_EKF_YAW parameter controls the maximum allowed inconsistency between the EKF inertial measurements and yaw measurement (magnetometer or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-##COM_ARM_EKF_AB
-The COM_ARM_EKF_AB parameter controls the maximum allowed EKF estimated IMU accelerometer bias. The default value of 0.005 allows for up to 0.5 m/s/s of accelerometer bias.
-##COM_ARM_EKF_GB
-The COM_ARM_EKF_GB parameter controls the maximum allowed EKF estimated IMU gyro bias. The default value of 0.00087 allows for up to 5 deg/sec of switch on gyro bias.
-##COM_ARM_IMU_ACC
-The COM_ARM_IMU_ACC parameter controls the maximum allowed inconsistency in acceleration measurements between the default IMU used for flight control and other IMU units if fitted. 
-##COM_ARM_IMU_GYR
-The COM_ARM_IMU_GYR parameter controls the maximum allowed inconsistency in angular rate measurements between the default IMU used for flight control and other IMU units if fitted.
+## COM_ARM_WO_GPS
 
+The [COM_ARM_WO_GPS](../advanced/parameter_reference.md#COM_ARM_WO_GPS) parameter controls whether arming is allowed without a GPS signal. This parameter must be set to 0 to allow arming when there is no GPS signal present. Arming without GPS is only allowed if the flight mode selected does not require GPS.
 
+## COM_ARM_EKF_POS
 
+The [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and position reference (GPS or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
 
+## COM_ARM_EKF_VEL
 
+The [COM_ARM_EKF_VEL](../advanced/parameter_reference.md#COM_ARM_EKF_VEL) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and GPS velocity measurements. The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
 
+## COM_ARM_EKF_HGT
 
+The [COM_ARM_EKF_HGT](../advanced/parameter_reference.md#COM_ARM_EKF_HGT) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and height measurement (Baro, GPS, range finder or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
+
+## COM_ARM_EKF_YAW
+
+The [COM_ARM_EKF_YAW](../advanced/parameter_reference.md#COM_ARM_EKF_YAW) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and yaw measurement (magnetometer or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
+
+## COM_ARM_EKF_AB
+
+The [COM_ARM_EKF_AB](../advanced/parameter_reference.md#COM_ARM_EKF_AB) parameter controls the maximum allowed EKF estimated IMU accelerometer bias. The default value of 0.005 allows for up to 0.5 m/s/s of accelerometer bias.
+
+## COM_ARM_EKF_GB
+
+The [COM_ARM_EKF_GB](../advanced/parameter_reference.md#COM_ARM_EKF_GB) parameter controls the maximum allowed EKF estimated IMU gyro bias. The default value of 0.00087 allows for up to 5 deg/sec of switch on gyro bias.
+
+## COM_ARM_IMU_ACC
+
+The [COM_ARM_IMU_ACC](../advanced/parameter_reference.md#COM_ARM_IMU_ACC) parameter controls the maximum allowed inconsistency in acceleration measurements between the default IMU used for flight control and other IMU units if fitted.
+
+## COM_ARM_IMU_GYR
+
+The [COM_ARM_IMU_GYR](../advanced/parameter_reference.md#COM_ARM_IMU_GYR) parameter controls the maximum allowed inconsistency in angular rate measurements between the default IMU used for flight control and other IMU units if fitted.

--- a/en/tutorials/pre_flight_checks.md
+++ b/en/tutorials/pre_flight_checks.md
@@ -1,54 +1,71 @@
 # Preflight Sensor and EKF Checks
 
-PX4 performs a number of preflight sensor quality and EKF checks to determine if there is a good enough position estimate to arm/fly. These checks are controlled by the [COM_ARM_](../advanced/parameter_reference.md#commander) parameters.
+PX4 performs a number of preflight sensor quality and EKF checks to determine if there is a good enough position estimate to arm/fly. These checks are controlled by the [COM\_ARM\_](../advanced/parameter_reference.md#commander) parameters.
 
-* PREFLIGHT FAIL: EKF HGT ERROR
-  * This error is produced when the IMU and height measurement data are inconsistent.
-  * Perform an accel and gyro calibration and restart the vehicle. If the error persists, check the height sensor data for problems.
-  * The check is controlled by the [COM_ARM_EKF_HGT](../advanced/parameter_reference.md#COM_ARM_EKF_HGT) parameter.
-* PREFLIGHT FAIL: EKF VEL ERROR
-  * This error is produced when the IMU and GPS velocity measurement data are inconsistent. 
-  * Check the GPS velocity data for un-realistic data jumps. If GPS quality looks OK, perform an accel and gyro calibration and restart the vehicle.
-  * The check is controlled by the [COM_ARM_EKF_VEL](../advanced/parameter_reference.md#COM_ARM_EKF_VEL) parameter.
-* PREFLIGHT FAIL: EKF HORIZ POS ERROR
-  * This error is produced when the IMU and position measurement data (either GPS or external vision) are inconsistent. 
-  * Check the position sensor data for un-realistic data jumps. If data quality looks OK, perform an accel and gyro calibration and restart the vehicle.
-  * The check is controlled by the [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS)) parameter.
-* PREFLIGHT FAIL: EKF YAW ERROR
-  * This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
-  * Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
-  * The check is controlled by the [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS) parameter
-* PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS
-  * This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
-  * The check is controlled by the [COM_ARM_EKF_AB](../advanced/parameter_reference.md#COM_ARM_EKF_AB) parameter.
-* PREFLIGHT FAIL: EKF HIGH IMU GYRO BIAS
-  * This error is produced when the IMU gyro bias estimated by the EKF is excessive. 
-  * The check is controlled by the [COM_ARM_EKF_GB](../advanced/parameter_reference.md#COM_ARM_EKF_GB) parameter.
-* PREFLIGHT FAIL: ACCEL SENSORS INCONSISTENT - CHECK CALIBRATION
-  * This error message is produced when the acceleration measurements from different IMU units are inconsistent.
-  * This check only applies to boards with more than one IMU.
-  * The check is controlled by the [COM_ARM_IMU_ACC](../advanced/parameter_reference.md#COM_ARM_IMU_ACC) parameter.
-* PREFLIGHT FAIL: GYRO SENSORS INCONSISTENT - CHECK CALIBRATION
-  * This error message is produced when the angular rate measurements from different IMU units are inconsistent.
-  * This check only applies to boards with more than one IMU.
-  * The check is controlled by the [COM_ARM_IMU_GYR](../advanced/parameter_reference.md#COM_ARM_IMU_GYR) parameter.
-* PREFLIGHT FAIL: EKF INTERNAL CHECKS
-  * This error message is generated if the innovation magnitudes of either the horizontal GPS velocity, magnetic yaw, vertical GPS velocity or vertical position sensor (Baro by default but could be range finder or GPS if non-standard params are being used) are excessive. Innovations are the difference between the value predicted by the inertial navigation calculation and measured by the sensor.
-  * Users should check the innovation levels in the log file to determine the cause. These can be found under the `ekf2_innovations` message. 
-    Common problems/solutions include:
-    * IMU drift on warmup. May be resolved by restarting the autopilot. May require an IMU accel and gyro calibration.
-    * Adjacent magnetic interference combined with vehicle movement. Resolve my moving vehicle and waiting or re-powering.
-    * Bad magnetometer calibration combined with vehicle movement. Resolve by recalibrating.
-    * Initial shock or rapid movement on startup that caused a bad inertial nav solution. Resolve by restarting the vehicle and minimising movement for the first 5 seconds.
+## EKF Preflight Checks/Errors
+
+The following errors (with associated checks and parameters) are reported by the EKF (and propagate to *QGroundControl*):
+
+`PREFLIGHT FAIL: EKF HGT ERROR`:
+* This error is produced when the IMU and height measurement data are inconsistent.
+* Perform an accel and gyro calibration and restart the vehicle. If the error persists, check the height sensor data for problems.
+* The check is controlled by the [COM_ARM_EKF_HGT](../advanced/parameter_reference.md#COM_ARM_EKF_HGT) parameter.
+
+`PREFLIGHT FAIL: EKF VEL ERROR`:
+* This error is produced when the IMU and GPS velocity measurement data are inconsistent. 
+* Check the GPS velocity data for un-realistic data jumps. If GPS quality looks OK, perform an accel and gyro calibration and restart the vehicle.
+* The check is controlled by the [COM_ARM_EKF_VEL](../advanced/parameter_reference.md#COM_ARM_EKF_VEL) parameter.
   
+`PREFLIGHT FAIL: EKF HORIZ POS ERROR`:
+* This error is produced when the IMU and position measurement data (either GPS or external vision) are inconsistent. 
+* Check the position sensor data for un-realistic data jumps. If data quality looks OK, perform an accel and gyro calibration and restart the vehicle.
+* The check is controlled by the [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS) parameter.
   
+`PREFLIGHT FAIL: EKF YAW ERROR`:
+* This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
+* Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
+* The check is controlled by the [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS) parameter
 
-## COM_ARM_WO_GPS
+`PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS`:
+* This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
+* The check is controlled by the [COM_ARM_EKF_AB](../advanced/parameter_reference.md#COM_ARM_EKF_AB) parameter.
+  
+`PREFLIGHT FAIL: EKF HIGH IMU GYRO BIAS`:
+* This error is produced when the IMU gyro bias estimated by the EKF is excessive. 
+* The check is controlled by the [COM_ARM_EKF_GB](../advanced/parameter_reference.md#COM_ARM_EKF_GB) parameter.
 
-The [COM_ARM_WO_GPS](../advanced/parameter_reference.md#COM_ARM_WO_GPS) parameter controls whether arming is allowed without a GPS signal. This parameter must be set to 0 to allow arming when there is no GPS signal present. Arming without GPS is only allowed if the flight mode selected does not require GPS.
+`PREFLIGHT FAIL: ACCEL SENSORS INCONSISTENT - CHECK CALIBRATION`:
+* This error message is produced when the acceleration measurements from different IMU units are inconsistent.
+* This check only applies to boards with more than one IMU.
+* The check is controlled by the [COM_ARM_IMU_ACC](../advanced/parameter_reference.md#COM_ARM_IMU_ACC) parameter.
+
+`PREFLIGHT FAIL: GYRO SENSORS INCONSISTENT - CHECK CALIBRATION`:
+* This error message is produced when the angular rate measurements from different IMU units are inconsistent.
+* This check only applies to boards with more than one IMU.
+* The check is controlled by the [COM_ARM_IMU_GYR](../advanced/parameter_reference.md#COM_ARM_IMU_GYR) parameter.
+
+`PREFLIGHT FAIL: EKF INTERNAL CHECKS`:
+* This error message is generated if the innovation magnitudes of either the horizontal GPS velocity, magnetic yaw, vertical GPS velocity or vertical position sensor (Baro by default but could be range finder or GPS if non-standard parameters are being used) are excessive. Innovations are the difference between the value predicted by the inertial navigation calculation and measured by the sensor.
+* Users should check the innovation levels in the log file to determine the cause. These can be found under the `ekf2_innovations` message. 
+  Common problems/solutions include:
+  * IMU drift on warmup. May be resolved by restarting the autopilot. May require an IMU accel and gyro calibration.
+  * Adjacent magnetic interference combined with vehicle movement. Resolve my moving vehicle and waiting or re-powering.
+  * Bad magnetometer calibration combined with vehicle movement. Resolve by recalibrating.
+  * Initial shock or rapid movement on startup that caused a bad inertial nav solution. Resolve by restarting the vehicle and minimising movement for the first 5 seconds.
 
 
-## COM_ARM_EKF_YAW
+## Other Parameters
 
-The [COM_ARM_EKF_YAW](../advanced/parameter_reference.md#COM_ARM_EKF_YAW) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and yaw measurement (magnetometer or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
+The following parameters also affect preflight checks.
+
+### COM_ARM_WO_GPS
+
+The [COM_ARM_WO_GPS](../advanced/parameter_reference.md#COM_ARM_WO_GPS) parameter controls whether or not arming is allowed without a global position estimate. 
+- `1` (default): Arming *is* allowed without a position estimate for flight modes that do not require position information (only).
+- `0`: Arming is allowed only if EKF is providing a global position estimate and EFK GPS quality checks are passing
+
+
+### COM_ARM_EKF_YAW
+
+The [COM_ARM_EKF_YAW](../advanced/parameter_reference.md#COM_ARM_EKF_YAW) parameter determines the maximum difference (in radians) between the navigation yaw angle and magnetic yaw angle (magnetometer or external vision) allowed before preflight checks fail. The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences. It can fail if the yaw gyro has a large offset or if the vehicle is moved or rotated in the presence of a bad magnetic interference or magnetometer calibration.
 

--- a/en/tutorials/pre_flight_checks.md
+++ b/en/tutorials/pre_flight_checks.md
@@ -1,6 +1,6 @@
 # Preflight Sensor and EKF Checks
 
-The commander module performs a number of preflight sensor quality and EKF checks which are controlled by the [COM_ARM_](../advanced/parameter_reference.md#commander) parameters. If these checks fail, the motors are prevented from arming and the following error messages are produced:
+PX4 performs a number of preflight sensor quality and EKF checks to determine if there is a good enough position estimate to arm/fly. These checks are controlled by the [COM_ARM_](../advanced/parameter_reference.md#commander) parameters.
 
 * PREFLIGHT FAIL: EKF HGT ERROR
   * This error is produced when the IMU and height measurement data are inconsistent.
@@ -36,7 +36,7 @@ The commander module performs a number of preflight sensor quality and EKF check
   * This error message is generated if the innovation magnitudes of either the horizontal GPS velocity, magnetic yaw, vertical GPS velocity or vertical position sensor (Baro by default but could be range finder or GPS if non-standard params are being used) are excessive. Innovations are the difference between the value predicted by the inertial navigation calculation and measured by the sensor.
   * Users should check the innovation levels in the log file to determine the cause. These can be found under the `ekf2_innovations` message. 
     Common problems/solutions include:
-	* IMU drift on warmup. May be resolved by restarting the autopilot. May require an IMU accel and gyro calibration.
+    * IMU drift on warmup. May be resolved by restarting the autopilot. May require an IMU accel and gyro calibration.
     * Adjacent magnetic interference combined with vehicle movement. Resolve my moving vehicle and waiting or re-powering.
     * Bad magnetometer calibration combined with vehicle movement. Resolve by recalibrating.
     * Initial shock or rapid movement on startup that caused a bad inertial nav solution. Resolve by restarting the vehicle and minimising movement for the first 5 seconds.

--- a/en/tutorials/pre_flight_checks.md
+++ b/en/tutorials/pre_flight_checks.md
@@ -5,66 +5,41 @@ The commander module performs a number of preflight sensor quality and EKF check
 * PREFLIGHT FAIL: EKF HGT ERROR
   * This error is produced when the IMU and height measurement data are inconsistent.
   * Perform an accel and gyro calibration and restart the vehicle. If the error persists, check the height sensor data for problems.
-  * The check is controlled by the [COM_ARM_EKF_HGT](#COM_ARM_EKF_HGT) parameter.
+  * The check is controlled by the [COM_ARM_EKF_HGT](../advanced/parameter_reference.md#COM_ARM_EKF_HGT) parameter.
 * PREFLIGHT FAIL: EKF VEL ERROR
   * This error is produced when the IMU and GPS velocity measurement data are inconsistent. 
   * Check the GPS velocity data for un-realistic data jumps. If GPS quality looks OK, perform an accel and gyro calibration and restart the vehicle.
-  * The check is controlled by the [COM_ARM_EKF_VEL](#COM_ARM_EKF_VEL) parameter.
+  * The check is controlled by the [COM_ARM_EKF_VEL](../advanced/parameter_reference.md#COM_ARM_EKF_VEL) parameter.
 * PREFLIGHT FAIL: EKF HORIZ POS ERROR
   * This error is produced when the IMU and position measurement data (either GPS or external vision) are inconsistent. 
   * Check the position sensor data for un-realistic data jumps. If data quality looks OK, perform an accel and gyro calibration and restart the vehicle.
-  * The check is controlled by the [COM_ARM_EKF_POS](#COM_ARM_EKF_POS) parameter.
+  * The check is controlled by the [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS)) parameter.
 * PREFLIGHT FAIL: EKF YAW ERROR
   * This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
   * Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
-  * The check is controlled by the [COM_ARM_EKF_POS](#COM_ARM_EKF_POS) parameter
+  * The check is controlled by the [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS) parameter
 * PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS
   * This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
-  * The check is controlled by the [COM_ARM_EKF_AB](#COM_ARM_EKF_AB) parameter.
+  * The check is controlled by the [COM_ARM_EKF_AB](../advanced/parameter_reference.md#COM_ARM_EKF_AB) parameter.
 * PREFLIGHT FAIL: EKF HIGH IMU GYRO BIAS
   * This error is produced when the IMU gyro bias estimated by the EKF is excessive. 
-  * The check is controlled by the [COM_ARM_EKF_GB](#COM_ARM_EKF_GB) parameter.
+  * The check is controlled by the [COM_ARM_EKF_GB](../advanced/parameter_reference.md#COM_ARM_EKF_GB) parameter.
 * PREFLIGHT FAIL: ACCEL SENSORS INCONSISTENT - CHECK CALIBRATION
   * This error message is produced when the acceleration measurements from different IMU units are inconsistent.
   * This check only applies to boards with more than one IMU.
-  * The check is controlled by the [COM_ARM_IMU_ACC](#COM_ARM_IMU_ACC) parameter.
+  * The check is controlled by the [COM_ARM_IMU_ACC](../advanced/parameter_reference.md#COM_ARM_IMU_ACC) parameter.
 * PREFLIGHT FAIL: GYRO SENSORS INCONSISTENT - CHECK CALIBRATION
   * This error message is produced when the angular rate measurements from different IMU units are inconsistent.
   * This check only applies to boards with more than one IMU.
-  * The check is controlled by the [COM_ARM_IMU_GYR](#COM_ARM_IMU_GYR) parameter.
+  * The check is controlled by the [COM_ARM_IMU_GYR](../advanced/parameter_reference.md#COM_ARM_IMU_GYR) parameter.
+
 
 ## COM_ARM_WO_GPS
 
 The [COM_ARM_WO_GPS](../advanced/parameter_reference.md#COM_ARM_WO_GPS) parameter controls whether arming is allowed without a GPS signal. This parameter must be set to 0 to allow arming when there is no GPS signal present. Arming without GPS is only allowed if the flight mode selected does not require GPS.
 
-## COM_ARM_EKF_POS
-
-The [COM_ARM_EKF_POS](../advanced/parameter_reference.md#COM_ARM_EKF_POS) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and position reference (GPS or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-
-## COM_ARM_EKF_VEL
-
-The [COM_ARM_EKF_VEL](../advanced/parameter_reference.md#COM_ARM_EKF_VEL) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and GPS velocity measurements. The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
-
-## COM_ARM_EKF_HGT
-
-The [COM_ARM_EKF_HGT](../advanced/parameter_reference.md#COM_ARM_EKF_HGT) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and height measurement (Baro, GPS, range finder or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
 
 ## COM_ARM_EKF_YAW
 
 The [COM_ARM_EKF_YAW](../advanced/parameter_reference.md#COM_ARM_EKF_YAW) parameter controls the maximum allowed inconsistency between the EKF inertial measurements and yaw measurement (magnetometer or external vision). The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
 
-## COM_ARM_EKF_AB
-
-The [COM_ARM_EKF_AB](../advanced/parameter_reference.md#COM_ARM_EKF_AB) parameter controls the maximum allowed EKF estimated IMU accelerometer bias. The default value of 0.005 allows for up to 0.5 m/s/s of accelerometer bias.
-
-## COM_ARM_EKF_GB
-
-The [COM_ARM_EKF_GB](../advanced/parameter_reference.md#COM_ARM_EKF_GB) parameter controls the maximum allowed EKF estimated IMU gyro bias. The default value of 0.00087 allows for up to 5 deg/sec of switch on gyro bias.
-
-## COM_ARM_IMU_ACC
-
-The [COM_ARM_IMU_ACC](../advanced/parameter_reference.md#COM_ARM_IMU_ACC) parameter controls the maximum allowed inconsistency in acceleration measurements between the default IMU used for flight control and other IMU units if fitted.
-
-## COM_ARM_IMU_GYR
-
-The [COM_ARM_IMU_GYR](../advanced/parameter_reference.md#COM_ARM_IMU_GYR) parameter controls the maximum allowed inconsistency in angular rate measurements between the default IMU used for flight control and other IMU units if fitted.

--- a/en/tutorials/pre_flight_checks.md
+++ b/en/tutorials/pre_flight_checks.md
@@ -32,7 +32,16 @@ The commander module performs a number of preflight sensor quality and EKF check
   * This error message is produced when the angular rate measurements from different IMU units are inconsistent.
   * This check only applies to boards with more than one IMU.
   * The check is controlled by the [COM_ARM_IMU_GYR](../advanced/parameter_reference.md#COM_ARM_IMU_GYR) parameter.
-
+* PREFLIGHT FAIL: EKF INTERNAL CHECKS
+  * This error message is generated if the innovation magnitudes of either the horizontal GPS velocity, magnetic yaw, vertical GPS velocity or vertical position sensor (Baro by default but could be range finder or GPS if non-standard params are being used) are excessive. Innovations are the difference between the value predicted by the inertial navigation calculation and measured by the sensor.
+  * Users should check the innovation levels in the log file to determine the cause. These can be found under the `ekf2_innovations` message. 
+    Common problems/solutions include:
+	* IMU drift on warmup. May be resolved by restarting the autopilot. May require an IMU accel and gyro calibration.
+    * Adjacent magnetic interference combined with vehicle movement. Resolve my moving vehicle and waiting or re-powering.
+    * Bad magnetometer calibration combined with vehicle movement. Resolve by recalibrating.
+    * Initial shock or rapid movement on startup that caused a bad inertial nav solution. Resolve by restarting the vehicle and minimising movement for the first 5 seconds.
+  
+  
 
 ## COM_ARM_WO_GPS
 


### PR DESCRIPTION
This tidies up the doc so that:
1. Descriptions of parameters in text are linked to "official" documentation (duplicated content removed)
1. Bullets are indented 2 spaces. This merely tidies the rendering in github - things always worked in final gitbook version
1. Headings have space between text and heading marker (just improves rendering).
1. Added definition for PREFLIGHT FAIL: EKF INTERNAL CHECKS from @priseborough 