### PR TITLE
make gst-launch pipeline copy-pastable

### DIFF
--- a/en/simulation/gazebo.md
+++ b/en/simulation/gazebo.md
@@ -262,7 +262,7 @@ The video from Gazebo should then display in *QGroundControl* just as it would f
   
 It is also possible to view the video using the *Gstreamer Pipeline*. Simply enter the following terminal command:
 ```
-gst-launch-1.0  -v udpsrc port=5600 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264'
+gst-launch-1.0  -v udpsrc port=5600 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264' \
 ! rtph264depay ! avdec_h264 ! videoconvert ! autovideosink fps-update-interval=1000 sync=false
 ```
   


### PR DESCRIPTION
The code block in the documentation had a non-escaped new line in it. This causes the two lines to be interpreted as two separate commands, which would break the pipeline.