### PR TITLE
Fix typo on vendor name

### DIFF
--- a/en/test_and_ci/test_flights.md
+++ b/en/test_and_ci/test_flights.md
@@ -46,7 +46,7 @@ Frame | Flight Controller | UUID
 [DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 4](https://docs.px4.io/en/flight_controller/pixhawk4.html) | 000200000000383339333038510700320016 (F450-v5)
 [DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 4 Mini](https://docs.px4.io/en/flight_controller/pixhawk4_mini.html) | 0002000000003432333830385115003a0033 (F450-v5-m)
 [DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) [UAVCAN](https://zubax.com/technologies/uavcan) | [Pixhawk 4](https://docs.px4.io/en/flight_controller/pixhawk4.html) | 000200000000323634353237511800200021 (F450-Pixhawk4)
-HoliBro [QAV250](https://docs.px4.io/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html) | [Pixhawk 4 Mini](https://docs.px4.io/en/flight_controller/pixhawk4_mini.html) |000200000000343233383038511500420032 (f450-v5-m)
+Holybro [QAV250](https://docs.px4.io/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html) | [Pixhawk 4 Mini](https://docs.px4.io/en/flight_controller/pixhawk4_mini.html) |000200000000343233383038511500420032 (f450-v5-m)
 NXP Semiconductor [KIT-HGDRONEK66](https://www.nxp.com/applications/solutions/industrial/unmanned-aerial-vehicles-uavs/uavs-drones-and-rovers/rddrone-fmuk66-px4-robotic-drone-fmu-reference-design:RDDRONE-FMUK66) ("[Hovergames](https://www.hovergames.com/)")| [RDDRONE-FMUK66](https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/k-seriesperformancem4/k6x-ethernet/rddrone-fmuk66-px4-robotic-drone-fmu-reference-design:RDDRONE-FMUK66?tid=vanRDDRONE-FMUK66) | 00030016ffffffffffff4e45362050130029
 
 Fixed Wing


### PR DESCRIPTION
http://www.holybro.com/

![](http://www.holybro.com/wp-content/uploads/2019/02/Holybro_lighter.jpg)
