### PR TITLE
More details on switching state estimators

### DIFF
--- a/en/advanced/switching_state_estimators.md
+++ b/en/advanced/switching_state_estimators.md
@@ -2,7 +2,9 @@
 
 This page shows you which state estimators are available and how you can switch between them.
 
-## Available #stimators
+> **Tip** EKF2 is highly recommended for all purposes (LPE is no longer maintained). 
+
+## Available Estimators
 
 The available estimators are: 
 - **Q attitude estimator** - The attitude Q estimator is a very simple, quaternion based complementary filter for attitude.
@@ -12,11 +14,12 @@ The available estimators are:
 
 ## How to Enable Different Estimators
 
-For multirotors and VTOL use the parameter [SYS_MC_EST_GROUP](../advanced/parameter_reference.md#SYS_MC_EST_GROUP) to choose between the following configurations.
-
+For multirotors and VTOL use the parameter [SYS_MC_EST_GROUP](../advanced/parameter_reference.md#SYS_MC_EST_GROUP) to choose between the following configurations (LPE is not supported for Fixed Wing).
 
 | SYS_MC_EST_GROUP | Q Estimator| INAV | LPE | EKF2 |
 | --- | --- | --- | --- | --- |
 | 0 | enabled | enabled | | |
 | 1 | enabled |  | enabled | |
 | 2 |  |  | | enabled |
+
+> **Note** For FMU-v2 (only) you will also need to build PX4 to specifically include required estimator (e.g. EKF2: `make px4fmu-v2`, LPE: `make px4fmu-v2_lpe`). This is required because FMU-v2 is too resource constrained to include both estimators. Other Pixhawk FMU versions include both.


### PR DESCRIPTION
- Not recommending EKF2/deprecating LPE
- Make it clear that you need to build FMUv2 to include required estimator
- Clarify FW does not support LPE