### PR TITLE
Devguide update to use ubuntu.sh

### DIFF
--- a/build_scripts/ubuntu_sim.sh
+++ b/build_scripts/ubuntu_sim.sh
@@ -31,7 +31,3 @@ sudo apt-get install gazebo9 -y
 ## For developers (who work on top of Gazebo) one extra package
 sudo apt-get install libgazebo9-dev -y
 
-
-
-# Go to the firmware directory
-cd $clone_dir/Firmware

--- a/build_scripts/ubuntu_sim_common_deps.sh
+++ b/build_scripts/ubuntu_sim_common_deps.sh
@@ -4,7 +4,7 @@
 ## It can be used for installing simulators (only) or for installing the preconditions for Snapdragon Flight or Raspberry Pi.
 ##
 ## Installs:
-## - Common dependencies and tools for all targets (including: Ninja build system, Qt Creator, pyulog)
+## - Common dependencies and tools for all targets (including: Ninja build system, pyulog)
 ## - FastRTPS and FastCDR
 ## - jMAVSim simulator dependencies
 ## - PX4/Firmware source (to ~/src/Firmware/)
@@ -21,7 +21,7 @@ sudo usermod -a -G dialout $USER
 # Common dependencies
 echo "Installing common dependencies"
 sudo apt-get update -y
-sudo apt-get install git zip qtcreator cmake build-essential genromfs ninja-build exiftool astyle -y
+sudo apt-get install git zip cmake build-essential genromfs ninja-build exiftool astyle -y
 # make sure xxd is installed, dedicated xxd package since Ubuntu 18.04 but was squashed into vim-common before
 which xxd || sudo apt install xxd -y || sudo apt-get install vim-common --no-install-recommends -y
 # Required python packages
@@ -55,14 +55,3 @@ fi
 echo "Installing jMAVSim simulator dependencies"
 sudo apt-get install ant openjdk-8-jdk openjdk-8-jre -y
 
-# Clone PX4/Firmware
-clone_dir=~/src
-echo "Cloning PX4 to: $clone_dir."
-if [ -d "$clone_dir" ]
-then
-    echo " Firmware already cloned."
-else
-    mkdir -p $clone_dir
-    cd $clone_dir
-    git clone https://github.com/PX4/Firmware.git
-fi

--- a/build_scripts/ubuntu_sim_nuttx.sh
+++ b/build_scripts/ubuntu_sim_nuttx.sh
@@ -44,8 +44,5 @@ else
 fi
 
 
-# Go to the firmware directory
-cd $clone_dir/Firmware
-
 #Reboot the computer (required before building)
 echo RESTART YOUR COMPUTER to complete installation of PX4 development toolchain

--- a/build_scripts/ubuntu_sim_ros_gazebo.sh
+++ b/build_scripts/ubuntu_sim_ros_gazebo.sh
@@ -81,10 +81,6 @@ if [[ $wget_return_code -ne 0 ]]; then echo "Error downloading 'install_geograph
 # Otherwise source the downloaded script.
 sudo bash -c "$install_geo"
 
-# Go to the firmware directory
-clone_dir=~/src
-cd $clone_dir/Firmware
-
 if [[ ! -z $unsupported_os ]]; then
     >&2 echo -e "\033[31mYour OS ($unsupported_os) is unsupported. Assumed an Ubuntu 16.04 installation,"
     >&2 echo -e "and continued with the installation, but if things are not working as"

--- a/build_scripts/ubuntu_sim_ros_melodic.sh
+++ b/build_scripts/ubuntu_sim_ros_melodic.sh
@@ -103,9 +103,3 @@ if grep -Fxq "$catkin_ws_source" ~/.bashrc; then echo ROS catkin_ws setup.bash a
 else echo "$catkin_ws_source" >> ~/.bashrc; fi
 eval $catkin_ws_source
 
-
-# Go to the firmware directory
-clone_dir=~/src
-cd $clone_dir/Firmware
-
-

--- a/build_scripts/windows_bash_nuttx.sh
+++ b/build_scripts/windows_bash_nuttx.sh
@@ -100,19 +100,3 @@ else
     popd
 fi
 
-
-# Clone PX4/Firmware
-clone_dir=~/src
-echo "Cloning PX4 to: $clone_dir."
-if [ -d "$clone_dir" ]
-then
-    echo " Firmware already cloned."
-else
-    mkdir -p $clone_dir
-    cd $clone_dir
-    git clone https://github.com/PX4/Firmware.git
-    cd Firmware
-fi
-cd $clone_dir/Firmware
-
-

--- a/en/setup/_ninja_build_system.md
+++ b/en/setup/_ninja_build_system.md
@@ -8,7 +8,8 @@ On Ubuntu Linux you can install this automatically from normal repos.
 sudo apt-get install ninja-build -y
 ```
 
-Other systems may not include Ninja in the package manager. In this case an alternative is to download the binary and add it to your path:
+Other systems may not include Ninja in the package manager.
+In this case an alternative is to download the binary and add it to your path:
 
 ```sh
 mkdir -p $HOME/ninja

