### PR TITLE
Dev env script and update for Ubuntu 18.04/ROS Melodic

### DIFF
--- a/build_scripts/ubuntu_sim_common_deps.sh
+++ b/build_scripts/ubuntu_sim_common_deps.sh
@@ -30,8 +30,8 @@ sudo -H pip install pandas jinja2 pyserial pyyaml
 # optional python tools
 sudo -H pip install pyulog
 
-# Install FastRTPS 1.5.0 and FastCDR-1.0.7
-fastrtps_dir=$HOME/eProsima_FastRTPS-1.5.0-Linux
+# Install FastRTPS 1.7.1 and FastCDR-1.0.8
+fastrtps_dir=$HOME/eProsima_FastRTPS-1.7.1-Linux
 echo "Installing FastRTPS to: $fastrtps_dir"
 if [ -d "$fastrtps_dir" ]
 then
@@ -39,14 +39,14 @@ then
 else
     pushd .
     cd ~
-    wget http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-5-0/eprosima_fastrtps-1-5-0-linux-tar-gz -O eprosima_fastrtps-1-5-0-linux.tar.gz
-    tar -xzf eprosima_fastrtps-1-5-0-linux.tar.gz eProsima_FastRTPS-1.5.0-Linux/
-    tar -xzf eprosima_fastrtps-1-5-0-linux.tar.gz requiredcomponents
-    tar -xzf requiredcomponents/eProsima_FastCDR-1.0.7-Linux.tar.gz
+    wget https://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-1/eprosima_fastrtps-1-7-1-linux-tar-gz -O eprosima_fastrtps-1-7-1-linux.tar.gz
+    tar -xzf eprosima_fastrtps-1-7-1-linux.tar.gz eProsima_FastRTPS-1.7.1-Linux/
+    tar -xzf eprosima_fastrtps-1-7-1-linux.tar.gz requiredcomponents
+    tar -xzf requiredcomponents/eProsima_FastCDR-1.0.8-Linux.tar.gz
     cpucores=$(( $(lscpu | grep Core.*per.*socket | awk -F: '{print $2}') * $(lscpu | grep Socket\(s\) | awk -F: '{print $2}') ))
-    (cd eProsima_FastCDR-1.0.7-Linux && ./configure --libdir=/usr/lib && make -j$cpucores && sudo make install)
-    (cd eProsima_FastRTPS-1.5.0-Linux && ./configure --libdir=/usr/lib && make -j$cpucores && sudo make install)
-    rm -rf requiredcomponents eprosima_fastrtps-1-5-0-linux.tar.gz
+    (cd eProsima_FastCDR-1.0.8-Linux && ./configure --libdir=/usr/lib && make -j$cpucores && sudo make install)
+    (cd eProsima_FastRTPS-1.7.1-Linux && ./configure --libdir=/usr/lib && make -j$cpucores && sudo make install)
+    rm -rf requiredcomponents eprosima_fastrtps-1-7-1-linux.tar.gz
     popd
 fi
 

