### PR TITLE
Add introduction to MAVLink middleware doc

### DIFF
--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -1,14 +1,24 @@
 # MAVLink Messaging
 
-An overview of all messages can be found [here](https://mavlink.io/en/messages/).
+[MAVLink](https://mavlink.io/en/) is a very lightweight messaging protocol that has been designed for the drone ecosystem.
 
-## Create Custom MAVLink Messages
+PX4 uses *MAVLink* to communicate with *QGroundControl* (and other ground stations), as the integration mechanism for connecting to drone components outside of the flight controller: companion computers, MAVLink enabled cameras etc. 
 
-This tutorial assumes you have a [custom uORB](../middleware/uorb.md) `ca_trajectory`
+The protocol defines a number of standard [messages](https://mavlink.io/en/messages/) and [microservices](https://mavlink.io/en/services/) for exchanging data (many, but not all, messages/services have been implemented in PX4).
+
+This tutorial explains how you can add PX4 support for your own new "custom" messages.
+
+
+## Defining Custom MAVLink Messages
+
+The MAVLink developer guide explains how to define new messages and build them into new programming-specific libraries:
+- [How to Define MAVLink Messages & Enums](https://mavlink.io/en/guide/define_xml_element.html)
+- [Generating MAVLink Libraries](https://mavlink.io/en/getting_started/generate_libraries.html)
+
+The tutorial assumes you have a [custom uORB](../middleware/uorb.md) `ca_trajectory`
 message in `msg/ca_trajectory.msg` and a custom MAVLink `ca_trajectory` message in
-`mavlink/include/mavlink/v1.0/custom_messages/mavlink_msg_ca_trajectory.h` (see
-[here](http://qgroundcontrol.org/mavlink/create_new_mavlink_message) how to
-create a custom MAVLink message and header).
+`mavlink/include/mavlink/v1.0/custom_messages/mavlink_msg_ca_trajectory.h`.
+
 
 ## Sending Custom MAVLink Messages
 
@@ -179,17 +189,20 @@ An alternative - and temporary - solution is to re-purpose debug messages.
 Instead of creating a custom MAVLink message `CA_TRAJECTORY`, you can send a message `DEBUG_VECT` with the string key `CA_TRAJ` and data in the `x`, `y` and `z` fields.
 See [this tutorial](../debug/debug_values.md). for an example usage of debug messages.
 
-> **Note** This solution is not efficient as it sends character string over the network and involves comparison of strings. It should be used for development only!
+> **Note** This solution is not efficient as it sends character string over the network and involves comparison of strings. 
+  It should be used for development only!
 
 ## General
 
 ### Set streaming rate
 
-Sometimes it is useful to increase the streaming rate of individual topics (e.g. for inspection in QGC). This can be achieved by typing the following line in the shell:
+Sometimes it is useful to increase the streaming rate of individual topics (e.g. for inspection in QGC). 
+This can be achieved by typing the following line in the shell:
 ```sh
 mavlink stream -u <port number> -s <mavlink topic name> -r <rate>
 ```
-You can get the port number with `mavlink status` which will output (amongst others) `transport protocol: UDP (<port number>)`. An example would be
+You can get the port number with `mavlink status` which will output (amongst others) `transport protocol: UDP (<port number>)`. 
+An example would be:
 ```sh
 mavlink stream -u 14556 -s OPTICAL_FLOW_RAD -r 300
 ```


### PR DESCRIPTION
Fixes https://github.com/PX4/Devguide/issues/648

@mrpollo This just fixes the introduction. You OK with it?

@bkueng I've looped you in here to discuss some other issues with this topic.
1. It is based on MAVLink 1.0. Can you make the required updates to 2.0? I THINK that is just a matter of changing the links. 
2. This starts at the point you already have a library with the new message available. However it should start a bit earlier. Specifically, what is the process for me to add my own new generated library into a build? Is it just a matter of building the library and dumping it into Firmware/mavlink/include/mavlink/ ?
   - My reasoning is that if the message is custom, you aren't getting this into the standard library. It isn't necessarily obvious the "right" way to get the message into PX4 for testing.