### PR TITLE
[Bebop 2] Upload to internal_000, automate mixer/config files upload, add the '2' to Bebop here and there

### DIFF
--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -202,9 +202,9 @@ cd /home/pi && ./px4 -d px4.config > px4.log
 ```
 
 
-### Parrot Bebop
+### Parrot  2
 
-Support for the [Parrot Bebop](https://docs.px4.io/en/flight_controller/bebop.html) is at an early stage and should be used very carefully.
+Support for the [Parrot Bebop 2](https://docs.px4.io/en/flight_controller/bebop.html) is at an early stage and should be used very carefully.
 
 #### Build
 ```sh

--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -201,8 +201,7 @@ accordingly if you use native build), right before the `exit 0` line:
 cd /home/pi && ./px4 -d px4.config > px4.log
 ```
 
-
-### Parrot  2
+### Parrot Bebop 2
 
 Support for the [Parrot Bebop 2](https://docs.px4.io/en/flight_controller/bebop.html) is at an early stage and should be used very carefully.
 
@@ -219,15 +218,12 @@ four times to enable ADB and to start the telnet daemon.
 make posix_bebop_default upload
 ```
 
-This will upload the PX4 mainapp into /usr/bin and create the file /home/root/parameters if not already
-present. In addition, we need the Bebop's mixer file and the px4.config. Currently, both files have
-to be copied manually using the following commands.
-```sh
-adb connect 192.168.42.1:9050
-adb push ROMFS/px4fmu_common/mixers/bebop.main.mix /home/root
-adb push posix-configs/bebop/px4.config /home/root
-adb disconnect
-```
+This will:
+- Upload the PX4 mainapp into `/data/ftp/internal_000`
+- Create the file `/home/root/parameters` if not already
+present.
+- Upload the mixer file `bebop.main.mix` into `/home/root`.
+- Upload the config file `/posix-configs/bebop/px4.config` into `/home/root`.
 
 #### Run
 Connect to the Bebop's wifi and press the power button four times. Next,
@@ -243,7 +239,7 @@ kk
 ```
 and start the PX4 mainapp with:
 ```sh
-px4 /home/root/px4.config
+/data/ftp/internal_000/px4 /home/root/px4.config
 ```
 
 In order to fly the Bebop, connect a joystick device with your host machine and start QGroundControl. Both,
@@ -258,7 +254,7 @@ DragonStarter.sh -out2null &
 ```
 Replace it with:
 ```
-px4 -d /home/root/px4.config > /home/root/px4.log
+/data/ftp/internal_000/px4 -d /home/root/px4.config > /home/root/px4.log
 ```
 
 Enable adb server by pressing the power button 4 times and connect to adb server as described before:

