### PR TITLE
Update to use wget instead of browser

### DIFF
--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -33,7 +33,7 @@ Then follow the instructions for your development target in the sections below.
 
 To install the development toolchain:
 
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_nuttx.sh" target="_blank" download>ubuntu_sim_nuttx.sh</a>.
+1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_nuttx.sh" target="_blank" download>ubuntu_sim_nuttx.sh</a>. It's best to use `wget`.
 1. Run the script in a bash shell:
    ```bash
    source ubuntu_sim_nuttx.sh
@@ -53,7 +53,7 @@ Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
 ### Raspberry Pi
 
 To install the development toolchain:
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_common_deps.sh" target="_blank" download>ubuntu_sim_common_deps.sh</a> (this contains the jMAVSim simulator and common toolchain dependencies).
+1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_common_deps.sh" target="_blank" download>ubuntu_sim_common_deps.sh</a> (this contains the jMAVSim simulator and common toolchain dependencies). It's best to use `wget`.
 1. Run the script in a bash shell:
    ```bash
    source ubuntu_sim_common_deps.sh
@@ -70,7 +70,7 @@ Follow the (manual) instructions here: [Ubuntu/Debian Linux > Parrot Bebop](../s
 
 To install the Gazebo9 and jMAVSim simulators:
 
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim.sh" target="_blank" download>ubuntu_sim.sh</a>.
+1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim.sh" target="_blank" download>ubuntu_sim.sh</a>. It's best to use `wget`.
 1. Run the script in a bash shell:
    ```bash
    source ubuntu_sim.sh
@@ -91,7 +91,7 @@ To install the Gazebo9 and jMAVSim simulators:
 
 To install the development toolchain:
 
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_melodic.sh" target="_blank" download>ubuntu_sim_ros_melodic.sh</a>.
+1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_melodic.sh" target="_blank" download>ubuntu_sim_ros_melodic.sh</a>. It's best to use `wget`.
 1. Run the script in a bash shell:
    ```bash
    source ubuntu_sim_ros_melodic.sh

--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -33,8 +33,11 @@ Then follow the instructions for your development target in the sections below.
 
 To install the development toolchain:
 
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_nuttx.sh" target="_blank" download>ubuntu_sim_nuttx.sh</a>. It's best to use `wget`.
-1. Run the script in a bash shell:
+1. Download the script in a bash shell:
+   ```bash
+   wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_nuttx.sh
+   ```
+1. Run the script:
    ```bash
    source ubuntu_sim_nuttx.sh
    ```
@@ -53,8 +56,11 @@ Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
 ### Raspberry Pi
 
 To install the development toolchain:
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_common_deps.sh" target="_blank" download>ubuntu_sim_common_deps.sh</a> (this contains the jMAVSim simulator and common toolchain dependencies). It's best to use `wget`.
-1. Run the script in a bash shell:
+1. Download the script in a bash shell (this contains the jMAVSim simulator and common toolchain dependencies):
+   ```bash
+   wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh
+   ```
+1. Run the script:
    ```bash
    source ubuntu_sim_common_deps.sh
    ```
@@ -70,8 +76,11 @@ Follow the (manual) instructions here: [Ubuntu/Debian Linux > Parrot Bebop](../s
 
 To install the Gazebo9 and jMAVSim simulators:
 
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim.sh" target="_blank" download>ubuntu_sim.sh</a>. It's best to use `wget`.
-1. Run the script in a bash shell:
+1. Download the script in a bash shell:
+   ```bash
+   wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim.sh
+   ```
+1. Run the script:
    ```bash
    source ubuntu_sim.sh
    ```
@@ -91,8 +100,11 @@ To install the Gazebo9 and jMAVSim simulators:
 
 To install the development toolchain:
 
-1. Download <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_melodic.sh" target="_blank" download>ubuntu_sim_ros_melodic.sh</a>. It's best to use `wget`.
-1. Run the script in a bash shell:
+1. Download the script in a bash shell:
+   ```bash
+   wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh
+   ```
+1. Run the script:
    ```bash
    source ubuntu_sim_ros_melodic.sh
    ```


### PR DESCRIPTION
I spent about a week reinstalling operating systems and running this script to later find that by downloading from the browser some characters were being rewritten essentially corrupting the file, thus failing the install. After consulting @julianoes I found that if I wget the file then it wouldn't cause issues and everything would install perfectly, the first time.