### PR TITLE
reference design: Clarify the mixer when IO disabled

### DIFF
--- a/en/hardware/reference_design.md
+++ b/en/hardware/reference_design.md
@@ -33,7 +33,7 @@ The I/O board is disabled by setting parameter [SYS_USE_IO=0](../advanced/parame
 When the I/O board is disabled:
 - The MAIN mixer file is loaded into the FMU (so the "MAIN" outputs listed in the [Airframe Reference](../airframes/airframe_reference.md) appear on the port labeled AUX).
   The AUX mixer file isn't loaded, so outputs defined in this file are not used.
-- RC input goes direct to the FMU rather than via the IO board.
+- RC input goes directly to the FMU rather than via the IO board.
 
 Flight controllers without an I/O board have `MAIN` ports, but they *do not* have `AUX` ports.
 Consequently they can only be used in [airframes](../airframes/airframe_reference.md) that do not use `AUX` ports, or that only use them for non-essential purposes (e.g. RC passthrough).

--- a/en/hardware/reference_design.md
+++ b/en/hardware/reference_design.md
@@ -31,8 +31,9 @@ Some Pixhawk-series controllers are built without the I/O board in order to redu
 
 The I/O board is disabled by setting parameter [SYS_USE_IO=0](../advanced/parameter_reference.md#SYS_USE_IO).
 When the I/O board is disabled:
-- FMU outputs (usually "AUX") instead become the "MAIN" outputs.
-- RC input goes direct to the FMU.
+- The MAIN mixer file is loaded into the FMU (so the "MAIN" outputs listed in the [Airframe Reference](../airframes/airframe_reference.md) appear on the port labeled AUX).
+  THE AUX mixer file isn't loaded, so outputs defined in this file are not used.
+- RC input goes direct to the FMU rather than via the IO board.
 
 Flight controllers without an I/O board have `MAIN` ports, but they *do not* have `AUX` ports.
 Consequently they can only be used in [airframes](../airframes/airframe_reference.md) that do not use `AUX` ports, or that only use them for non-essential purposes (e.g. RC passthrough).

--- a/en/hardware/reference_design.md
+++ b/en/hardware/reference_design.md
@@ -32,7 +32,7 @@ Some Pixhawk-series controllers are built without the I/O board in order to redu
 The I/O board is disabled by setting parameter [SYS_USE_IO=0](../advanced/parameter_reference.md#SYS_USE_IO).
 When the I/O board is disabled:
 - The MAIN mixer file is loaded into the FMU (so the "MAIN" outputs listed in the [Airframe Reference](../airframes/airframe_reference.md) appear on the port labeled AUX).
-  THE AUX mixer file isn't loaded, so outputs defined in this file are not used.
+  The AUX mixer file isn't loaded, so outputs defined in this file are not used.
 - RC input goes direct to the FMU rather than via the IO board.
 
 Flight controllers without an I/O board have `MAIN` ports, but they *do not* have `AUX` ports.


### PR DESCRIPTION
This removes ambiguity about what happens when IO disabled by clarifying that the MAIN mixer file is loaded into the port labeled AUX.