### PR TITLE
Re-order AUTOPILOT_HOST steps for Raspberry Pi Boards

### DIFF
--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -179,6 +179,19 @@ The command below builds the target for [Raspberry Pi 2/3 Navio2](https://docs.p
 
 #### Cross-compiler Build
 
+Set the IP (or hostname) of your RPi using:
+
+```sh
+export AUTOPILOT_HOST=192.168.X.X
+```
+or
+```sh
+export AUTOPILOT_HOST=pi_hostname.domain
+```
+* The value of the environment variable is incorporated during the build process so it should be set before the build or 'make upload' will fail to find your RPi.
+
+Build the executable file:
+
 ```sh
 cd Firmware
 make emlid_navio2_cross # for cross-compiler build
@@ -187,13 +200,7 @@ make emlid_navio2_cross # for cross-compiler build
 The "px4" executable file is in the directory **build/emlid_navio2_cross/**.
 Make sure you can connect to your RPi over ssh, see [instructions how to access your RPi](https://docs.px4.io/master/en/flight_controller/raspberry_pi_navio2.html#developer-quick-start).
 
-Then set the IP (or hostname) of your RPi using:
-
-```sh
-export AUTOPILOT_HOST=192.168.X.X
-```
-
-And upload it with:
+Then upload it with:
 
 ```sh
 cd Firmware


### PR DESCRIPTION
Move 'export AUTOPILOT_HOST' to before build to ensure hostname is incorporate in the build so 'make upload' doesn't fail.