### PR TITLE
Update description of daemon communication in 'System Startup'.

### DIFF
--- a/en/concept/system_startup.md
+++ b/en/concept/system_startup.md
@@ -20,9 +20,9 @@ For that to work, a few things are required:
   > **Tip** The `px4-` prefix is used to avoid conflicts with system commands (e.g. `shutdown`), and it also allows for simple tab completion by typing `px4-<TAB>`.
 - The shell needs to know where to find the symbolic links. For that the `bin` directory with the symbolic links is added to the `PATH` variable right before executing the startup scripts.
 - The shell starts each module as a new (client) process. Each client process needs to communicate with the main instance of px4 (the server), where the actual modules are running as threads.
-  This is done with [FIFOs (also called named pipes)](http://man7.org/linux/man-pages/man7/fifo.7.html).
-  The server has a FIFO opened, on which clients can send commands.
-  In addition each client opens its own FIFO, which the server then uses to send information to the client (strings printed to the console for example).
+  This is done through a [UNIX socket](http://man7.org/linux/man-pages/man7/unix.7.html).
+  The server listens on a socket, to which clients can connect and send a command.
+  The server then sends the output and return code back to the client.
 - The startup scripts call the module directly, e.g. `commander start`, rather than using the `px4-` prefix. This works via aliases: for each module an alias in the form of `alias <module>=px4-<module>` is created in the file `bin/px4-alias.sh`.
 - The `rcS` script is executed from the main px4 instance.
   It does not start any modules, but first updates the `PATH` variable and then simply runs a shell with the `rcS` file as argument.


### PR DESCRIPTION
We no longer use FIFOs, but instead use a single Unix socket.

(As mentioned in #656.)