### PR TITLE
jmavsim: Fix up detail on system startup

### DIFF
--- a/en/simulation/jmavsim.md
+++ b/en/simulation/jmavsim.md
@@ -140,7 +140,7 @@ The simulation can be [interfaced to ROS](../simulation/ros_interface.md) the sa
 
 ## Important Files
 
-* The startup script is in the [posix-configs/SITL/init](https://github.com/PX4/Firmware/tree/master/posix-configs/SITL/init) folder and named `rcS_SIM_AIRFRAME`, the default is `rcS_jmavsim_iris`.
+* The startup scripts are discussed in [System Startup](../concept/system_startup.md).
 * The simulated root file system ("`/`" directory) is created inside the build directory here: `build/px4_sitl_default/tmp/rootfs`.
 
 ## Troubleshooting


### PR DESCRIPTION
The startup script behaviour for posix changed. This refers to the docs on the subject rather than the defunct files.