### PR TITLE
Gitbook versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,16 +44,19 @@ pipeline {
         unstash('gitbook')
         withCredentials([usernamePassword(credentialsId: 'px4buildbot_github_personal_token', passwordVariable: 'GIT_PASS', usernameVariable: 'GIT_USER')]) {
           sh('git clone https://${GIT_USER}:${GIT_PASS}@github.com/PX4/dev.px4.io.git')
-          sh('rm -rf dev.px4.io/*')
-          sh('cp -r _book/* dev.px4.io/')
-          sh('cd dev.px4.io; git add .; git commit -a -m "gitbook build update `date`"')
+          sh('rm -rf dev.px4.io/${BRANCH_NAME}')
+          sh('mkdir -p dev.px4.io/${BRANCH_NAME}')
+          sh('cp -r _book/* dev.px4.io/${BRANCH_NAME}/')
+          sh('cd dev.px4.io; git add ${BRANCH_NAME}; git commit -a -m "gitbook build update `date`"')
           sh('cd dev.px4.io; git push origin master')
         }
       }
 
       when {
         anyOf {
-          branch 'master'
+          branch "master";
+          branch "v1.*"
+          branch "*jenkins*"
         }
       }
 


### PR DESCRIPTION
@hamishwillee any opinion on granularity? Either match releases 1-1 or get away with v1.8 docs until a point release version is necessary.

I think we might as well go with branches instead of tags (helps with CI as well).
