### PR TITLE
Update mavlink.md

### DIFF
--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -55,7 +55,7 @@ public:
     {
         return "CA_TRAJECTORY";
     }
-    uint16_t get_id_static()
+    static uint16_t get_id_static()
     {
         return MAVLINK_MSG_ID_CA_TRAJECTORY;
     }


### PR DESCRIPTION
Omission of static return type keyword in get_id_static() causes compiler error.