### PR TITLE
build script: add astyle, remove vim-common

### DIFF
--- a/build_scripts/ubuntu_sim_common_deps.sh
+++ b/build_scripts/ubuntu_sim_common_deps.sh
@@ -20,7 +20,7 @@ sudo apt-get remove modemmanager -y
 # Common dependencies
 echo "Installing common dependencies"
 sudo apt-get update -y
-sudo apt-get install git zip qtcreator cmake build-essential genromfs ninja-build exiftool vim-common -y
+sudo apt-get install git zip qtcreator cmake build-essential genromfs ninja-build exiftool astyle -y
 # Required python packages
 sudo apt-get install python-argparse python-empy python-toml python-numpy python-dev python-pip -y
 sudo -H pip install --upgrade pip

--- a/build_scripts/ubuntu_sim_common_deps.sh
+++ b/build_scripts/ubuntu_sim_common_deps.sh
@@ -21,6 +21,8 @@ sudo apt-get remove modemmanager -y
 echo "Installing common dependencies"
 sudo apt-get update -y
 sudo apt-get install git zip qtcreator cmake build-essential genromfs ninja-build exiftool astyle -y
+# make sure xxd is installed, dedicated xxd package since Ubuntu 18.04 but was squashed into vim-common before
+which xxd || sudo apt install xxd -y || sudo apt-get install vim-common --no-install-recommends -y
 # Required python packages
 sudo apt-get install python-argparse python-empy python-toml python-numpy python-dev python-pip -y
 sudo -H pip install --upgrade pip


### PR DESCRIPTION
I think adding `astyle` to the deafult installation makes sense because then the `make format` command can be used. I tested any it works fine on Ubuntu 18.04.

On the other hand I don't see how `vim-common` is a necessary package. People using the editor will have/install it anyways and beginners will probably not decide because it's installed here.

@julianoes Any objection regarding vim?

FYI @Stifael 