### PR TITLE
Correct Docker container hierarchy

### DIFF
--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -38,8 +38,8 @@ Container | Description
 ---|---
 px4-dev-base | Base setup common to all containers
 &emsp;px4-dev-nuttx | NuttX toolchain
-&emsp;&emsp;px4-dev-simulation | NuttX toolchain + simulation (jMAVSim, Gazebo)
-&emsp;&emsp;&emsp;px4-dev-ros | NuttX toolchain, simulation + ROS (incl. MAVROS)
+&emsp;px4-dev-simulation | NuttX toolchain + simulation (jMAVSim, Gazebo)
+&emsp;&emsp;px4-dev-ros | NuttX toolchain, simulation + ROS (incl. MAVROS)
 &emsp;px4-dev-raspi | Raspberry Pi toolchain
 &emsp;px4-dev-snapdragon | Qualcomm Snapdragon Flight toolchain
 &emsp;px4-dev-clang | Clang tools


### PR DESCRIPTION
The `px4-dev-simulation` Docker container is *not* based on `px4-dev-nuttx`: https://hub.docker.com/r/px4io/px4-dev-nuttx/