### PR TITLE
mixing: expand on mixing and output group

### DIFF
--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -125,7 +125,9 @@ The mixer file does not explicitly define the actual *output group* (physical bu
 Instead, the purpose of the mixer (e.g. to control MAIN or AUX outputs) is inferred from the mixer [filename](#mixer_file_names), and mapped to the appropriate physical bus in the system [startup scripts](../concept/system_startup.md) (and in particular in [rc.interface](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/rc.interface)).
 
 > **Note** This approach is needed because the physical bus used for MAIN outputs is not always the same; it depends on whether or not the flight controller has an IO Board (see [PX4 Reference Flight Controller Design > Main/IO Function Breakdown](../hardware/reference_design.md#mainio-function-breakdown)) or uses UAVCAN for motor control.
-  The startup scripts load the mixer into the appropriate driver device for the board: `/dev/pwm_output0` (IO driver) or `/dev/pwm_output1` (FMU driver), `/dev/uavcan/esc` (uavcan driver).
+  The startup scripts load the mixer files into the appropriate device driver for the board, using the abstraction of a "device".
+  The main mixer is loaded into device `/dev/uavcan/esc` (uavcan) if UAVCAN is enabled, and otherwise `/dev/pwm_output0` (this device is mapped to the IO driver on controllers with an I/O board, and the FMU driver on boards that don't).
+  The aux mixer file is loaded into device `/dev/pwm_output1`, which maps to the FMU driver on Pixhawk controllers that have an I/O board.
 
 Since there are multiple control groups (like flight controls, payload, etc.) and multiple output groups (busses), one control group can send commands to multiple output groups.
 
@@ -135,6 +137,10 @@ graph TD;
   actuator_group_0-->output_group_6
   actuator_group_1-->output_group_0
 {% endmermaid %}
+
+> **Note** In practice, the startup scripts only load mixers into a single device (output group).
+  This is a configuration rather than technical limitation; you could load the main mixer into multiple drivers and have, for example, the same signal on both UAVCAN and the main pins.
+
 
 ## PX4 Mixer Definitions
 

--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -125,7 +125,7 @@ The mixer file does not explicitly define the actual *output group* (physical bu
 Instead, the purpose of the mixer (e.g. to control MAIN or AUX outputs) is inferred from the mixer [filename](#mixer_file_names), and mapped to the appropriate physical bus in the system [startup scripts](../concept/system_startup.md) (and in particular in [rc.interface](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/rc.interface)).
 
 > **Note** This approach is needed because the physical bus used for MAIN outputs is not always the same; it depends on whether or not the flight controller has an IO Board (see [PX4 Reference Flight Controller Design > Main/IO Function Breakdown](../hardware/reference_design.md#mainio-function-breakdown)) or uses UAVCAN for motor control.
-  The startup scripts load the mixer into the appropirate driver device for the board: `/dev/pwm_output0` (IO driver) or `/dev/pwm_output1` (FMU driver), `/dev/uavcan/esc` (uavcan driver).
+  The startup scripts load the mixer into the appropriate driver device for the board: `/dev/pwm_output0` (IO driver) or `/dev/pwm_output1` (FMU driver), `/dev/uavcan/esc` (uavcan driver).
 
 Since there are multiple control groups (like flight controls, payload, etc.) and multiple output groups (busses), one control group can send commands to multiple output groups.
 

--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -117,9 +117,17 @@ These groups are NOT mixer inputs, but serve as meta-channels to feed fixed wing
 * 6: reserved / aux2
 * 7: reserved / aux3
 
-## Mapping
+## Output Groups/Mapping
 
-Since there are multiple control groups (like flight controls, payload, etc.) and multiple output groups (first 8 PWM outputs, UAVCAN, etc.), one control group can send command to multiple output groups.
+An output group is one physical bus (e.g. FMU PWM outputs, IO PWM outputs, UAVCAN etc.) that has 8 normalized (-1..+1) command ports that can be mapped and scaled through the mixer.
+
+The mixer file does not explicitly define the actual *output group* (physical bus) where the outputs are applied.
+Instead, the purpose of the mixer (e.g. to control MAIN or AUX outputs) is inferred from the mixer [filename](#mixer_file_names), and mapped to the appropriate physical bus in the system [startup scripts](../concept/system_startup.md) (and in particular in [rc.interface](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/rc.interface)).
+
+> **Note** This approach is needed because the physical bus used for MAIN outputs is not always the same; it depends on whether or not the flight controller has an IO Board (see [PX4 Reference Flight Controller Design > Main/IO Function Breakdown](../hardware/reference_design.md#mainio-function-breakdown)) or uses UAVCAN for motor control.
+  The startup scripts load the mixer into the appropirate driver device for the board: `/dev/pwm_output0` (IO driver) or `/dev/pwm_output1` (FMU driver), `/dev/uavcan/esc` (uavcan driver).
+
+Since there are multiple control groups (like flight controls, payload, etc.) and multiple output groups (busses), one control group can send commands to multiple output groups.
 
 {% mermaid %}
 graph TD;
@@ -133,7 +141,7 @@ graph TD;
 Files in **ROMFS/px4fmu_common/mixers** implement mixers that are used for predefined airframes.
 They can be used as a basis for customisation, or for general testing purposes. 
 
-### Mixer File Names
+### Mixer File Names {#mixer_file_names}
 
 A mixer file must be named **XXXX._main_.mix** if it is responsible for the mixing of MAIN outputs or **XXXX._aux_.mix** if it mixes AUX outputs.
 

--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -119,7 +119,7 @@ These groups are NOT mixer inputs, but serve as meta-channels to feed fixed wing
 
 ## Output Groups/Mapping
 
-An output group is one physical bus (e.g. FMU PWM outputs, IO PWM outputs, UAVCAN etc.) that has 8 normalized (-1..+1) command ports that can be mapped and scaled through the mixer.
+An output group is one physical bus (e.g. FMU PWM outputs, IO PWM outputs, UAVCAN etc.) that has N (usually 8) normalized (-1..+1) command ports that can be mapped and scaled through the mixer.
 
 The mixer file does not explicitly define the actual *output group* (physical bus) where the outputs are applied.
 Instead, the purpose of the mixer (e.g. to control MAIN or AUX outputs) is inferred from the mixer [filename](#mixer_file_names), and mapped to the appropriate physical bus in the system [startup scripts](../concept/system_startup.md) (and in particular in [rc.interface](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/rc.interface)).


### PR DESCRIPTION
This better explains how output groups are mapped to physical bus, and hence how the magic of "MAIN" and "AUX" going to different physical but on different Pixhawk boards works. IT follows on from discussion here: https://github.com/PX4/Devguide/pull/852#issuecomment-522808899