### PR TITLE
SITL failsafes: fix RC and DL loss

### DIFF
--- a/en/simulation/failsafes.md
+++ b/en/simulation/failsafes.md
@@ -2,39 +2,37 @@
 
 [Failsafes](https://docs.px4.io/en/config/safety.html) define the safe limits/conditions under which you can safely use PX4, and the action that will be performed if a failsafe is triggered (for example, landing, holding position, or returning to a specified point).
 
-In SITL most failsafes are disabled by default to enable easier simulation usage.
+In SITL some failsafes are disabled by default to enable easier simulation usage.
 This topic explains how you can test safety-critical behavior in SITL simulation before attempting it in the real world.
 
-> **Note** You can also test failsafes using [HITL simulation](../simulation/hitl.md). 
+> **Note** You can also test failsafes using [HITL simulation](../simulation/hitl.md).
   HITL uses the normal configuration parameters of your flight controller.
 
 
 ## Data Link Loss
 
-The *Data Link Loss* failsafe (unavailability of external data via MAVLink) is ignored by default.
-This makes the simulation usable without a connected GCS, SDK, or other MAVLink application.
+The *Data Link Loss* failsafe (unavailability of external data via MAVLink) is enabled by default.
+This makes the simulation only usable with a connected GCS, SDK, or other MAVLink application.
 
-Set the parameter [NAV_DLL_ACT](../advanced/parameter_reference.md#NAV_DLL_ACT) to the desired failsafe action to enable the failsafe. 
-For example, set to `2` to make the vehicle return to launch.
+Set the parameter [NAV_DLL_ACT](../advanced/parameter_reference.md#NAV_DLL_ACT) to the desired failsafe action to change the behavior.
+For example, set to `0` to disable it.
 
-> **Note** The parameter gets reset if SITL is restarted. 
-  To prevent that from happening remove the line `param set NAV_DLL_ACT 0` from the [SITL startup script](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS).
+> **Note** All parameters in SITL including this one get reset when you do `make clean`.
 
 ## RC Link Loss
 
-The *RC Link Loss* failsafe (unavailability of data from a remote control) is ignored by default.
-This makes the simulation usable without additional hardware.
+The *RC Link Loss* failsafe (unavailability of data from a remote control) is enabled by default.
+This makes the simulation only usable with either an active MAVLink or remote control connection.
 
-Set the parameter [NAV_RCL_ACT](../advanced/parameter_reference.md#NAV_RCL_ACT) to the desired failsafe action to enable the failsafe. 
-For example, set to `2` to make the vehicle return to launch.
+Set the parameter [NAV_RCL_ACT](../advanced/parameter_reference.md#NAV_RCL_ACT) to the desired failsafe action to change the behavior.
+For example, set to `0` to disable it.
 
-> **Note** The parameter gets reset if SITL is restarted. 
-  To prevent that from happening remove the line `param set NAV_RCL_ACT 0` from the [SITL startup script](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS).
+> **Note** All parameters in SITL including this one get reset when you do `make clean`.
 
 
 ## Low Battery
 
-The simulated battery is implemented to never run out of energy, and by default only depletes to 50% of its capacity. 
+The simulated battery is implemented to never run out of energy, and by default only depletes to 50% of its capacity and hence reported voltage.
 This enables testing of battery indication in GCS UIs without triggering low battery reactions that might interrupt other testing.
 
 To change this minimal battery percentage value change [this line](https://github.com/PX4/Firmware/blob/9d67bbc328553bbd0891ffb8e73b8112bca33fcc/src/modules/simulator/simulator_mavlink.cpp#L330).
@@ -45,5 +43,5 @@ To control how fast the battery depletes to the minimal value use the parameter 
 
 ## GPS Loss
 
-To make simulate losing and regaining GPS information you can just stop/restart the GPS driver. 
+To make simulate losing and regaining GPS information you can just stop/restart the GPS driver.
 This is done by running the `gpssim stop` and `gpssim start` commands on your SITL instance *pxh shell*.


### PR DESCRIPTION
Sorry @hamishwillee I must correct my mistakes from https://github.com/PX4/Devguide/pull/729:

- I wrote as if https://github.com/PX4/Firmware/pull/11357 was accepted, which it is not (yet)
- The parameters do not get reset on every SITL restart, I don't know why I thought that