### PR TITLE
[WIP] Add camera zoom to control group 2

### DIFF
--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -60,7 +60,7 @@ For a multicopter things are a bit different: control 0 (roll) is connected to a
 * 1: gimbal pitch
 * 2: gimbal yaw
 * 3: gimbal shutter
-* 4: reserved
+* 4: camera zoom
 * 5: reserved
 * 6: reserved
 * 7: reserved (parachute, -1..1)


### PR DESCRIPTION
Some cameras allow to control the zoom with PWM. So it makes sense to add the zoom to the actuator controls/outputs. A first implementation for handling mavlinks SET_CAMERA_ZOOM can be found in https://github.com/PX4/Firmware/pull/13681

- [x] Pending https://github.com/PX4/Firmware/pull/13681 merged.