### PR TITLE
simulation: add note how to avoid datalink timeout

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -125,6 +125,8 @@ make px4_sitl jmavsim
 > **Note** At some point IO or CPU will limit the speed that is possible on your machine and it will be slowed down "automatically".
 > Powerful desktop machines can usually run the simulation at around 6-10x, for notebooks the achieved rates can be around 3-4x.
 
+> **Note** To avoid px4 detecting data link timeouts, set the param `COM_DL_LOSS_T` to something bigger. E.g. for 10x you would set COM_DL_LOSS_T to 100 instead of 10.
+
 
 ### Startup Scripts {#scripts}
 

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -125,7 +125,8 @@ make px4_sitl jmavsim
 > **Note** At some point IO or CPU will limit the speed that is possible on your machine and it will be slowed down "automatically".
 > Powerful desktop machines can usually run the simulation at around 6-10x, for notebooks the achieved rates can be around 3-4x.
 
-> **Note** To avoid px4 detecting data link timeouts, set the param `COM_DL_LOSS_T` to something bigger. E.g. for 10x you would set COM_DL_LOSS_T to 100 instead of 10.
+<span></span>
+> **Note** To avoid PX4 detecting data link timeouts, increase the value of param [COM_DL_LOSS_T](../advanced/parameter_reference.md#COM_DL_LOSS_T) proportional to the simulation rate. For example, if `COM_DL_LOSS_T` is 10 in realtime, at 10x simulation rate increase to 100.
 
 
 ### Startup Scripts {#scripts}


### PR DESCRIPTION
When you speed up the simulation you can receive data link timeouts because px4 is "measuring time too fast". Therefore, you need to raise the timeout by setting a param.