### PR TITLE
params: multi-instance and yaml

### DIFF
--- a/en/advanced/parameters_and_configurations.md
+++ b/en/advanced/parameters_and_configurations.md
@@ -274,3 +274,21 @@ The purpose of each line is given below (for more detail see [module_schema.yaml
  * @group <a title for parameters that form a group>
  */
 ```
+
+### Multi-Instance (Templated) Meta Data {#multi_instance_metadata}
+
+Templated parameter definitions are supported in [YAML parameter definitions](https://github.com/PX4/Firmware/blob/master/validation/module_schema.yaml) (templated parameter code is not supported).
+
+The YAML allows you to define instance numbers in parameter names, descriptions, etc. using `${i}`.
+For example, below will generate MY_PARAM_1_RATE, MY_PARAM_2_RATE etc.
+```
+MY_PARAM_${i}_RATE:
+            description:
+                short: Maximum rate for instance ${i}
+```
+
+The following YAML definitions provide the start and end indexes. 
+- `num_instances` (default 1): Number of instances to generate (>=1)
+- `instance_start` (default 0): First instance number. If 0, `${i}` expands to [0, N-1]`.
+
+For a full example see the MAVLink parameter definitions: [/src/modules/mavlink/module.yaml](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/module.yaml)

--- a/en/advanced/parameters_and_configurations.md
+++ b/en/advanced/parameters_and_configurations.md
@@ -219,10 +219,14 @@ PX4 uses an extensive parameter metadata system to drive the user-facing present
 
 > **Tip** Correct meta data is critical for good user experience in a ground station.
 
-Parameter metadata can be stored anywhere in the source tree, in a file with extension **.c**.
+Parameter metadata can be stored anywhere in the source tree as either **.c** or **.yaml** parameter definitions (the YAML definition is newer, and more flexible).
 Typically it is stored alongside its associated module. 
 
 The build system extracts the metadata (using `make parameters_metadata`) to build the [parameter reference](../advanced/parameter_reference.md) and the parameter information used by ground stations.
+
+### c Parameter Metadata {#c_metadata}
+
+The legacy approach for defining parameter metadata is in a file with extension **.c** (at time of writing this is the approach most commonly used in the source tree).
 
 Parameter metadata sections look like the following examples:
 
@@ -275,7 +279,17 @@ The purpose of each line is given below (for more detail see [module_schema.yaml
  */
 ```
 
-### Multi-Instance (Templated) Meta Data {#multi_instance_metadata}
+### YAML Metadata {#yaml_metadata}
+
+> **Note** At time of writing YAML parameter definitions cannot be used in *libraries*.
+
+YAML meta data is intended as a full replacement for the **.c** definitions. 
+It supports all the same metadata, along with new features like multi-instance definitions.
+
+- The YAML parameter metadata schema is here: [validation/module_schema.yaml](https://github.com/PX4/Firmware/blob/master/validation/module_schema.yaml).
+- An example of YAML definitions being used can be found in the MAVLink parameter definitions: [/src/modules/mavlink/module.yaml](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/module.yaml).
+
+#### Multi-Instance (Templated) Meta Data {#multi_instance_metadata}
 
 Templated parameter definitions are supported in [YAML parameter definitions](https://github.com/PX4/Firmware/blob/master/validation/module_schema.yaml) (templated parameter code is not supported).
 


### PR DESCRIPTION
This follows on from discussion that multi-instance params are not documented: https://github.com/PX4/Firmware/pull/12551#issuecomment-555281171

@bkueng This is a starting point covering just multi-instance. However reading over this, the very existance of yaml parameter instances is not covered - currently everything is about documenting in the .c file. We need full docs.

My understanding is that the YAML format is
- an alternative to using a .c file.
- It must follow the format defined in https://github.com/PX4/Firmware/blob/master/validation/module_schema.yaml
- It allows extra stuff like multi-instance. Anything else?
- Any limitations? ie can you do anything with .c format you can't with this. Timmy mentioned something about problems with parameters that are defined in libraries "since some parameters are defined outside of a module (in the battery library)."

Do you want to write that/extend this? Then I subedit?