### PR TITLE
*/debug/debug_values.md: fix broken links for mavlink_debug example

### DIFF
--- a/en/debug/debug_values.md
+++ b/en/debug/debug_values.md
@@ -21,8 +21,8 @@ This tutorial shows how to send the MAVLink message `NAMED_VALUE_FLOAT` using th
 
 The code for this tutorial is available here:
 
-* [Debug Tutorial Code](https://github.com/PX4/Firmware/blob/master/src/examples/px4_mavlink_debug/px4_mavlink_debug.c)
-* [Enable the tutorial app](https://github.com/PX4/Firmware/tree/master/cmake/configs) by uncommenting / enabling the mavlink debug app in the config of your board
+* [Debug Tutorial Code](https://github.com/PX4/Firmware/blob/master/src/examples/px4_mavlink_debug/px4_mavlink_debug.cpp)
+* [Enable the tutorial app](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/default.cmake) by uncommenting / enabling the mavlink debug app in the config of your board if it's commented
 
 All required to set up a debug publication is this code snippet. First add the header file:
 

--- a/kr/debug/debug_values.md
+++ b/kr/debug/debug_values.md
@@ -21,8 +21,8 @@ This tutorial shows how to send the MAVLink message `NAMED_VALUE_FLOAT` using th
 
 The code for this tutorial is available here:
 
-  * [Debug Tutorial Code](https://github.com/PX4/Firmware/blob/master/src/examples/px4_mavlink_debug/px4_mavlink_debug.c)
-  * [Enable the tutorial app](https://github.com/PX4/Firmware/tree/master/cmake/configs) by uncommenting / enabling the mavlink debug app in the config of your board
+  * [Debug Tutorial Code](https://github.com/PX4/Firmware/blob/master/src/examples/px4_mavlink_debug/px4_mavlink_debug.cpp)
+  * [Enable the tutorial app](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/default.cmake) by uncommenting / enabling the mavlink debug app in the config of your board if it's commented
 
 All required to set up a debug publication is this code snippet. First add the header file:
 

--- a/zh/debug/debug_values.md
+++ b/zh/debug/debug_values.md
@@ -12,8 +12,8 @@ translated_sha: 95b39d747851dd01c1fe5d36b24e59ec865e323e
 
 这个教程的代码可以从这里获取:
 
-* [调试教程代码](https://github.com/PX4/Firmware/blob/master/src/examples/px4_mavlink_debug/px4_mavlink_debug.c)
-* [使能教程应用](https://github.com/PX4/Firmware/tree/master/cmake/configs) 通过取消掉板子中配置文件中对 mavlink debug app 的注释来使能这个应用。
+* [调试教程代码](https://github.com/PX4/Firmware/blob/master/src/examples/px4_mavlink_debug/px4_mavlink_debug.cpp)
+* [使能教程应用](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/default.cmake) 通过取消掉板子中配置文件中对 mavlink debug app 的注释来使能这个应用。
 
 配置一个调试发布（debug publication）只需要这个代码片段，先加入头文件：
 


### PR DESCRIPTION
The directory from https://github.com/PX4/Firmware/tree/master/cmake/configs has been already restructured with https://github.com/PX4/Firmware/commit/f692ad04d0ea22b8874926e9dc0cac23263bbeae, so I've decided to choose fmu-v5 `default.cmake` as the example.