### PR TITLE
Change mac from main dev env to supported

### DIFF
--- a/en/setup/dev_env_mac.md
+++ b/en/setup/dev_env_mac.md
@@ -1,6 +1,6 @@
 # Development Environment on Mac
 
-Mac OS X is the main development platform for PX4. The following instructions set up a development environment for building:
+MacOS is a supported development platform for PX4. The following instructions set up an environment for building:
 * NuttX-based hardware (Pixhawk, etc.)
 * jMAVSim Smulation
 * Gazebo 8 Simulation


### PR DESCRIPTION
This removes the not-justified statement that Mac OS X is the main development platform with one that states that "MacOS is a supported development platform". Addresses https://github.com/PX4/Devguide/pull/551#discussion_r199757588