### PR TITLE
simulation: notes on lockstep, how to disable it

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -131,17 +131,22 @@ make px4_sitl jmavsim
 
 ### Lockstep Simulation
 
-SITL simulation is implemented using lockstep. This enables [running the simulation faster or slower than realtime](#simulation_speed), and also to pause it in order to step through code. This is achieved because the simulation (e.g. jMAVSim or Gazebo) and PX4 are running in lockstep meaning they wait on each other for their turn.
-The steps are:
+PX4 SITL and the simulators (jMAVSim or Gazebo) have been set up to run in *lockstep*.
+What this means is that PX4 and the simulator wait on each other for sensor and actuator messages, rather than running at their own speeds.
+
+> **Note** Lockstep makes it possible to [run the simulation faster or slower than realtime](#simulation_speed), and also to pause it in order to step through code. 
+
+The sequence of steps for lockstep are:
 1. The simulation sends a sensor message [HIL_SENSOR](https://mavlink.io/en/messages/common.html#HIL_SENSOR) including a timestamp `time_usec` to update the sensor state and time of PX4.
-1. PX4 receives this and does one iteration of state estimation, controls, etc. and eventually send a actuator message [HIL_ACTUATOR_CONTROLS](https://mavlink.io/en/messages/common.html#HIL_ACTUATOR_CONTROLS).
-1. The simulation has waited until it receives the actuator/motor message, then simulates the physics and calculates the next sensor message to send to PX4 again.
+1. PX4 receives this and does one iteration of state estimation, controls, etc. and eventually sends an actuator message [HIL_ACTUATOR_CONTROLS](https://mavlink.io/en/messages/common.html#HIL_ACTUATOR_CONTROLS).
+1. The simulation waits until it receives the actuator/motor message, then simulates the physics and calculates the next sensor message to send to PX4 again.
 
 The system starts with a "freewheeling" period where the simulation sends sensor messages including time and therefore runs PX4 until it has initialized and responds with an actautor message.
 
-### Disable Lockstep Simulation
+#### Disable Lockstep Simulation
 
-If required the lockstep simulation can be disabled which means that the old behavior is used where both simulator and PX4 use the host system time.
+The lockstep simulation can be disabled if, for example, SITL is to be used with a simulator that does not support this feature. 
+In this case the simulator and PX4 use the host system time and do not wait on each other.
 
 To disable lockstep in PX4, use `set(ENABLE_LOCKSTEP_SCHEDULER no)` in the [SITL board config](https://github.com/PX4/Firmware/blob/77097b6adc70afbe7e5d8ff9797ed3413e96dbf6/boards/px4/sitl/default.cmake#L104).
 


### PR DESCRIPTION
This adds some missing information about how lockstep simulation actually works under the hood and how it can be disabled if needed.