### PR TITLE
Add version switcher

### DIFF
--- a/book.json
+++ b/book.json
@@ -16,6 +16,7 @@
         "bulk-redirect@git+https://github.com/Dronecode/gitbook-plugin-bulk-redirect.git",
         "toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git",
         "validate-links",
+        "versions",
         "mathjax@git+https://github.com/Dronecode/plugin-mathjax.git#update_cdn",
         "mermaid",
         "-stub-out-blocks@git+https://github.com/hamishwillee/gitbook-plugin-stub-out-blocks.git",
@@ -64,6 +65,17 @@
                     "icon": "fa fa-pencil-square-o",
                     "position" : "left",
                     "url": "https://github.com/PX4/Devguide/edit/master/{{filepath_lang}}"
+                }
+            ]
+        },
+        
+        "versions": {
+            "gitbookConfigURL": "https://raw.githubusercontent.com/PX4/Devguide/master/book.json",
+            "options": [
+                {
+                    "value": "https://dev.px4.io/en/",
+                    "text": "Master",
+                    "selected": true
                 }
             ]
         }


### PR DESCRIPTION
This adds a version switcher to the book, with just one option "Master". This has been setup so that when we make new versions we can add additional snapshots "after the fact" (they are controlled by the book.json in the master branch).

The plugin used is https://plugins.gitbook.com/plugin/versions