### PR TITLE
For clarity of the position of the 'S:' line

### DIFF
--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -177,6 +177,8 @@ inputs and their scaling, in the form:
 
 	S: <group> <index> <-ve scale> <+ve scale> <offset> <lower limit> <upper limit>
 
+The 'S:' lines cannot be located above the 'O:' line.
+
 The &lt;group&gt; value identifies the control group from which the scaler will read,
 and the &lt;index&gt; value an offset within that group.  These values are specific to
 the device reading the mixer definition.


### PR DESCRIPTION
If 'S:' lines are located above the 'O:' line it does not work properly.
So this change clarifies the misuse.

By the misuse, user may spend several hours.