### PR TITLE
Fix a Markdown syntex error in pwm_limit.md

### DIFF
--- a/en/concept/pwm_limit.md
+++ b/en/concept/pwm_limit.md
@@ -8,7 +8,7 @@
   * pre-armed: asserted to enable benign behaviors such as moving control surfaces
    * this input overrides the current state
    * assertion of pre-armed immediately forces behavior of state ON, regardless of current state
-   ** deassertion of pre-armed reverts behavior to current state
+   * deassertion of pre-armed reverts behavior to current state
 
 **States**
   * INIT and OFF


### PR DESCRIPTION
It's look like this now, I think maybe it's not the desire format.
![image](https://user-images.githubusercontent.com/4748411/50442738-26315b00-093b-11e9-85ed-835dea9ace61.png)