--- a/en/setup/dev_env.md
+++ b/en/setup/dev_env.md
@@ -12,7 +12,7 @@ Target | Linux (Ubuntu) | Mac | Windows
 --|:--:|:--:|:--:
 **NuttX based hardware:** [Pixhawk Series](https://docs.px4.io/en/flight_controller/pixhawk_series.html), [Crazyflie](https://docs.px4.io/en/flight_controller/crazyflie2.html), [Intel® Aero Ready to Fly Drone](https://docs.px4.io/en/flight_controller/intel_aero.html) | X | X | X
 [Qualcomm Snapdragon Flight hardware](https://docs.px4.io/en/flight_controller/snapdragon_flight.html) | X | | 
-**Linux-based hardware:** [Raspberry Pi 2/3](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html), [Parrot Bebop](https://docs.px4.io/en/flight_controller/bebop.html)  | X | | 
+**Linux-based hardware:** [Raspberry Pi 2/3](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html), [Parrot Bebop 2](https://docs.px4.io/en/flight_controller/bebop.html)  | X | | 
 **Simulation:** [jMAVSim SITL](../simulation/jmavsim.md) | X | X | X
 **Simulation:** [Gazebo SITL](../simulation/gazebo.md) | X | X | 
 **Simulation:** [ROS with Gazebo](../simulation/ros_interface.md) | X | | 

--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -55,9 +55,9 @@ To install the development toolchain:
    You may need to acknowledge some prompts as the script progresses.
 1. Follow setup instructions in [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md) for [Raspberry Pi](../setup/dev_env_linux_ubuntu.md#raspberry-pi-hardware).
 
-### Parrot Bepop
+### Parrot Bepop 2
 
-Follow the (manual) instructions here: [Ubuntu/Debian Linux > Parrot Bebop](../setup/dev_env_linux_ubuntu.md#raspberry-pi-hardware).
+Follow the (manual) instructions here: [Ubuntu/Debian Linux > Parrot Bebop 2](../setup/dev_env_linux_ubuntu.md#parrot-bebop-2).
 
 
 ### jMAVSim/Gazebo Simulation

--- a/en/setup/dev_env_linux_ubuntu.md
+++ b/en/setup/dev_env_linux_ubuntu.md
@@ -4,7 +4,7 @@
 
 The following instructions explain how to *manually* set up a development environment each of the supported targets.
 
-> **Tip** We recommend that you use the [Convenience bash scripts](#convenience-bash-scripts) to install the Simulators and/or NuttX toolchain (this is easier than typing in the instructions below). Then follow just the additional instructions for other targets (e.g. Qualcomm Snapdragon Flight, Bebop, Raspberry Pi, etc.)
+> **Tip** We recommend that you use the [Convenience bash scripts](#convenience-bash-scripts) to install the Simulators and/or NuttX toolchain (this is easier than typing in the instructions below). Then follow just the additional instructions for other targets (e.g. Qualcomm Snapdragon Flight, Bebop 2, Raspberry Pi, etc.)
 
 
 
@@ -18,7 +18,7 @@ The scripts are:
 
 * <strong><a href="https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh" target="_blank" download>ubuntu_sim_common_deps.sh</a></strong>: [Common Dependencies](#common-dependencies), [jMAVSim](#jmavsim) simulator
   * This script contains the common dependencies for all PX4 build targets. It is automatically downloaded and run when you call any of the other scripts.
-  * You can run this before installing the remaining dependencies for [Qualcomm Snapdragon Flight](#snapdragon-flight) or [Raspberry Pi/Parrot Bebop](#raspberry-pi-hardware).
+  * You can run this before installing the remaining dependencies for [Qualcomm Snapdragon Flight](#snapdragon-flight) or [Raspberry Pi/Parrot Bebop 2](#raspberry-pi-hardware).
 
 * <strong><a href="https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim.sh" target="_blank" download>ubuntu_sim.sh</a></strong>: **ubuntu_sim_common_deps.sh** + [Gazebo8](#gazebo) simulator. 
 * <strong><a href="https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_nuttx.sh" target="_blank" download>ubuntu_sim_nuttx.sh</a></strong>: **ubuntu_sim.sh** + NuttX tools. 
@@ -305,7 +305,7 @@ cmake \
 
 Additional developer information for using PX4 on Raspberry Pi (including building PX4 natively) can be found here: [Raspberry Pi 2/3 Navio2 Autopilot](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html).
 
-## Parrot Bebop
+## Parrot Bebop 2
 
 Developers working with the Parrot Bebop should install the RPi Linux Toolchain. Follow the
 description under [Raspberry Pi hardware](#raspberry-pi-hardware).

--- a/en/tutorials/optical_flow.md
+++ b/en/tutorials/optical_flow.md
@@ -59,7 +59,7 @@ In order to ensure good optical flow quality, it is important to focus the camer
 
 #### Other Cameras
 
-It is also possible to use a board/quad that has an integrated camera (Bebop2, Snapdragon Flight). For this the [Optical Flow repo](https://github.com/PX4/OpticalFlow) can be used (see also [snap_cam](https://github.com/PX4/snap_cam)).
+It is also possible to use a board/quad that has an integrated camera (Bebop 2, Snapdragon Flight). For this the [Optical Flow repo](https://github.com/PX4/OpticalFlow) can be used (see also [snap_cam](https://github.com/PX4/snap_cam)).
 
 ### Range Finder
 


### PR DESCRIPTION
Syncs with this PR: https://github.com/PX4/Firmware/pull/9805

- move px4 executable to internal_000
- automate upload of mixer and config files
- add the '2' to Bebop here and there, Bebop 1 is not supported at all, this avoids some confusion