--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -100,7 +100,7 @@ This will reposition the vehicle.
   make px4_sitl gazebo
   ```
 
-## NuttX / Pixhawk Based Boards
+## NuttX / Pixhawk Based Boards {#nuttx}
 
 ### Building {#building_nuttx}
 

--- a/en/setup/dev_env_linux.md
+++ b/en/setup/dev_env_linux.md
@@ -1,123 +1,18 @@
 # Development Environment on Linux
 
-Linux allows you to build for [all PX4 targets](../setup/dev_env.md#supported-targets) (NuttX based hardware, Qualcomm Snapdragon Flight hardware, Linux-based hardware, Simulation, ROS).
+Linux allows you to build for [all PX4 targets](../setup/dev_env.md#supported-targets) (NuttX based hardware, Qualcomm Snapdragon Flight hardware, Bebop, Linux-based hardware, Simulation, ROS).
 
-> **Tip** [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) 16.04 is the tested/supported Linux distribution for most development.
-  Ubuntu 18.04 LTS with ROS Melodic is used for [ROS development](#ros). 
-  Instructions are also provided for [CentOS](../setup/dev_env_linux_centos.md) and [Arch Linux](../setup/dev_env_linux_arch.md).
+> **Tip** [Ubuntu Linux LTS](../setup/dev_env_linux_ubuntu.md) 16.04 is recommended.
+  Other environments can be made to work, but are less well tested and documented.
 
-The following instructions explain how to set up a development environment on Ubuntu LTS using convenience bash scripts. 
-Instructions for *manually installing* these and additional targets can be found in [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md).
+The following instructions explain how to set up a development environment on various Linux platforms.
 
-
-## Development Toolchain
-
-The instructions below show how you can use our [convenience bash scripts](../setup/dev_env_linux_ubuntu.md#convenience-bash-scripts) to setup the developer toolchain on Ubuntu LTS. 
-All the scripts install the *Qt Creator IDE*, [Ninja Build System](https://ninja-build.org/), [Common Dependencies](../setup/dev_env_linux_ubuntu.md#common-dependencies), [FastRTPS](../setup/dev_env_linux_ubuntu.md#fastrtps-installation), and also download the PX4 source to your computer (**~/src/Firmware**).
-
-> **Tip** The scripts have been tested on clean Ubuntu LTS 16.04 and Ubuntu LTS 18.04 installations.
-  They *may* not work as expected if installed on top of an existing system or on another Ubuntu release. 
-  If you have any problems then follow the [manual installation instructions](../setup/dev_env_linux_ubuntu.md).
-
-First make the user a member of the group "dialout":
-1. On the command prompt enter:
-   ```sh
-   sudo usermod -a -G dialout $USER
-   ```
-1. Logout and login again (the change is only made after a new login).
-
-Then follow the instructions for your development target in the sections below.
+* [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md) - Recommended!
+* [CentOS Linux](../setup/dev_env_linux_centos.md)
+* [Arch Linux](../setup/dev_env_linux_arch.md)
+* [Advanced Linux](../setup/dev_env_advanced_linux.md)
 
 
-### Pixhawk/NuttX (and jMAVSim)
-
-To install the development toolchain:
-
-1. Download the script in a bash shell:
-   ```bash
-   wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_nuttx.sh
-   ```
-1. Run the script:
-   ```bash
-   source ubuntu_sim_nuttx.sh
-   ```
-   You may need to acknowledge some prompts as the script progresses.
-1. Restart the computer on completion.
-
-
-### Snapdragon Flight
-
-Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
-* [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
-* [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
-* [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
-
-   
-### Raspberry Pi
-
-To install the development toolchain:
-1. Download the script in a bash shell (this contains the jMAVSim simulator and common toolchain dependencies):
-   ```bash
-   wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh
-   ```
-1. Run the script:
-   ```bash
-   source ubuntu_sim_common_deps.sh
-   ```
-   You may need to acknowledge some prompts as the script progresses.
-1. Follow setup instructions in [Ubuntu/Debian Linux](../setup/dev_env_linux_ubuntu.md) for [Raspberry Pi](../setup/dev_env_linux_ubuntu.md#raspberry-pi-hardware).
-
-### Parrot Bepop
-
-Follow the (manual) instructions here: [Ubuntu/Debian Linux > Parrot Bebop](../setup/dev_env_linux_ubuntu.md#raspberry-pi-hardware).
-
-
-### jMAVSim/Gazebo Simulation
-
-To install the Gazebo9 and jMAVSim simulators:
-
-1. Download the script in a bash shell:
-   ```bash
-   wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim.sh
-   ```
-1. Run the script:
-   ```bash
-   source ubuntu_sim.sh
-   ```
-   You may need to acknowledge some prompts as the script progresses.
-
-> **Tip** If you just need jMAVSim, instead download and run <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_common_deps.sh" target="_blank" download>ubuntu_sim_common_deps.sh</a>.
-
-<span><span>
-> **Note** PX4 works with Gazebo 7, 8, and 9. 
-  The script installs Gazebo 9.
-
-### Gazebo with ROS Melodic {#ros}
-
-> **Note** PX4 is tested with ROS Melodic on Ubuntu 18.04 LTS.
-  ROS Melodic does not work on Ubuntu 16.04.
-
-
-To install the development toolchain:
-
-1. Download the script in a bash shell:
-   ```bash
-   wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh
-   ```
-1. Run the script:
-   ```bash
-   source ubuntu_sim_ros_melodic.sh
-   ```
-   You may need to acknowledge some prompts as the script progresses.
-
-Note: 
-* ROS Melodic is installed with Gazebo9 by default.
-* Your catkin (ROS build system) workspace is created at **~/catkin_ws/**.
-
-## Additional Tools
-
-After setting up the build/simulation toolchain, see [Additional Tools](../setup/generic_dev_tools.md) for information about other useful tools.
-
-## Next Steps
-
-Once you have finished setting up the environment, continue to the [build instructions](../setup/building_px4.md).
+After setting up the build/simulation toolchain:
+- [Additional Tools](../setup/generic_dev_tools.md) lists some other useful tools.
+- [Build instructions](../setup/building_px4.md) explains how to download and build PX4 source code.

--- a/en/setup/dev_env_linux_ubuntu.md
+++ b/en/setup/dev_env_linux_ubuntu.md
@@ -1,304 +1,80 @@
 # Development Environment on Ubuntu LTS / Debian Linux
 
 [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) 16.04 is the standard/preferred Linux development OS.
-It allows you to build for [most PX4 targets](../setup/dev_env.md#supported-targets) (NuttX based hardware, Qualcomm Snapdragon Flight hardware, Linux-based hardware, Simulation).
+It allows you to build for the [most PX4 targets](../setup/dev_env.md#supported-targets) (NuttX based hardware, *Qualcomm Snapdragon Flight* hardware, Linux-based hardware, Simulation).
 
-> **Note** Ubuntu 18.04 is required if you want to work with *ROS Melodic* (which does not install on Ubuntu 16.04).
-
-The following instructions explain how to *manually* set up a development environment each of the supported targets.
-
-> **Tip** We recommend that you use the [Convenience bash scripts](#convenience-bash-scripts) to install the Simulators and/or NuttX toolchain (this is easier than typing in the instructions below).
-  Then follow just the additional instructions for other targets (e.g. Qualcomm Snapdragon Flight, Bebop, Raspberry Pi, etc.)
-
-<span></span>
-> **Tip** After setting up the build/simulation toolchain, see [Additional Tools](../setup/generic_dev_tools.md) for information about other useful tools.
-
-
-## Convenience Bash Scripts
-
-We've created a number of bash scripts that you can use to install the Simulators and/or NuttX toolchain. 
-All the scripts install the *Qt Creator IDE*, [Ninja Build System](#ninja-build-system), [Common Dependencies](#common-dependencies), [FastRTPS](#fastrtps-installation), and also download the PX4 source to your computer (**~/src/Firmware**). 
+Bash scripts are provided to help make it easy to install development environment for different target platforms:
+- **[ubuntu.sh](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/Tools/setup/ubuntu.sh)**: Installs [Gazebo 9](../simulation/gazebo.md) and [jMAVSim](../simulation/jmavsim.md) simulators and/or [NuttX/Pixhawk](../setup/building_px4.md#nuttx) tools. Does not include dependencies for [FastRTPS](#fast_rtps).
+- **[ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_melodic.sh)**: Installs [ROS "Melodic"](#rosgazebo) and PX4 on Ubuntu 18.04 LTS.
 
 > **Tip** The scripts have been tested on clean Ubuntu 16.04 and 18.04 LTS installations.
-They *may* not work as expected if installed on top of an existing system or a different Ubuntu release.
+  They *may* not work as expected if installed on top of an existing system or a different Ubuntu release.
 
-The scripts are:
-
-* <strong><a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_common_deps.sh" target="_blank" download>ubuntu_sim_common_deps.sh</a></strong>: [Common Dependencies](#common-dependencies), [jMAVSim](#jmavsim) simulator
-  * This script contains the common dependencies for all PX4 build targets. It is automatically downloaded and run when you call any of the other scripts.
-  * You can run this before installing the remaining dependencies for [Qualcomm Snapdragon Flight](#snapdragon-flight) or [Raspberry Pi/Parrot Bebop](#raspberry-pi-hardware).
-
-* <strong><a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim.sh" target="_blank" download>ubuntu_sim.sh</a></strong>: **ubuntu_sim_common_deps.sh** + [Gazebo8](#gazebo) simulator. 
-* <strong><a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_nuttx.sh" target="_blank" download>ubuntu_sim_nuttx.sh</a></strong>: **ubuntu_sim.sh** + NuttX tools. 
-  * *This requires computer restart on completion.*
-* <strong><a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_melodic.sh" target="_blank" download>ubuntu_sim_ros_melodic.sh</a></strong>: **ubuntu_sim_common_deps.sh** + [ROS/Gazebo and MAVROS](#rosgazebo). 
-  * ROS Melodic is installed with Gazebo 9 by default.
-  * Your catkin (ROS build system) workspace is created at **~/catkin_ws/**.
+The instructions below explain how to download and use the scripts.
 
 
-### How to use the scripts
+## Gazebo, JMAVSim and NuttX (Pixhawk) Targets {#sim_nuttx}
 
-To use the scripts:
-1. Make the user a member of the group "dialout" (this only has to be done once):
-   1. Open a terminal and enter the following command:
-      ```sh
-      sudo usermod -a -G dialout $USER
-      ```
-   1. Logout and login again (the change is only made after a new login).
-1. Download the desired script
-1. Run the script in a bash shell (e.g. to run **ubuntu_sim.sh**):
+Use the [ubuntu.sh](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/Tools/setup/ubuntu.sh) script to set up a development environment that includes [Gazebo 9](../simulation/gazebo.md) and [jMAVSim](../simulation/jmavsim.md) simulators, and/or the [NuttX/Pixhawk](../setup/building_px4.md#nuttx) toolchain.
+
+To install the toolchain:
+
+1. Download [ubuntu.sh](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/Tools/setup/ubuntu.sh) and [requirements.txt](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/Tools/setup/requirements.txt) from the PX4 source repository (**/Tools/setup/**):
+   <br>`wget https://raw.githubusercontent.com/PX4/Firmware/{{ book.px4_version }}/Tools/setup/ubuntu.sh`
+   <br>`wget https://raw.githubusercontent.com/PX4/Firmware/{{ book.px4_version }}/Tools/setup/requirements.txt`
+1. Run the **ubuntu.sh** with no arguments (in a bash shell) to install everything:
    ```bash
-   source ubuntu_sim.sh
+   source ubuntu.sh
    ```
