### PR TITLE
Jenkins update px4io/px4-docs to 2019-02-03

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'px4io/px4-docs:2018-06-14'
+      image 'px4io/px4-docs:2019-02-03'
     }
   }
   stages {


### PR DESCRIPTION
This won't pass until the build is done on docker hub. https://cloud.docker.com/u/px4io/repository/docker/px4io/px4-docs/timeline 