### PR TITLE
Replace legacy snapdragon instructions

### DIFF
--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -36,7 +36,15 @@ To install the development toolchain:
 1. Restart the computer on completion.
 
 
-### Snapdragon Flight or Raspberry Pi
+### Snapdragon Flight
+
+Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
+* [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
+* [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
+* [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
+
+   
+### Raspberry Pi
 
 To install the development toolchain:
 1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh" target="_blank" download>ubuntu_sim_common_deps.sh</a> (this contains the jMAVSim simulator and common toolchain dependencies).
@@ -45,9 +53,7 @@ To install the development toolchain:
    source ubuntu_sim_common_deps.sh
    ```
    You may need to acknowledge some prompts as the script progresses.
-1. Follow the platform-specific instructions in [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md) for your target:
-   * [Snapdragon Flight](../setup/dev_env_linux_ubuntu.md#snapdragon-flight)
-   * [Raspberry Pi](../setup/dev_env_linux_ubuntu.md#raspberry-pi-hardware)
+1. Follow setup instructions in [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md) for [Raspberry Pi](../setup/dev_env_linux_ubuntu.md#raspberry-pi-hardware).
 
 ### Parrot Bepop
 

--- a/en/setup/dev_env_linux_ubuntu.md
+++ b/en/setup/dev_env_linux_ubuntu.md
@@ -253,65 +253,10 @@ sudo add-apt-repository --remove ppa:team-gcc-arm-embedded/ppa
 
 ## Snapdragon Flight
 
-### (Cross) Toolchain installation
-
-```sh
-sudo apt-get install android-tools-adb android-tools-fastboot \
-    fakechroot fakeroot unzip xz-utils wget python python-empy -y
-```
-
-Please follow the instructions on https://github.com/ATLFlight/cross_toolchain for the toolchain installation.
-
-Load the new configuration:
-
-```sh
-source ~/.bashrc
-```
-
-### Sysroot Installation
-
-A sysroot is required to provide the libraries and header files needed to cross compile applications for the Snapdragon Flight applications processor.
-
-The qrlSDK sysroot provides the required header files and libraries for the camera, GPU, etc.
-
-Download the file [Flight_3.1.3_qrlSDK.tgz](https://support.intrinsyc.com/attachments/download/1515/Flight_3.1.3_qrlSDK.tgz) and save it in `cross_toolchain/download/`.
-
-```sh
-cd cross_toolchain
-unset HEXAGON_ARM_SYSROOT
-./qrlinux_sysroot.sh
-```
-
-Append the following to your ~/.bashrc:
-
-```sh
-export HEXAGON_ARM_SYSROOT=${HOME}/Qualcomm/qrlinux_v3.1.1_sysroot
-```
-
-Load the new configuration:
-
-```sh
-source ~/.bashrc
-```
-
-For more sysroot options see [Sysroot Installation](https://github.com/ATLFlight/cross_toolchain/blob/sdk3/README.md#sysroot-installation)
-
-### Update ADSP firmware
-
-Before building, flashing and running code, you'll need to update the [ADSP firmware](https://docs.px4.io/en/flight_controller/snapdragon_flight_advanced.html#updating-the-adsp-firmware).
-
-### References
-
-There is a an external set of documentation for Snapdragon Flight toolchain and SW setup and verification:
-[ATLFlightDocs](https://github.com/ATLFlight/ATLFlightDocs/blob/master/README.md)
-
-Messages from the DSP can be viewed using mini-dm.
-
-```sh
-${HEXAGON_SDK_ROOT}/tools/debug/mini-dm/Linux_Debug/mini-dm
-```
-
-Note: Alternatively, especially on Mac, you can also use [nano-dm](https://github.com/kevinmehall/nano-dm).
+Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
+* [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
+* [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
+* [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
 
 ## Raspberry Pi Hardware
 

--- a/kr/setup/dev_env_linux.md
+++ b/kr/setup/dev_env_linux.md
@@ -34,8 +34,15 @@
    스크립트 진행되면서 프롬프트가 나타날 수 있습니다.
 1. 완료되면 컴퓨터를 재시작합니다.
 
+### Snapdragon Flight
 
-### Snapdragon Flight 혹은 Raspberry Pi
+Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
+* [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
+* [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
+* [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
+
+
+### Raspberry Pi
 
 개발 툴체인 설치하기:
 1. <a href="https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim.sh" target="_blank" download>ubuntu_sim.sh</a> 다운로드 (시뮬레이터와 공통 툴체인 관련 내용이 포함).
@@ -45,7 +52,6 @@
    ```
    스크립트 진행되면서 프롬프트가 나타날 수 있습니다.
 1. [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md)에서 플랫폼에 따라 해당 지시를 따릅니다:
-   * [Snapdragon Flight](../setup/dev_env_linux_ubuntu.md#snapdragon-flight)
    * [Raspberry Pi](../setup/dev_env_linux_ubuntu.md#raspberry-pi-hardware)
 
 ### Parrot Bepop

--- a/kr/setup/dev_env_linux_ubuntu.md
+++ b/kr/setup/dev_env_linux_ubuntu.md
@@ -275,65 +275,10 @@ arm-none-eabi-gcc: No such file or directory
 
 ## Snapdragon Flight
 
-### (Cross) Toolchain installation
-
-```sh
-sudo apt-get install android-tools-adb android-tools-fastboot \
-    fakechroot fakeroot unzip xz-utils wget python python-empy -y
-```
-
-Please follow the instructions on https://github.com/ATLFlight/cross_toolchain for the toolchain installation.
-
-Load the new configuration:
-
-```sh
-source ~/.bashrc
-```
-
-### Sysroot Installation
-
-A sysroot is required to provide the libraries and header files needed to cross compile applications for the Snapdragon Flight applications processor.
-
-The qrlSDK sysroot provides the required header files and libraries for the camera, GPU, etc.
-
-Download the file [Flight_3.1.3_qrlSDK.tgz](https://support.intrinsyc.com/attachments/download/1515/Flight_3.1.3_qrlSDK.tgz) and save it in `cross_toolchain/download/`.
-
-```sh
-cd cross_toolchain
-unset HEXAGON_ARM_SYSROOT
-./qrlinux_sysroot.sh
-```
-
-Append the following to your ~/.bashrc:
-
-```sh
-export HEXAGON_ARM_SYSROOT=${HOME}/Qualcomm/qrlinux_v3.1.1_sysroot
-```
-
-Load the new configuration:
-
-```sh
-source ~/.bashrc
-```
-
-For more sysroot options see [Sysroot Installation](https://github.com/ATLFlight/cross_toolchain/blob/sdk3/README.md#sysroot-installation)
-
-### Update ADSP firmware
-
-Before building, flashing and running code, you'll need to update the [ADSP firmware](https://docs.px4.io/en/flight_controller/snapdragon_flight_advanced.html#updating-the-adsp-firmware).
-
-### References
-
-There is a an external set of documentation for Snapdragon Flight toolchain and SW setup and verification:
-[ATLFlightDocs](https://github.com/ATLFlight/ATLFlightDocs/blob/master/README.md)
-
-Messages from the DSP can be viewed using mini-dm.
-
-```sh
-${HEXAGON_SDK_ROOT}/tools/debug/mini-dm/Linux_Debug/mini-dm
-```
-
-Note: Alternatively, especially on Mac, you can also use [nano-dm](https://github.com/kevinmehall/nano-dm).
+Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
+* [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
+* [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
+* [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
 
 ## Raspberry Pi Hardware
 

--- a/zh/setup/dev_env_linux.md
+++ b/zh/setup/dev_env_linux.md
@@ -176,8 +176,6 @@ $HOME/Qualcomm/Hexagon_SDK/2.0/tools/mini-dm/Linux_Debug/mini-dm
 
 树莓派开发者应该从下面地址下载树莓派Linux工具链。安装脚本会自动安装交叉编译工具链。如果想要用原生树莓派工具链在树莓派上直接编译，参见[这里](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html#native-builds-optional)。
 
-<div class="host-code"></div>
-
 ```sh
 git clone https://github.com/pixhawk/rpi_toolchain.git
 cd rpi_toolchain
@@ -186,7 +184,15 @@ cd rpi_toolchain
 
 在工具链安装过程中需要输入密码。
 
-如果不想把工具链安装在默认位置```/opt/rpi_toolchain```，可以执行``` ./install_cross.sh <PATH>```向安装脚本传入其它地址。安装脚本会自动配置需要的环境变量。
+如果不想把工具链安装在默认位置
+```
+/opt/rpi_toolchain
+```
+，可以执行
+```
+./install_cross.sh <PATH>
+```
+向安装脚本传入其它地址。安装脚本会自动配置需要的环境变量。
 
 最后，运行以下命令更新环境变量：
 


### PR DESCRIPTION
This  removes the out of date instructions for setting up developer environment for snapdragon with links to new docs on User guide.

@nicovanduijn Does this work for you?