### PR TITLE
PX4 build - correct checkout older release command

### DIFF
--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -48,7 +48,7 @@ This will copy *most* of the *very latest* version of PX4 source code onto your 
 >  git tag -l
 >  
 >  # Checkout code for particular tag (e.g. for tag 1.7.4beta)
->  git checkout -b tags/v1.7.4beta
+>  git checkout v1.7.4beta
 >  ```
 
 


### PR DESCRIPTION
`git checkout -b tags/v1.7.4beta` creates a branch named tags/v1.7.4beta where you are; it's was not the expected behavior. 
Since we just want to checkout a tag, `git checkout v1.7.4beta` is enough and does the correct thing.