-   Acknowledge any prompts as the scripts progress.
+   - Acknowledge any prompts as the script progress.
+   - You can use the `--no-nuttx` and `--no-sim-tools` to omit the nuttx and/or simulation tools.
+1. Restart the computer on completion.
 
 
-## Permission Setup
+Notes:
+- The sections above explain how you can download just the scripts.
+  You may prefer to download all the PX4 source code ([Building the Code > Downloading PX4 Source Code](../setup/building_px4.md)) and run the scripts in place:
+  ```
+  source ./Tools/setup/ubuntu.sh
+  ```
+- PX4 works with Gazebo 7, 8, and 9.
+   The script uses [gazebosim.org instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install) to install Gazebo9.
+- If you're going work with ROS then follow the [ROS/Gazebo](#rosgazebo) instructions instead (these install Gazebo automatically, as part of the ROS installation).
+- You can verify the the NuttX installation by confirming the gcc version as shown:
+  ```bash
+   $arm-none-eabi-gcc --version
+   
+   arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 7-2017-q4-major) 7.2.1 20170904 (release) [ARM/embedded-7-branch revision 255204]
+   Copyright (C) 2017 Free Software Foundation, Inc.
+   This is free software; see the source for copying conditions.  There is NO
+   warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+   ```
 
-> **Warning** Never ever fix permission problems by using `sudo`.
-  It will create more permission problems in the process and require a system re-installation to fix them.
-
-The user needs to be part of the group "dialout":
-
-```sh
-sudo usermod -a -G dialout $USER
-```
-
-Then logout and login again (the change is only made after a new login).
-
-
-## Remove the modemmanager
-
-Ubuntu comes with a serial modem manager which interferes heavily with any robotics related use of a serial port \(or USB serial\).
-It can removed/deinstalled without side effects:
-
-```sh
-sudo apt-get remove modemmanager
-```
-
-
-## Common Dependencies
-
-Update the package list and install the following dependencies for all PX4 build targets.
-
-```sh
-sudo apt-get update -y
-sudo apt-get install git zip qtcreator cmake \
-    build-essential genromfs ninja-build exiftool -y
-
-# Install xxd (package depends on version)
-which xxd || sudo apt install xxd -y || sudo apt-get install vim-common --no-install-recommends -y
-
-# Required python packages
-sudo apt-get install python-argparse \
-    python-empy python-toml python-numpy python-yaml \
-    python-dev python-pip -y
-sudo -H pip install --upgrade pip 
-sudo -H pip install pandas jinja2 pyserial cerberus
-```
-
-You may also wish to install [pyulog](https://github.com/PX4/pyulog#pyulog). This is is a useful python package that contains scripts to parse *ULog* files and display them.
-```
-# optional python tools
-sudo -H pip install pyulog
-```
-
-<!-- import docs ninja build system -->
-{% include "_ninja_build_system.md" %}
-
-
-## FastRTPS installation
-# Install FastRTPS 1.7.1 and FastCDR-1.0.8
-fastrtps_dir=$HOME/eProsima_FastRTPS-1.7.1-Linux
-echo "Installing FastRTPS to: $fastrtps_dir"
-if [ -d "$fastrtps_dir" ]
-then
-    echo " FastRTPS already installed."
-else
-    pushd .
-    cd ~
-    
-    cpucores=$(( $(lscpu | grep Core.*per.*socket | awk -F: '{print $2}') * $(lscpu | grep Socket\(s\) | awk -F: '{print $2}') ))
-
-    popd
-fi
-
-[eProsima Fast RTPS](http://eprosima-fast-rtps.readthedocs.io/en/latest/) is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol.
-FastRTPS is used, via the [RTPS/ROS2 Interface: PX4-FastRTPS Bridge](../middleware/micrortps.md), to allow PX4 uORB topics to be shared with offboard components.
-
-The following instructions can be used to install the FastRTPS 1.7.1 binaries to your home directory.
-
-```sh
-wget https://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-1/eprosima_fastrtps-1-7-1-linux-tar-gz -O eprosima_fastrtps-1-7-1-linux.tar.gz
-tar -xzf eprosima_fastrtps-1-7-1-linux.tar.gz eProsima_FastRTPS-1.7.1-Linux/
-tar -xzf eprosima_fastrtps-1-7-1-linux.tar.gz requiredcomponents
-tar -xzf requiredcomponents/eProsima_FastCDR-1.0.8-Linux.tar.gz
-```
-
-> **Note** In the following lines where we compile the FastCDR and FastRTPS libraries, the `make` command is issued with the `-j2` option.
-  This option defines the number of parallel threads (or `j`obs) that are used to compile the source code. 
-  Change `-j2` to `-j<number_of_cpu_cores_in_your_system>` to speed up the compilation of the libraries.
-
-```sh
-(cd eProsima_FastCDR-1.0.8-Linux && ./configure --libdir=/usr/lib && make -j2 && sudo make install)
-(cd eProsima_FastRTPS-1.7.1-Linux && ./configure --libdir=/usr/lib && make -j2 && sudo make install)
-rm -rf requiredcomponents eprosima_fastrtps-1-7-1-linux.tar.gz
-```
-
-> **Note** More "generic" instructions, which additionally cover installation from source, can be found here: [Fast RTPS installation](../setup/fast-rtps-installation.md).
-
-
-## Simulation Dependencies
-
-The dependencies for the Gazebo and jMAVSim simulators listed below.
-You should minimally install jMAVSim to make it easy to test the installation.
-Additional information about these and other supported simulators is covered in: [Simulation](../simulation/README.md).
-
-### jMAVSim
-
-Install the dependencies for [jMAVSim Simulation](../simulation/jmavsim.md).
-
-```
-# jMAVSim simulator
-sudo apt-get install ant openjdk-8-jdk openjdk-8-jre -y
-```
-
-### Gazebo
-
-> **Note** If you're going work with ROS then follow the [ROS/Gazebo](#rosgazebo) instructions in the following section (these install Gazebo automatically, as part of the ROS installation).
-
-Install the dependencies for [Gazebo Simulation](../simulation/gazebo.md).
-
-```
-# Gazebo simulator
-sudo apt-get install protobuf-compiler libeigen3-dev libopencv-dev -y
-sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-## Setup keys
-wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-## Update the debian database:
-sudo apt-get update -y
-## Install Gazebo9
-sudo apt-get install gazebo9 -y
-## For developers (who work on top of Gazebo) one extra package
-sudo apt-get install libgazebo9-dev -y
-```
-
-> **Tip** PX4 works with Gazebo 7, 8, and 9.
-  The [installation instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install) above are for installing Gazebo 9.
-
-
-### ROS/Gazebo
-
-Install the dependencies for [ROS/Gazebo](../ros/README.md) ("Melodic").
-These include Gazebo9 (the default version that comes with ROS Melodic).
-The instructions come from the ROS Wiki [Ubuntu page](http://wiki.ros.org/kinetic/Installation/Ubuntu).
-
-> **Note** ROS Melodic requires Ubuntu 18.04 (and later).
-  It cannot be installed on Ubuntu 16.04.
-
-```sh
-# ROS Melodic/Gazebo
-## Gazebo dependencies
-sudo apt-get install protobuf-compiler libeigen3-dev libopencv-dev -y
-
-## ROS Gazebo: http://wiki.ros.org/melodic/Installation/Ubuntu
-## Setup keys
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-## For keyserver connection problems substitute hkp://pgp.mit.edu:80 or hkp://keyserver.ubuntu.com:80 above.
-sudo apt-get update
-## Get ROS/Gazebo
-sudo apt install ros-melodic-desktop-full -y
-## Initialize rosdep
-sudo rosdep init
-rosdep update
-## Setup environment variables
-rossource="source /opt/ros/melodic/setup.bash"
-if grep -Fxq "$rossource" ~/.bashrc; then echo ROS setup.bash already in .bashrc;
-else echo "$rossource" >> ~/.bashrc; fi
-eval $rossource
-## Install rosinstall and other dependencies
-sudo apt install python-rosinstall build-essential -y
-```
-
-Install the [MAVROS \(MAVLink on ROS\)](../ros/mavros_installation.md) package.
-This enables MAVLink communication between computers running ROS, MAVLink enabled autopilots, and MAVLink enabled GCS.
-
-> **Tip** MAVROS can be installed as an Ubuntu package or from source.
-  Source is recommended for developers.
-
-
-```sh
-## Create catkin workspace (ROS build system)
-mkdir -p ~/catkin_ws/src
-cd ~/catkin_ws
-
-## Install dependencies
-sudo apt-get install python-wstool python-rosinstall-generator python-catkin-tools -y
-
-## Initialise wstool
-wstool init ~/catkin_ws/src
-
-## Build MAVROS
-### Get source (upstream - released)
-rosinstall_generator --upstream mavros | tee /tmp/mavros.rosinstall
-### Get latest released MAVLink package
-rosinstall_generator mavlink | tee -a /tmp/mavros.rosinstall
-### Setup workspace & install deps
-wstool merge -t src /tmp/mavros.rosinstall
-wstool update -t src
-rosdep install --from-paths src --ignore-src --rosdistro melodic -y
-```
-
-> **Note** If you use a Ubuntu-based distro and the command `rosdep install --from-paths src --ignore-src --rosdistro melodic -y` fails, you can try to force the command to run by executing `rosdep install --from-paths src --ignore-src --rosdistro melodic -y --os ubuntu:bionic`
-
-```sh
-## Build!
-catkin build
-## Re-source environment to reflect new packages/build environment
-catkin_ws_source="source ~/catkin_ws/devel/setup.bash"
-if grep -Fxq "$catkin_ws_source" ~/.bashrc; then echo ROS catkin_ws setup.bash already in .bashrc;
-else echo "$catkin_ws_source" >> ~/.bashrc; fi
-source ~/.bashrc
-```
-
-
-## NuttX-based Hardware
-
-Install the following dependencies to build for NuttX based hardware: Pixhawk, Pixfalcon, Pixracer, Pixhawk 3, Intel® Aero Ready to Fly Drone.
-
-> **Note** Packages with specified versions should be installed with the specified package version.
-
-```sh
-sudo apt-get install python-serial openocd \
-    flex bison libncurses5-dev autoconf texinfo \
-    libftdi-dev libtool zlib1g-dev -y
-```
-
-
+<!-- Do we need to add to our scripts or can we assume correct version installs over?
 Remove any old versions of the arm-none-eabi toolchain.
-
 ```sh
 sudo apt-get remove gcc-arm-none-eabi gdb-arm-none-eabi binutils-arm-none-eabi gcc-arm-embedded
 sudo add-apt-repository --remove ppa:team-gcc-arm-embedded/ppa
 ```
-
-<!-- import GCC toolchain common documentation -->
-{% include "_gcc_toolchain_installation.md" %}
+-->
 
 
 
-## Snapdragon Flight
+## Raspberry Pi {#raspberry-pi-hardware}
 
-Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
-* [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
-* [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
-* [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
+To get the build toolchain for Raspberry Pi:
 
+1. Download [ubuntu.sh](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/Tools/setup/ubuntu.sh) and [requirements.txt](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/Tools/setup/requirements.txt) from the PX4 source repository (**/Tools/setup/**):
+   <br>`wget https://raw.githubusercontent.com/PX4/Firmware/{{ book.px4_version }}/Tools/setup/ubuntu.sh`
+   <br>`wget https://raw.githubusercontent.com/PX4/Firmware/{{ book.px4_version }}/Tools/setup/requirements.txt`
+1. Run **ubuntu.sh** in a terminal to get just the common dependencies:
+   ```bash
+   source ubuntu.sh --no-nuttx --no-sim-tools
+   ```
+1. Then setup an ARMv7 cross-compiler (either GCC or clang) as described in the following sections.
+ 
+### GCC
 
-## Raspberry Pi Hardware
-
-Developers working on Raspberry Pi hardware need to download a ARMv7 cross-compiler, either GCC or clang.
 The current recommended toolchain for raspbian can be cloned from `https://github.com/raspberrypi/tools.git` (at time of writing 4.9.3).
 The `PATH` environmental variable should include the path to the gcc cross-compiler collection of tools (e.g. gcc, g++, strip) prefixed with `arm-linux-gnueabihf-`.
 
@@ -315,7 +91,7 @@ echo 'export PATH=$PATH:$HOME/rpi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabi
 export PATH=$PATH:$HOME/rpi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin
 ```
 
-### clang
+### Clang
 
 In order to use clang, you also need GCC.
 
@@ -343,16 +119,76 @@ cmake \
 
 Additional developer information for using PX4 on Raspberry Pi (including building PX4 natively) can be found here: [Raspberry Pi 2/3 Navio2 Autopilot](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html).
 
+
+
 ## Parrot Bebop
 
-Developers working with the Parrot Bebop should install the RPi Linux Toolchain. Follow the
-description under [Raspberry Pi hardware](#raspberry-pi-hardware).
+Developers working with the Parrot Bebop should first install the [Raspberry Pi Linux Toolchain](#raspberry-pi-hardware) as described above.
 
-Next, install ADB.
-
+Then install ADB:
 ```sh
 sudo apt-get install android-tools-adb -y
 ```
+
+
+## ROS/Gazebo {#rosgazebo}
+
+This section explains how to install [ROS/Gazebo](../ros/README.md) ("Melodic") for use with PX4.
+
+> **Note** PX4 is tested with ROS Melodic on Ubuntu 18.04 LTS.
+  ROS Melodic does not work on Ubuntu 16.04.
+
+To install the development toolchain:
+
+1. Download the script in a bash shell:
+   <br>`wget https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_melodic.sh`
+1. Run the script:
+   ```bash
+   source ubuntu_sim_ros_melodic.sh
+   ```
+   You may need to acknowledge some prompts as the script progresses.
+
+Note: 
+* ROS Melodic is installed with Gazebo9 by default.
+* Your catkin (ROS build system) workspace is created at **~/catkin_ws/**.
+* The script uses instructions from the ROS Wiki "Melodic" [Ubuntu page](http://wiki.ros.org/melodic/Installation/Ubuntu).
+
+
+
+## Snapdragon Flight
+
+Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
+* [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
+* [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
+* [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
+
+
+## FastRTPS installation {#fast_rtps}
+
+[eProsima Fast RTPS](http://eprosima-fast-rtps.readthedocs.io/en/latest/) is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol.
+FastRTPS is used, via the [RTPS/ROS2 Interface: PX4-FastRTPS Bridge](../middleware/micrortps.md), to allow PX4 uORB topics to be shared with offboard components.
+
+The following instructions can be used to install the FastRTPS 1.7.1 binaries to your home directory.
+
+```sh
+wget https://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-1/eprosima_fastrtps-1-7-1-linux-tar-gz -O eprosima_fastrtps-1-7-1-linux.tar.gz
+tar -xzf eprosima_fastrtps-1-7-1-linux.tar.gz eProsima_FastRTPS-1.7.1-Linux/
+tar -xzf eprosima_fastrtps-1-7-1-linux.tar.gz requiredcomponents
+tar -xzf requiredcomponents/eProsima_FastCDR-1.0.8-Linux.tar.gz
+```
+
+> **Note** In the following lines where we compile the FastCDR and FastRTPS libraries, the `make` command is issued with the `-j2` option.
+  This option defines the number of parallel threads (or `j`obs) that are used to compile the source code. 
+  Change `-j2` to `-j<number_of_cpu_cores_in_your_system>` to speed up the compilation of the libraries.
+
+```sh
+(cd eProsima_FastCDR-1.0.8-Linux && ./configure --libdir=/usr/lib && make -j2 && sudo make install)
+(cd eProsima_FastRTPS-1.7.1-Linux && ./configure --libdir=/usr/lib && make -j2 && sudo make install)
+rm -rf requiredcomponents eprosima_fastrtps-1-7-1-linux.tar.gz
+```
+
+> **Note** More "generic" instructions, which additionally cover installation from source, can be found here: [Fast RTPS installation](../setup/fast-rtps-installation.md).
+
 
 ## Additional Tools
 

--- a/en/setup/fast-rtps-installation.md
+++ b/en/setup/fast-rtps-installation.md
@@ -1,8 +1,11 @@
 # Fast RTPS Installation
 
-<img src="../../assets/fastrtps/eprosima_logo.png" style="float:left;"/> [eProsima Fast RTPS](http://eprosima-fast-rtps.readthedocs.io/en/latest/) is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium. RTPS is also the wire interoperability protocol defined for the Data Distribution Service (DDS) standard, again by the OMG.
+<img src="../../assets/fastrtps/eprosima_logo.png" style="float:left;"/> [eProsima Fast RTPS](http://eprosima-fast-rtps.readthedocs.io/en/latest/) is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.
+RTPS is also the wire interoperability protocol defined for the Data Distribution Service (DDS) standard, again by the OMG.
 
-Fast RTPS is used by PX4 to enable an RTPS interface allowing PX4 uORB topics to be shared with offboard components, including robotics and simulator tools. RTPS is the underlying protocol of DDS, a standard from the OMG (Object Management Group) providing a real-time publish/subscribe middleware that is widely used in aerospace, defense and IoT applications. It has also been adopted as the middleware for the ROS2 robotics toolkit. For more information see: [RTPS/ROS2 Interface: PX4-FastRTPS Bridge](../middleware/micrortps.md).
+Fast RTPS is used by PX4 to enable an RTPS interface allowing PX4 uORB topics to be shared with offboard components, including robotics and simulator tools.
+RTPS is the underlying protocol of DDS, a standard from the OMG (Object Management Group) providing a real-time publish/subscribe middleware that is widely used in aerospace, defense and IoT applications. It has also been adopted as the middleware for the ROS2 robotics toolkit.
+For more information see: [RTPS/ROS2 Interface: PX4-FastRTPS Bridge](../middleware/micrortps.md).
 
 <span></span>
 > **Note** This topic is derived from the official [*eProsima Fast RTPS* documentation](http://eprosima-fast-rtps.readthedocs.io/en/latest/). For more information see:
@@ -15,7 +18,7 @@ Fast RTPS is used by PX4 to enable an RTPS interface allowing PX4 uORB topics to
 Fast RTPS is installed as part of the PX4 developer environment on some platforms:
 
 * [Development Environment on Mac](../setup/dev_env_mac.md) (FastRTPS included in common tools)
-* [Development Environment on Linux](../setup/dev_env_linux.md) (FastRTPS included in install scripts)
+* [Development Environment on Linux](../setup/dev_env_linux.md) (FastRTPS included in install ROS install script but not NuttX/Simulator script)
 * [Development Environment on Windows > Bash on Windows](../setup/dev_env_windows_bash_on_win.md) (FastRTPS included in install script)
 
 The instruction below are useful for adding FastRTPS support in other environments.
@@ -37,7 +40,8 @@ Java is required to use our built-in code generation tool - *fastrtpsgen*. [Java
 
 #### Visual C++ 2013 or 2015 Redistributable Package
 
-*eProsima Fast RTPS* requires the Visual C++ Redistributable packages for the Visual Studio version you chose during the installation or compilation. The installer gives you the option of downloading and installing them.
+*eProsima Fast RTPS* requires the Visual C++ Redistributable packages for the Visual Studio version you chose during the installation or compilation.
+The installer gives you the option of downloading and installing them.
 
 
 
@@ -59,10 +63,10 @@ $ cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON ..
 $ make
 $ sudo make install
 ```
-This will install Fast RTPS to `/usr/local`. You can use
-`-DCMAKE_INSTALL_PREFIX=<path>` to install to a custom location. Afterwards make
-sure the `fastrtpsgen` application is in your `PATH`. You can check with `which
-fastrtpsgen`.
+This will install Fast RTPS to `/usr/local`.
+You can use `-DCMAKE_INSTALL_PREFIX=<path>` to install to a custom location.
+Afterwards make sure the `fastrtpsgen` application is in your `PATH`.
+You can check with `which fastrtpsgen`.
 
 If you are on Windows, choose your version of *Visual Studio*:
 
@@ -73,7 +77,6 @@ If you are on Windows, choose your version of *Visual Studio*:
 If you want to compile the examples, you will need to add the argument `-DCOMPILE_EXAMPLES=ON` when calling *CMake*.
 
 If you want to compile the performance tests, you will need to add the argument `-DPERFORMANCE_TESTS=ON` when calling *CMake*.
-
 
 
 
@@ -100,7 +103,8 @@ These variables are set automatically by checking the corresponding box during t
 
 ### Linux
 
-Extract the contents of the package. It will contain both *eProsima Fast RTPS* and its required package *eProsima Fast CDR*. You will have follow the same procedure for both packages, starting with *Fast CDR*.
+Extract the contents of the package.
+It will contain both *eProsima Fast RTPS* and its required package *eProsima Fast CDR*. You will have follow the same procedure for both packages, starting with *Fast CDR*.
 
 Configure the compilation:
 


### PR DESCRIPTION
At high level this replaces the existing devguide scripts with ubuntu.sh. Note:
- New structure removes manual steps except where not covered in scripts from ubuntu docs.
- Old scripts replaced in doc, but not removed from tree (yet). Exception is ROS melodic script, which is not covered by ubuntu.sh. I did some tidy up of the old scripts to in order to remove installing firmware and also remove qtcreator.

Rendered version here: https://hamishwillee.gitbooks.io/havdevguide/content/v/pr_ubuntu_sh/en/setup/dev_env_linux_ubuntu.html

Also hoping to close some other things around the place - e.g. https://github.com/PX4/Firmware/issues/11024