### PR TITLE
[BACKPORT] ROS install script update (#826)

### DIFF
--- a/build_scripts/ubuntu_sim_ros_melodic.sh
+++ b/build_scripts/ubuntu_sim_ros_melodic.sh
@@ -31,7 +31,7 @@ sudo apt-get install protobuf-compiler libeigen3-dev libopencv-dev -y
 ## ROS Gazebo: http://wiki.ros.org/melodic/Installation/Ubuntu
 ## Setup keys
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 ## For keyserver connection problems substitute hkp://pgp.mit.edu:80 or hkp://keyserver.ubuntu.com:80 above.
 sudo apt-get update
 ## Get ROS/Gazebo


### PR DESCRIPTION
We need to update the new GPG key for v1.9 as well.

Fixes #830.