### PR TITLE
Include javascript ulog parser

### DIFF
--- a/en/log/ulog_file_format.md
+++ b/en/log/ulog_file_format.md
@@ -357,6 +357,7 @@ A valid ULog parser must fulfill the following requirements:
 - [mavlink-router](https://github.com/01org/mavlink-router): C++, ULog streaming via MAVLink.
 - [MAVGAnalysis](https://github.com/ecmnet/MAVGCL): Java, ULog streaming via MAVLink and parser for plotting and analysis.
 - [PlotJuggler](https://github.com/facontidavide/PlotJuggler): C++/Qt application to plot logs and time series. Supports ULog since version 2.1.3.
+- [ulogreader](https://github.com/maxsun/ulogreader): Javascript, ULog reader and parser outputs log in JSON object format.  
 
 
 ## File Format Version History


### PR DESCRIPTION
Added line in Known Implementations for ulogreader by maxsun (https://github.com/maxsun/ulogreader). JavaScript code for reading and parsing ULog to JSON object. Well written code with that also includes an example of its implementation.