--- a/build_scripts/ubuntu_sim_ros_melodic.sh
+++ b/build_scripts/ubuntu_sim_ros_melodic.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+## Bash script for setting up ROS Melodic (with Gazebo 9) development environment for PX4 on Ubuntu LTS (18.04). 
+## It installs the common dependencies for all targets (including Qt Creator)
+##
+## Installs:
+## - Common dependencies libraries and tools as defined in `ubuntu_sim_common_deps.sh`
+## - ROS Melodic (including Gazebo9)
+## - MAVROS
+
+echo "Downloading dependent script 'ubuntu_sim_common_deps.sh'"
+# Source the ubuntu_sim_common_deps.sh script directly from github
+common_deps=$(wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh -O -)
+wget_return_code=$?
+# If there was an error downloading the dependent script, we must warn the user and exit at this point.
+if [[ $wget_return_code -ne 0 ]]; then echo "Error downloading 'ubuntu_sim_common_deps.sh'. Sorry but I cannot proceed further :("; exit 1; fi
+# Otherwise source the downloaded script.
+. <(echo "${common_deps}")
+
+# ROS Melodic
+## Gazebo simulator dependencies
+sudo apt-get install protobuf-compiler libeigen3-dev libopencv-dev -y
+
+## ROS Gazebo: http://wiki.ros.org/melodic/Installation/Ubuntu
+## Setup keys
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+## For keyserver connection problems substitute hkp://pgp.mit.edu:80 or hkp://keyserver.ubuntu.com:80 above.
+sudo apt-get update
+## Get ROS/Gazebo
+sudo apt install ros-melodic-desktop-full -y
+## Initialize rosdep
+sudo rosdep init
+rosdep update
+## Setup environment variables
+rossource="source /opt/ros/melodic/setup.bash"
+if grep -Fxq "$rossource" ~/.bashrc; then echo ROS setup.bash already in .bashrc;
+else echo "$rossource" >> ~/.bashrc; fi
+eval $rossource
+
+## Install rosinstall and other dependencies
+sudo apt install python-rosinstall python-rosinstall-generator python-wstool build-essential -y
+
+
+
+# MAVROS: https://dev.px4.io/en/ros/mavros_installation.html
+## Install dependencies
+sudo apt-get install python-catkin-tools python-rosinstall-generator -y
+
+## Create catkin workspace
+mkdir -p ~/catkin_ws/src
+cd ~/catkin_ws
+catkin init
+wstool init src
+
+
+## Install MAVLink
+###we use the Kinetic reference for all ROS distros as it's not distro-specific and up to date
+rosinstall_generator --rosdistro kinetic mavlink | tee /tmp/mavros.rosinstall
+
+## Build MAVROS
+### Get source (upstream - released)
+rosinstall_generator --upstream mavros | tee -a /tmp/mavros.rosinstall
+
+### Setup workspace & install deps
+wstool merge -t src /tmp/mavros.rosinstall
+wstool update -t src
+if ! rosdep install --from-paths src --ignore-src -y; then
+    # (Use echo to trim leading/trailing whitespaces from the unsupported OS name
+    unsupported_os=$(echo $(rosdep db 2>&1| grep Unsupported | awk -F: '{print $2}'))
+    rosdep install --from-paths src --ignore-src --rosdistro melodic -y --os ubuntu:bionic
+fi
+
+if [[ ! -z $unsupported_os ]]; then
+    >&2 echo -e "\033[31mYour OS ($unsupported_os) is unsupported. Assumed an Ubuntu 18.04 installation,"
+    >&2 echo -e "and continued with the installation, but if things are not working as"
+    >&2 echo -e "expected you have been warned."
+fi
+
+#Install geographiclib
+sudo apt install geographiclib -y
+echo "Downloading dependent script 'install_geographiclib_datasets.sh'"
+# Source the install_geographiclib_datasets.sh script directly from github
+install_geo=$(wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh -O -)
+wget_return_code=$?
+# If there was an error downloading the dependent script, we must warn the user and exit at this point.
+if [[ $wget_return_code -ne 0 ]]; then echo "Error downloading 'install_geographiclib_datasets.sh'. Sorry but I cannot proceed further :("; exit 1; fi
+# Otherwise source the downloaded script.
+sudo bash -c "$install_geo"
+
+## Build!
+catkin build
+## Re-source environment to reflect new packages/build environment
+catkin_ws_source="source ~/catkin_ws/devel/setup.bash"
+if grep -Fxq "$catkin_ws_source" ~/.bashrc; then echo ROS catkin_ws setup.bash already in .bashrc; 
+else echo "$catkin_ws_source" >> ~/.bashrc; fi
+eval $catkin_ws_source
+
+
+# Go to the firmware directory
+clone_dir=~/src
+cd $clone_dir/Firmware
+
+

--- a/en/ros/mavros_installation.md
+++ b/en/ros/mavros_installation.md
@@ -1,6 +1,6 @@
 # MAVROS
 
