### PR TITLE
build_scripts: pyyaml missing

### DIFF
--- a/build_scripts/ubuntu_sim_common_deps.sh
+++ b/build_scripts/ubuntu_sim_common_deps.sh
@@ -24,7 +24,7 @@ sudo apt-get install git zip qtcreator cmake build-essential genromfs ninja-buil
 # Required python packages
 sudo apt-get install python-argparse python-empy python-toml python-numpy python-dev python-pip -y
 sudo -H pip install --upgrade pip
-sudo -H pip install pandas jinja2 pyserial
+sudo -H pip install pandas jinja2 pyserial pyyaml
 # optional python tools
 sudo -H pip install pyulog
 


### PR DESCRIPTION
pyyaml is necessary to build PX4 since two months now, it should be included in the toolchain setup script.
Pull request that introduced the dependency: https://github.com/PX4/Firmware/pull/10388