### PR TITLE
 fix some mistakes in the ulog documentation 

### DIFF
--- a/en/log/ulog_file_format.md
+++ b/en/log/ulog_file_format.md
@@ -106,7 +106,7 @@ struct message_header_s {
   ```
   struct message_format_s {
   	struct message_header_s header;
-  	char format[header.msg_size-hdr_size];
+  	char format[header.msg_size];
   };
   ```
   `format`: plain-text string with the following format: `message_name:field0;field1;`
@@ -135,7 +135,7 @@ struct message_header_s {
   	struct message_header_s header;
   	uint8_t key_len;
   	char key[key_len];
-  	char value[header.msg_size-hdr_size-1-key_len]
+  	char value[header.msg_size-1-key_len]
   };
   ```
   `key` is a plain string, as in the format message (can also be a custom type), but consists of only a single field without ending `;`, eg. `float[3] myvalues`. 
@@ -178,7 +178,7 @@ int32_t time_ref_utc | UTC Time offset in seconds | -3600 |
   	uint8_t is_continued; ///< can be used for arrays
   	uint8_t key_len;
   	char key[key_len];
-  	char value[header.msg_size-hdr_size-2-key_len]
+  	char value[header.msg_size-2-key_len]
   };
   ```
   The same as the information message, except that there can be multiple messages with the same key (parsers store them as a list). 
@@ -203,7 +203,7 @@ The following messages belong to this section:
   	struct message_header_s header;
   	uint8_t multi_id;
   	uint16_t msg_id;
-  	char message_name[header.msg_size-hdr_size-3];
+  	char message_name[header.msg_size-3];
   };
   ```
   `multi_id`: the same message format can have multiple instances, for example if the system has two sensors of the same type.
@@ -227,7 +227,7 @@ The following messages belong to this section:
   struct message_data_s {
   	struct message_header_s header;
   	uint16_t msg_id;
-  	uint8_t data[header.msg_size-hdr_size];
+  	uint8_t data[header.msg_size-2];
   };
   ```
   `msg_id`: as defined by a `message_add_logged_s` message. 
@@ -240,7 +240,7 @@ The following messages belong to this section:
   	struct message_header_s header;
   	uint8_t log_level;
   	uint64_t timestamp;
-  	char message[header.msg_size-hdr_size-9]
+  	char message[header.msg_size-9]
   };
   ```
   `timestamp`: in microseconds, `log_level`: same as in the Linux kernel:


### PR DESCRIPTION
The `hdr_size` is never in the `msg_size` as said at the top of this document:

> `msg_size` is the size of the message in bytes without the header (`hdr_size`= 3 bytes). 

This seems to also be how log data is read, e.g. in pyulog:
https://github.com/PX4/pyulog/blob/235ecaf26c67268d9b3d7b25ec94e50e34c60d90/pyulog/core.py#L479

The documentation is still a bit inconsistent with `ulog_message_flag_bits_s` not having a header as part of the struct, while e.g. `message_format_s` has one.