-The [mavros](http://wiki.ros.org/mavros#mavros.2BAC8-Plugins.sys_status) ROS package enables MAVLink extendable communication between computers running ROS, MAVLink enabled autopilots, and MAVLink enabled GCS.  
+The [mavros](http://wiki.ros.org/mavros#mavros.2BAC8-Plugins.sys_status) ROS package enables MAVLink extendable communication between computers running ROS, MAVLink enabled autopilots, and MAVLink enabled GCS.
 
 > **Note** *MAVROS* is the "official" supported bridge between ROS and the MAVLink protocol. It is currently being extended to enable [fast-RTPS messaging](../middleware/micrortps.md), including a layer to translate PX4 [uORB messages](../middleware/uorb.md) to common ROS idioms.
 
@@ -10,7 +10,8 @@ While MAVROS can be used to communicate with any MAVLink enabled autopilot this 
 
 MAVROS can be installed either from source or binary. Developers working with ROS are advised to use the source installation.
 
-> **Tip** These instructions are a simplified version of the [official installation guide](https://github.com/mavlink/mavros/tree/master/mavros#installation).   They cover the *ROS Kinetic* release.
+> **Tip** These instructions are a simplified version of the [official installation guide](https://github.com/mavlink/mavros/tree/master/mavros#installation).
+  They cover the *ROS Melodic* release.
 
 
 ### Binary Installation (Debian / Ubuntu)

--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -2,18 +2,24 @@
 
 Linux allows you to build for [all PX4 targets](../setup/dev_env.md#supported-targets) (NuttX based hardware, Qualcomm Snapdragon Flight hardware, Linux-based hardware, Simulation, ROS).
 
-> **Tip** We have standardized on Debian / [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) (16.04) as the supported Linux distribution. Instructions are also provided for [CentOS](../setup/dev_env_linux_centos.md) and [Arch Linux](../setup/dev_env_linux_arch.md).
+> **Tip** [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) 16.04 is the tested/supported Linux distribution for most development.
+  Ubuntu 18.04 LTS with ROS Melodic is used for [ROS development](#ros). 
+  Instructions are also provided for [CentOS](../setup/dev_env_linux_centos.md) and [Arch Linux](../setup/dev_env_linux_arch.md).
 
-The following instructions explain how to set up a development environment on Ubuntu LTS using convenience bash scripts. Instructions for *manually installing* these and additional targets can be found in [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md).
+The following instructions explain how to set up a development environment on Ubuntu LTS using convenience bash scripts. 
+Instructions for *manually installing* these and additional targets can be found in [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md).
 
 
 ## Development Toolchain
 
-The instructions below show how you can use our [convenience bash scripts](../setup/dev_env_linux_ubuntu.md#convenience-bash-scripts) to setup the developer toolchain on Ubuntu LTS. All the scripts install the *Qt Creator IDE*, [Ninja Build System](https://ninja-build.org/), [Common Dependencies](../setup/dev_env_linux_ubuntu.md#common-dependencies), [FastRTPS](../setup/dev_env_linux_ubuntu.md#fastrtps-installation), and also download the PX4 source to your computer (**~/src/Firmware**).
+The instructions below show how you can use our [convenience bash scripts](../setup/dev_env_linux_ubuntu.md#convenience-bash-scripts) to setup the developer toolchain on Ubuntu LTS. 
+All the scripts install the *Qt Creator IDE*, [Ninja Build System](https://ninja-build.org/), [Common Dependencies](../setup/dev_env_linux_ubuntu.md#common-dependencies), [FastRTPS](../setup/dev_env_linux_ubuntu.md#fastrtps-installation), and also download the PX4 source to your computer (**~/src/Firmware**).
 
-> **Tip** The scripts have been tested on a clean Ubuntu LTS 16.04 installation. They *may* not work as expected if installed on top of an existing system or on another Ubuntu release. If you have any problems then follow the [manual installation instructions](../setup/dev_env_linux_ubuntu.md).
+> **Tip** The scripts have been tested on clean Ubuntu LTS 16.04 and Ubuntu LTS 18.04 installations.
+  They *may* not work as expected if installed on top of an existing system or on another Ubuntu release. 
+  If you have any problems then follow the [manual installation instructions](../setup/dev_env_linux_ubuntu.md).
 
-First make the user a member of the group "dialout"
+First make the user a member of the group "dialout":
 1. On the command prompt enter:
    ```sh
    sudo usermod -a -G dialout $USER
@@ -62,7 +68,7 @@ Follow the (manual) instructions here: [Ubuntu/Debian Linux > Parrot Bebop](../s
 
 ### jMAVSim/Gazebo Simulation
 
-To install the Gazebo and jMAVSim simulators:
+To install the Gazebo9 and jMAVSim simulators:
 
 1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim.sh" target="_blank" download>ubuntu_sim.sh</a>.
 1. Run the script in a bash shell:
@@ -74,9 +80,14 @@ To install the Gazebo and jMAVSim simulators:
 > **Tip** If you just need jMAVSim, instead download and run <a href="https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh" target="_blank" download>ubuntu_sim_common_deps.sh</a>.
 
 <span><span>
-> **Note** PX4 works with Gazebo 7, 8, and 9. The script installs Gazebo 9.
+> **Note** PX4 works with Gazebo 7, 8, and 9. 
+  The script installs Gazebo 9.
 
-### Gazebo with ROS
+### Gazebo with ROS Melodic {#ros}
+
+> **Note** PX4 is tested with ROS Melodic on Ubuntu 18.04 LTS.
+  ROS Melodic does not work on Ubuntu 16.04.
+
 
 To install the development toolchain:
 
@@ -88,7 +99,7 @@ To install the development toolchain:
    You may need to acknowledge some prompts as the script progresses.
 
 Note: 
-* ROS is installed with Gazebo7 by default (we have chosen to use the default rather than Gazebo8 or Gazebo9 to simplify ROS development).
+* ROS Melodic is installed with Gazebo9 by default.
 * Your catkin (ROS build system) workspace is created at **~/catkin_ws/**.
 
 ## Additional Tools

--- a/en/setup/dev_env_linux_ubuntu.md
+++ b/en/setup/dev_env_linux_ubuntu.md
@@ -1,6 +1,9 @@
 # Development Environment on Ubuntu LTS / Debian Linux
 
-[Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) (16.04) is the standard/preferred Linux development OS. It allows you to build for [all PX4 targets](../setup/dev_env.md#supported-targets) (NuttX based hardware, Qualcomm Snapdragon Flight hardware, Linux-based hardware, Simulation, ROS).
+[Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) 16.04 is the standard/preferred Linux development OS. 
+It allows you to build for [most PX4 targets](../setup/dev_env.md#supported-targets) (NuttX based hardware, Qualcomm Snapdragon Flight hardware, Linux-based hardware, Simulation).
+
+> **Note** Ubuntu 18.04 is required if you want to work with *ROS Melodic* (which does not install on Ubuntu 16.04).
 
 The following instructions explain how to *manually* set up a development environment each of the supported targets.
 
@@ -12,9 +15,11 @@ The following instructions explain how to *manually* set up a development enviro
 
 ## Convenience Bash Scripts
 
-We've created a number of bash scripts that you can use to install the Simulators and/or NuttX toolchain. All the scripts install the *Qt Creator IDE*, [Ninja Build System](#ninja-build-system), [Common Dependencies](#common-dependencies), [FastRTPS](#fastrtps-installation), and also download the PX4 source to your computer (**~/src/Firmware**). 
+We've created a number of bash scripts that you can use to install the Simulators and/or NuttX toolchain. 
+All the scripts install the *Qt Creator IDE*, [Ninja Build System](#ninja-build-system), [Common Dependencies](#common-dependencies), [FastRTPS](#fastrtps-installation), and also download the PX4 source to your computer (**~/src/Firmware**). 
 
-> **Tip** The scripts have been tested on a clean Ubuntu 16.04 LTS installation. They *may* not work as expected if installed on top of an existing system.
+> **Tip** The scripts have been tested on clean Ubuntu 16.04 and 18.04 LTS installations. 
+They *may* not work as expected if installed on top of an existing system or a different Ubuntu release.
 
 The scripts are:
 
@@ -155,15 +160,15 @@ sudo apt-get install gazebo9 -y
 sudo apt-get install libgazebo9-dev -y
 ```
 
-> **Tip** PX4 works with Gazebo 7, 8, and 9. The [installation instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install) above are for installing Gazebo 9.
+> **Tip** PX4 works with Gazebo 7, 8, and 9. 
+  The [installation instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install) above are for installing Gazebo 9.
 
-<!-- these dependencies left over when I separated the dependencies. These appear to both be for using Clang. MOve them down?
-sudo apt-get install clang-3.5 lldb-3.5 -y
--->
 
 ### ROS/Gazebo
 
-Install the dependencies for [ROS/Gazebo](../ros/README.md) ("Kinetic"). These include Gazebo7 (at time of writing, the default version that comes with ROS). The instructions come from the ROS Wiki [Ubuntu page](http://wiki.ros.org/kinetic/Installation/Ubuntu).
+Install the dependencies for [ROS/Gazebo](../ros/README.md) ("Melodic"). 
+These include Gazebo9 (the default version that comes with ROS Melodic). 
+The instructions come from the ROS Wiki [Ubuntu page](http://wiki.ros.org/kinetic/Installation/Ubuntu).
 
 ```sh
 # ROS Kinetic/Gazebo
@@ -190,9 +195,11 @@ source ~/.bashrc
 sudo apt-get install python-rosinstall -y
 ```
 
-Install the [MAVROS \(MAVLink on ROS\)](../ros/mavros_installation.md) package. This enables MAVLink communication between computers running ROS, MAVLink enabled autopilots, and MAVLink enabled GCS. 
+Install the [MAVROS \(MAVLink on ROS\)](../ros/mavros_installation.md) package. 
+This enables MAVLink communication between computers running ROS, MAVLink enabled autopilots, and MAVLink enabled GCS. 
 
-> **Tip** MAVROS can be installed as an ubuntu package or from source. Source is recommended for developers.
+> **Tip** MAVROS can be installed as an ubuntu package or from source. 
+  Source is recommended for developers.
 
 
 ```sh
@@ -261,6 +268,7 @@ Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
 * [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
 * [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
 * [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
+
 
 ## Raspberry Pi Hardware
 


### PR DESCRIPTION
Fixes #751

This is required because PX4 updated to ROS melodic, which only runs on 18.04. 
This will require a little more work, but would be good to get the new script reviewed before we proceed.