### PR TITLE
Tidy up Windows PX4 toolchain support

### DIFF
--- a/en/setup/dev_env.md
+++ b/en/setup/dev_env.md
@@ -2,8 +2,6 @@
 
 PX4 code can be developed on [Linux](../setup/dev_env_linux.md) or [Mac OS](../setup/dev_env_mac.md). We recommend [Ubuntu Linux LTS edition](https://wiki.ubuntu.com/LTS) as this enables building [all PX4 targets](#supported-targets), and using most [simulators](../simulation/README.md) and [ROS](../ros/README.md).
 
-> **Warning** A [Windows](../setup/dev_env_windows.md) toolchain also exists but is not officially supported (we highly discourage its use). It is possible to build PX4 on Windows using a virtual machine running Ubuntu Linux, but this may not provide a reliable platform for Simulation. Before starting to develop on Windows, consider installing a dual-boot environment with [Ubuntu](http://ubuntu.com). 
-
 ## Supported Targets
 
 The table below show what PX targets you can build on each OS.
@@ -24,6 +22,6 @@ The installation of the development environment is covered below:
 
   * [Mac OS](../setup/dev_env_mac.md)
   * [Linux](../setup/dev_env_linux.md)
-  * [Windows](../setup/dev_env_windows.md) (not recommended!)
+  * [Windows](../setup/dev_env_windows.md)
 
 If you're familiar with Docker you can also use one of the prepared containers: [Docker Containers](../test_and_ci/docker.md)

--- a/en/setup/dev_env_windows.md
+++ b/en/setup/dev_env_windows.md
@@ -1,13 +1,28 @@
 # Windows Installation Instructions
 
-There are a number of ways you can set up a Windows development toolchain for PX4. Depending on what option you choose these allow you to build for NuttX/Pixhawk and jMAVSim simulator targets.
+To develop for PX4 on Windows, follow the instructions in [Windows Cygwin Toolchain](../setup/dev_env_windows_cygwin.md).
 
-> **Warning** The Windows toolchains are not officially supported (and we discourage their use). Depending on the option you choose they might be slow and not support all targets. Some options also cannot run the standard robotics software packages many developers use to prototype computer vision and navigation.
+> **Tip** The *Cygwin toolchain* supports building for NuttX/Pixhawk and jMAVSim simulator targets. If you want to build for [other targets](/setup/dev_env.md#supported-targets), consider setting up a dual boot system with [Ubuntu Linux](http://ubuntu.com).
 
-<span></span>
-> **Tip** We recommend using [Ubuntu Linux](http://ubuntu.com) for development. Consider setting up a dual-boot setup next to your existing Windows installation.
+## Additional Tools
 
-| | [Cygwin Toolchain](../setup/dev_env_windows_cygwin.md) | [Virtual Machine Toolchain](../setup/dev_env_windows_vm.md) | [Bash on Windows Toolchain](../setup/dev_env_windows_bash_on_win.md) | [Msys Toolchain](../setup/dev_env_windows_msys.md) |
+After setting up the build/simulation toolchain, see [Additional Tools](../setup/generic_dev_tools.md) for information about other useful "general development" tools.
+
+
+## Next Steps
+
+Once you have finished setting up the environment, continue to the [build instructions](../setup/building_px4.md).
+
+
+## Other Windows Toolchains
+
+There are a number of other legacy/alternative solutions that may be of interest to some developers. 
+A comparison of the options is provided below.
+
+> **Note** The [Cygwin Toolchain](../setup/dev_env_windows_cygwin.md) is the only one that is supported by the PX4 dev team.
+It is regularly tested as part of our continuous integration system and is known to be better performing than the other alternatives. 
+
+| | [Cygwin Toolchain](../setup/dev_env_windows_cygwin.md) **(Supported)**  | [Virtual Machine Toolchain](../setup/dev_env_windows_vm.md) | [Bash on Windows Toolchain](../setup/dev_env_windows_bash_on_win.md) | [Msys Toolchain](../setup/dev_env_windows_msys.md) |
 |---|---|---|---|---|
 | Installation | MSI installer or Script | Manual (Hard) | Script | NSIS Installer |
 | Native binary execution | yes | no | no | yes |
@@ -17,13 +32,3 @@ There are a number of ways you can set up a Windows development toolchain for PX
 | Simulation gazebo | - (not yet) | + (slow) | + (slow) | -- |
 | Support | + | ++ (Linux) | +/- | -- |
 | Comments | <ul><li>New in 2018</li><li>Slim setup</li><li>Portable</li></ul> | <ul><li>Full Linux features</li><li>CPU & RAM intensive</li><li>Disk space intensive</li></ul> | <ul><li>Simulation UI is a "hack".</li><li>Windows 10 only</li><li>Essentially a VM</li></ul> | <ul><li>No support</li><li>No documentation</li><li>No simulation</li></ul> |
-
-
-## Additional Tools
-
-After setting up the build/simulation toolchain (see links above), see [Additional Tools](../setup/generic_dev_tools.md) for information about other useful tools.
-
-
-## Next Steps
-
-Once you have finished setting up the environment, continue to the [build instructions](../setup/building_px4.md).

--- a/en/setup/dev_env_windows_bash_on_win.md
+++ b/en/setup/dev_env_windows_bash_on_win.md
@@ -1,5 +1,7 @@
 # Bash on Windows Toolchain
 
+> **Note** The [Windows Cygwin Toolchain](../setup/dev_env_windows_cygwin.md) is the (only) officially supported toolchain for Windows development.
+
 Windows users can alternatively install a *slightly modified* Ubuntu Linux PX4 development environment within [Bash on Windows](https://github.com/Microsoft/BashOnWindows), and use it to:
 * Build firmware for NuttX/Pixhawk targets. 
 * Run the PX4 JMAVSim simulation (using a Windows-hosted X-Windows app to display the UI)

--- a/en/setup/dev_env_windows_cygwin.md
+++ b/en/setup/dev_env_windows_cygwin.md
@@ -1,10 +1,16 @@
 # Windows Cygwin Toolchain
 
-This is the newest (and best!) toolchain for developing PX4 on Windows.
+This toolchain is portable, easy to install, and easy to use. 
+It is the newest and best performing toolchain for developing PX4 on Windows.
 
-The toolchain is portable, easy to install, and easy to use. 
-It supports build/upload of PX4 to NuttX targets (Pixhawk series controllers) and can run the JMAVSim/SITL simulator with significantly better performance than the other Windows toolchains. 
+> **Tip** This is the only officially supported toolchain for building PX4 on Windows (i.e. it is tested in our continuous integration system).
 
+The toolchain supports:
+* Build/upload of PX4 to NuttX targets (Pixhawk series controllers)
+* JMAVSim/SITL simulator with significantly better performance than the other Windows toolchains.
+* Style check, portable installer, command line completion and many [other features](#features).
+
+This topic explains how download and use the environment, and how it can be extended and updated if needed (for example, to use a different compiler).
 
 <!--
 ## Ready to use MSI Installer Download {#installation}
@@ -19,21 +25,7 @@ Legacy Versions (**deprecated**):
 * [PX4 Windows Cygwin Toolchain 0.1 Download](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.1.msi) (23.02.2018)
 -->
 
-## Features / Issues
 
-The following features are known to work (version 2.0):
-
-* Building and running SITL with jMAVSim with significantly better performance than a VM (it generates a native windows binary **px4.exe**).
-* Building and uploading NuttX builds (e.g.: px4fmu-v2 and px4fmu-v4)
-* Style check with *astyle* (supports the command: `make format`)
-* Command line auto completion
-* Non-invasive installer! The installer does NOT affect your system and global path (it only modifies the selected installation directory e.g. **C:\PX4\** and uses a temporary local path).
-* The installer supports updating to a new version keeping your personal changes inside the toolchain folder
-
-Omissions:
-* Simulation: Gazebo and ROS are not supported
-* Only NuttX and JMAVSim/SITL builds are supported.
-* [Known problems / Report your issue](https://github.com/orgs/PX4/projects/6)
 
 ## Installation Instructions
 
@@ -125,7 +117,28 @@ new mode 100755
 
 We recommend disabling this functionality by executing `git config core.fileMode false` in every repo where you use with this toolchain.
 
-## Shell Script Installation {#script_setup} 
+
+## Additional Information
+
+### Features / Issues {#features}
+
+The following features are known to work (version 2.0):
+
+* Building and running SITL with jMAVSim with significantly better performance than a VM (it generates a native windows binary **px4.exe**).
+* Building and uploading NuttX builds (e.g.: px4fmu-v2 and px4fmu-v4)
+* Style check with *astyle* (supports the command: `make format`)
+* Command line auto completion
+* Non-invasive installer! The installer does NOT affect your system and global path (it only modifies the selected installation directory e.g. **C:\PX4\** and uses a temporary local path).
+* The installer supports updating to a new version keeping your personal changes inside the toolchain folder
+
+Omissions:
+* Simulation: Gazebo and ROS are not supported
+* Only NuttX and JMAVSim/SITL builds are supported.
+* [Known problems / Report your issue](https://github.com/orgs/PX4/projects/6)
+
+### Shell Script Installation {#script_setup}
+
+You can also install the environment using shell scripts in the Github project.
 
 1. Make sure you have [Git for Windows](https://git-scm.com/download/win) installed.
 1. Clone the repository https://github.com/MaEtUgR/PX4Toolchain to the location you want to install the toolchain. Default location and naming is achieved by opening the `Git Bash` and executing:
@@ -137,7 +150,7 @@ git clone https://github.com/MaEtUgR/PX4Toolchain PX4
 1. Continue with [Getting Started](#getting_started) (or [Usage Instructions](#usage_instructions)) 
 
 
-## Manual Installation (for Toolchain Developers) {#manual_setup}
+### Manual Installation (for Toolchain Developers) {#manual_setup}
 
 This section describes how to setup the Cygwin toolchain manually yourself while pointing to the corresponding scripts from the script based installation repo. The result should be the same as using the scripts or MSI installer.
 

--- a/en/setup/dev_env_windows_msys.md
+++ b/en/setup/dev_env_windows_msys.md
@@ -1,6 +1,6 @@
 # Windows Msys Toolchain
 
-> **Note** This solution is currently broken.
+> **Note** This solution is currently broken. The [Windows Cygwin Toolchain](../setup/dev_env_windows_cygwin.md) is the officially supported toolchain for Windows development.
 
 ## Instructions
 

--- a/en/setup/dev_env_windows_vm.md
+++ b/en/setup/dev_env_windows_vm.md
@@ -1,5 +1,7 @@
 # Windows Virtual Machine-Hosted Toolchain
 
+> **Note** The [Windows Cygwin Toolchain](../setup/dev_env_windows_cygwin.md) is the (only) officially supported toolchain for Windows development.
+
 Windows developers can run the PX4 toolchain in a virtual machine (VM) with Linux as the guest operating system. After setting up the virtual machine, the installation and setup of PX4 within the VM is exactly the same as on a native Linux computer.
 
 > **Tip** Allocate as many CPU cores and memory resources to the VM as possible.


### PR DESCRIPTION
- Remove warnings about Windows development not being supported.
- Highlight Cygwin solution is best at top level and in the other solutions
- Restructure Cygwin to make the main installation path direct - ie push features and the other installation options under sub heading. Otherwise this doc looks scary.