### PR TITLE
Add alternative wifi dongle for video streaming - TL-WN821N

### DIFF
--- a/en/qgc/video_streaming.md
+++ b/en/qgc/video_streaming.md
@@ -6,6 +6,7 @@ The whole hardware setup is shown in the figure below. It consists of the follow
 * Odroid C1
 * Logitech camera C920
 * WiFi module TP-LINK TL-WN722N
+  > **Note** The [TP-LINK WN821N](https://www.conrad-electronic.co.uk/ce/en/product/995310/TP-LINK-TL-WN821N-WiFi-dongle-USB-20-300-Mbps) can also be used (without modification to the instructions). This is smaller and has a better range.
 
 ![Setup](../../assets/videostreaming/setup_whole.jpg)
 


### PR DESCRIPTION
Anecdotally this is better - proposed by @AlexisTM in slack. 

I have just added it as a note because the rest of the tutorial is very specific. @AlexisTM, can you confirm that nothing else had to be changed in the configuration? Looking at this the instructions should actually work for any dongle right?