### PR TITLE
Update dev_mac ulimit

### DIFF
--- a/en/setup/dev_env_mac.md
+++ b/en/setup/dev_env_mac.md
@@ -12,7 +12,7 @@ MacOS is a supported development platform for PX4. The following instructions se
 
 Increase the maximum allowed number of open files on macOS using the *Terminal* command:
 ```sh
-ulimit -S -n 300
+ulimit -S -n 2048
 ```
 
 > **Note**  At time of writing (December 2018) the master branch uses more than the default maximum allowed open files on macOS (256 in all running processes).


### PR DESCRIPTION
The maximum allowed number of open files on macOS needs to be increased even further to 2048. See thread https://discuss.px4.io/t/errors-about-too-many-open-files/9150