### PR TITLE
hello_sky: fix link to px4_add_module docs

### DIFF
--- a/en/apps/hello_sky.md
+++ b/en/apps/hello_sky.md
@@ -133,7 +133,7 @@ In this section we create a *minimal application* that just prints out `Hello Sk
    The `px4_add_module()` method builds a static library from a module description. 
    The `MAIN` block lists the name of the module - this registers the command with NuttX so that it can be called from the PX4 shell or SITL console.
    
-   > **Tip** The `px4_add_module()` format is documented in [Firmware/cmake/common/px4_base.cmake](https://github.com/PX4/Firmware/blob/master/cmake/common/px4_base.cmake).
+   > **Tip** The `px4_add_module()` format is documented in [Firmware/cmake/px4_add_module.cmake](https://github.com/PX4/Firmware/blob/master/cmake/px4_add_module.cmake).
    
 
 ## Build the Application/Firmware

--- a/en/apps/hello_sky.md
+++ b/en/apps/hello_sky.md
@@ -127,7 +127,6 @@ In this section we create a *minimal application* that just prints out `Hello Sk
    	SRCS
    		px4_simple_app.c
    	DEPENDS
-   		platforms__common
    	)
    ```
    The `px4_add_module()` method builds a static library from a module description. 


### PR DESCRIPTION
This fixes (I "think") broken link to px4_add_module() docs in hello_sky tutorial.

@bkueng

1. Can you also confirm that the code below basically identifies dependency library for this app (platforms__common) and that this library is the common platform components - as opposed to those for nuttx only or posix?
   ```
    DEPENDS
        platforms__common
  ```
2. That if removed the code will not work. What is the code that this provides access to? The bit that registers the app in the line `MAIN px4_simple_app`?