### PR TITLE
Adding a section about runnig simulation on a remote server

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -140,3 +140,32 @@ The simulated camera is a gazebo plugin that implements the [MAVLink Camera Prot
 
 The same approach can be used by other simulators to implement camera support.
 
+## Running simulation on the remote server 
+
+As had been mentioned at the beginning the simulation environment can be run on multiple computers on the same network. Unfortunately, it is a slightly complicated situation, because of the out of box configuration of Ubuntu computer does not broadcast the PX4 UDP packets to external interfaces and packets are routed internally by default. 
+A solution is to modify system routes to broadcast UDP packets to the network or use a tunnel to connect computers together. 
+
+Using the tunnel is a more flexible option because the computers are not required to sit on the same network and remote powerful simulation server can be used for example. 
+
+One, probably the easiest way to create the tunnel is the use of SSH tunneling options.  The tunnel itself could be created easily by running the following command on localhost.
+
+    ssh -C -fR 14551:localhost:14551 remote.local
+
+Where "remote.local" is the name of a remote computer. 
+
+Unfortunately, the SSH itself cannot route the UDP packets.  Therefore the UDP packets need to be translated to TCP packets. By netcat utility separately on the local and remote side of the tunnel. 
+Local side of UDP packet translation of QGC could be implemented by running following commands.
+
+     mkfifo /tmp/tcp2udp
+     netcat -lvp 14551 < /tmp/tcp2udp | netcat -u localhost 14550 > /tmp/tcp2udp
+
+For the remote side of the tunnel, the command differs. 
+
+    mkfifo /tmp/udp2tcp
+    netcat -lvup 14550 < /tmp/udp2tcp | netcat localhost 14551 > /tmp/udp2tcp
+
+It is necessary to have QGC running before executing the netcat. 
+The tunnel could run infinitely, but netcat connections may need a restart in case of improper communication state occurs. The port number 14550 is valid for QGC software connection and should be adjusted for other possible communication channels.  
+
+The automated [bash connection script](https://raw.githubusercontent.com/ThunderFly-aerospace/sitl_gazebo/autogyro-sitl/scripts/QGC_remote_connect.bash) is prepared for automation of QGC to simulation server running the PX4 stack. 
+

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -140,7 +140,7 @@ The simulated camera is a gazebo plugin that implements the [MAVLink Camera Prot
 
 The same approach can be used by other simulators to implement camera support.
 
-## Running simulation on the remote server 
+## Running Simulation On The Remote Server 
 
 As had been mentioned at the beginning the simulation environment can be run on multiple computers on the same network. Unfortunately, it is a slightly complicated situation, because of the out of box configuration of Ubuntu computer does not broadcast the PX4 UDP packets to external interfaces and packets are routed internally by default. 
 A solution is to modify system routes to broadcast UDP packets to the network or use a tunnel to connect computers together. 
@@ -148,24 +148,24 @@ A solution is to modify system routes to broadcast UDP packets to the network or
 Using the tunnel is a more flexible option because the computers are not required to sit on the same network and remote powerful simulation server can be used for example. 
 
 One, probably the easiest way to create the tunnel is the use of SSH tunneling options.  The tunnel itself could be created easily by running the following command on localhost.
-
-    ssh -C -fR 14551:localhost:14551 remote.local
-
+```
+ssh -C -fR 14551:localhost:14551 remote.local
+```
 Where "remote.local" is the name of a remote computer. 
 
-Unfortunately, the SSH itself cannot route the UDP packets.  Therefore the UDP packets need to be translated to TCP packets. By netcat utility separately on the local and remote side of the tunnel. 
+Unfortunately, the SSH itself cannot route the UDP packets.  Therefore the UDP packets need to be translated to TCP packets. By [netcat](https://en.wikipedia.org/wiki/Netcat) utility separately on the local and remote side of the tunnel. 
 Local side of UDP packet translation of QGC could be implemented by running following commands.
-
-     mkfifo /tmp/tcp2udp
-     netcat -lvp 14551 < /tmp/tcp2udp | netcat -u localhost 14550 > /tmp/tcp2udp
-
+```
+mkfifo /tmp/tcp2udp
+netcat -lvp 14551 < /tmp/tcp2udp | netcat -u localhost 14550 > /tmp/tcp2udp
+```
 For the remote side of the tunnel, the command differs. 
-
-    mkfifo /tmp/udp2tcp
-    netcat -lvup 14550 < /tmp/udp2tcp | netcat localhost 14551 > /tmp/udp2tcp
-
+```
+mkfifo /tmp/udp2tcp
+netcat -lvup 14550 < /tmp/udp2tcp | netcat localhost 14551 > /tmp/udp2tcp
+```
 It is necessary to have QGC running before executing the netcat. 
-The tunnel could run infinitely, but netcat connections may need a restart in case of improper communication state occurs. The port number 14550 is valid for QGC software connection and should be adjusted for other possible communication channels.  
+The tunnel could run infinitely, but netcat connections may need a restart in case of improper communication state occurs. The port number `14550` is valid for QGC software connection and should be adjusted for other possible communication channels.  
 
 The automated [bash connection script](https://raw.githubusercontent.com/ThunderFly-aerospace/sitl_gazebo/autogyro-sitl/scripts/QGC_remote_connect.bash) is prepared for automation of QGC to simulation server running the PX4 stack. 
 

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -142,8 +142,8 @@ The same approach can be used by other simulators to implement camera support.
 
 ## Running Simulation on the Remote Server 
 
-As had been mentioned at the beginning the simulation environment can be run on multiple computers on the same network. Unfortunately, it is a slightly complicated situation, because of the out of box configuration of Ubuntu computer does not broadcast the PX4 UDP packets to external interfaces and packets are routed internally by default. 
-A solution is to modify system routes to broadcast UDP packets to the network or use a tunnel to connect computers together. 
+As had been mentioned at the beginning the simulation environment can be run on multiple computers on the same network. Unfortunately, it is a slightly complicated, because of the out of box configuration does not broadcast the PX4 UDP packets to external interfaces and packets are routed internally by default. 
+A solution is to enable brodcasting by [MAV_BROADCAST](../advanced/parameter_reference.md#MAV_BROADCAST) parameter to allow broadcast UDP packets to the local network or use a tunnel to connect computers together. 
 
 Using the tunnel is a more flexible option because the computers are not required to sit on the same network and remote powerful simulation server can be used for example. 
 

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -140,7 +140,7 @@ The simulated camera is a gazebo plugin that implements the [MAVLink Camera Prot
 
 The same approach can be used by other simulators to implement camera support.
 
-## Running Simulation On The Remote Server 
+## Running Simulation on the Remote Server 
 
 As had been mentioned at the beginning the simulation environment can be run on multiple computers on the same network. Unfortunately, it is a slightly complicated situation, because of the out of box configuration of Ubuntu computer does not broadcast the PX4 UDP packets to external interfaces and packets are routed internally by default. 
 A solution is to modify system routes to broadcast UDP packets to the network or use a tunnel to connect computers together. 


### PR DESCRIPTION
The new section discussing the options of connection in case of simulation is run on multiple computers. The SSH tunneling example and a link to connection bash script were introduced.