### PR TITLE
Cygwin: update link to 0.4 toolchain

### DIFF
--- a/en/setup/dev_env_windows_cygwin.md
+++ b/en/setup/dev_env_windows_cygwin.md
@@ -12,24 +12,16 @@ The toolchain supports:
 
 This topic explains how download and use the environment, and how it can be extended and updated if needed (for example, to use a different compiler).
 
-<!--
-## Ready to use MSI Installer Download {#installation}
-
-Latest Download: [PX4 Windows Cygwin Toolchain 0.3 Download](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.3.msi) (25.07.2018)
-
-
-Legacy Versions (**deprecated**):
-
+<!-- Legacy Versions (**deprecated**):
+* [PX4 Windows Cygwin Toolchain 0.4 Download](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.4.msi) (18.09.2018)
 * [PX4 Windows Cygwin Toolchain 0.3 Download](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.3.msi) (25.07.2018)
 * [PX4 Windows Cygwin Toolchain 0.2 Download](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.2.msi) (09.05.2018)
 * [PX4 Windows Cygwin Toolchain 0.1 Download](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.1.msi) (23.02.2018)
 -->
 
+## Installation Instructions {#installation}
 
-
-## Installation Instructions
-
-1. Download the latest version of the ready to use MSI installer: [PX4 Windows Cygwin Toolchain 0.3 Download](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.3.msi) (25.07.2018)
+1. Download the latest version of the ready to use MSI installer: [PX4 Windows Cygwin Toolchain 0.4 Download](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.4.msi) (18.09.2018)
 1. Run it, choose your desired installation location, let it install
     ![jMAVSimOnWindows](../../assets/toolchain/cygwin_toolchain_installer.PNG)
 1. Tick the box at the end of the installation to *clone the PX4 repository, build and run simulation with jMAVSim* (this simplifies the process to get you started). 


### PR DESCRIPTION
FYI @hamishwillee 
This version has pkill for the shutdown command in SITL and the python module pyyaml for RTPS message generation (needed on master).

I CI this version is already used for some days: https://github.com/PX4/Firmware/pull/10516