### PR TITLE
Add instructions to simulate multi vehicles without ROS

### DIFF
--- a/en/simulation/multi-vehicle-simulation.md
+++ b/en/simulation/multi-vehicle-simulation.md
@@ -6,12 +6,13 @@ A different approach is used for simulation with and without ROS.
 
 ## Multiple Vehicle with Gazebo (No ROS) {#no_ros}
 
-To launch multiple vehicles in Gazebo (without ROS) use the following commands in the terminal (from the root of the *Firmware* tree):
+To simulate (up to 10) iris or plane vehicles in Gazebo use the following commands in the terminal (from the root of the *Firmware* tree):
 ```
-Tools/gazebo_sitl_multiple_run.sh [-m <model>] -n <number_of_vehicles>
+Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>]
 ```
 
-The `<model>` flag specifies which model to spawn: `iris` (default), `plane`.
+- `<model>`: The vehicle type/model to spawn: `iris` (default), `plane`.
+- `number_of_vehicles`: The number of vehicles to spawn. Default is 3. Maximum is 10.
 
 
 ### Video: Multiple Multicopter (Iris)

--- a/en/simulation/multi-vehicle-simulation.md
+++ b/en/simulation/multi-vehicle-simulation.md
@@ -6,7 +6,7 @@ A different approach is used for simulation with and without ROS.
 
 ## Multiple Vehicle with Gazebo (No ROS) {#no_ros}
 
-To simulate (up to 10) iris or plane vehicles in Gazebo use the following commands in the terminal (from the root of the *Firmware* tree):
+To simulate multiple iris or plane vehicles in Gazebo use the following commands in the terminal (from the root of the *Firmware* tree):
 ```
 Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>]
 ```
@@ -14,7 +14,10 @@ Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>]
 - `<model>`: The vehicle type/model to spawn: `iris` (default), `plane`.
 - `number_of_vehicles`: The number of vehicles to spawn. Default is 3. Maximum is 10.
 
-Each vehicle instance is allocated a unique MAVLink system id (1, 2, 3, etc) and can be accessed from a unique UDP port (14540, 14541, 14542, etc.).
+Each vehicle instance is allocated a unique MAVLink system id (1, 2, 3, etc.) and can be accessed from a unique remote offboard UDP port (14540, 14541, 14542, etc.).
+
+> **Note** The 10-vehicle limitation occurs because the 11th vehicle would be allocated a remote offboard UDP port 14550, which is already used for QGC.
+  The `MAV_SYS_ID` and various UDP ports are allocated in the SITL rcS: [init.d-posix/rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS#L108-L112)
 
 ### Video: Multiple Multicopter (Iris)
 

--- a/en/simulation/multi-vehicle-simulation.md
+++ b/en/simulation/multi-vehicle-simulation.md
@@ -14,6 +14,7 @@ Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>]
 - `<model>`: The vehicle type/model to spawn: `iris` (default), `plane`.
 - `number_of_vehicles`: The number of vehicles to spawn. Default is 3. Maximum is 10.
 
+Each vehicle instance is allocated a unique MAVLink system id (1, 2, 3, etc) and can be accessed from a unique UDP port (14540, 14541, 14542, etc.).
 
 ### Video: Multiple Multicopter (Iris)
 

--- a/en/simulation/multi-vehicle-simulation.md
+++ b/en/simulation/multi-vehicle-simulation.md
@@ -1,27 +1,37 @@
 # Multi-Vehicle Simulation with Gazebo
 
 This topic explains how to simulate multiple UAV vehicles using Gazebo and SITL (Linux only).
+A different approach is used for simulation with and without ROS.
 
-> **Tip** If you don't need a feature provided by Gazebo or ROS, [Multi-Vehicle Simulation with JMAVSim](../simulation/multi_vehicle_jmavsim.md) is easier to set up.
 
-It demonstrates an example setup that opens the Gazebo client GUI showing two Iris vehicles in an empty world.
+## Multiple Vehicle with Gazebo (No ROS) {#no_ros}
+
+To launch multiple vehicles in Gazebo (without ROS) use the following commands in the terminal (from the root of the *Firmware* tree):
+```
+Tools/gazebo_sitl_multiple_run.sh [-m <model>] -n <number_of_vehicles>
+```
+
+The `<model>` flag specifies which model to spawn: `iris` (default), `plane`.
+
+
+### Video: Multiple Multicopter (Iris)
+
+{% youtube %}
+https://youtu.be/Mskx_WxzeCk
+{% endyoutube %}
+
+### Video: Multiple Plane
+
+{% youtube %}
+https://youtu.be/aEzFKPMEfjc
+{% endyoutube %}
+
+
+## Multiple Vehicles with ROS and Gazebo {#with_ros}
+
+This example demonstrates a setup that opens the Gazebo client GUI showing two Iris vehicles in an empty world.
 You can then control the vehicles with *QGroundControl* and MAVROS in a similar way to how you would manage a single vehicle.
 
-## Multiple vehicles without ROS
-
-```
-   cd Firmware_clone
-   Tools/gazebo_sitl_multiple_run.sh -m <model> -n <number_of_vehicles>
-```
-
-The `<model>` flag specifies which model to spawn. Currently the following models are supported
-- iris
-- plane
-
-  > **Note** If `-m <model>` is omitted, `iris` model will be launched by deafault.
-
-
-## Launching with ROS
 ### Required
 
 * Current [PX4 ROS/Gazebo development environment](../setup/dev_env_linux_ubuntu.md#rosgazebo)

--- a/en/simulation/multi-vehicle-simulation.md
+++ b/en/simulation/multi-vehicle-simulation.md
@@ -7,7 +7,22 @@ This topic explains how to simulate multiple UAV vehicles using Gazebo and SITL 
 It demonstrates an example setup that opens the Gazebo client GUI showing two Iris vehicles in an empty world.
 You can then control the vehicles with *QGroundControl* and MAVROS in a similar way to how you would manage a single vehicle.
 
-## Required
+## Multiple vehicles without ROS
+
+```
+   cd Firmware_clone
+   Tools/gazebo_sitl_multiple_run.sh -m <model> -n <number_of_vehicles>
+```
+
+The `<model>` flag specifies which model to spawn. Currently the following models are supported
+- iris
+- plane
+
+  > **Note** If `-m <model>` is omitted, `iris` model will be launched by deafault.
+
+
+## Launching with ROS
+### Required
 
 * Current [PX4 ROS/Gazebo development environment](../setup/dev_env_linux_ubuntu.md#rosgazebo)
   > **Note** At time of writing this is Ubuntu 18.04 with ROS Melodic/Gazebo 9.
@@ -15,7 +30,7 @@ You can then control the vehicles with *QGroundControl* and MAVROS in a similar 
 * [MAVROS package](http://wiki.ros.org/mavros)
 * a clone of latest [PX4/Firmware](https://github.com/PX4/Firmware)
 
-## Build and Test
+### Build and Test
 
 To build an example setup, follow the step below:
 
@@ -46,7 +61,7 @@ You can control the vehicles with *QGroundControl* or MAVROS in a similar way to
 
 
 
-## What's Happening?
+### What's Happening?
 
 For each simulated vehicle, the following is required:
 


### PR DESCRIPTION
This describes the instructions on launching multi vehicle simulation without ROS from https://github.com/PX4/Firmware/pull/13806 https://github.com/PX4/Firmware/pull/13729 [Note, don't merge until these in]

@hamishwillee It would be nice if I can add videos examples as the following. How do you suggest that we can do this?
- [multiple iris gazebo sitl](https://youtu.be/Mskx_WxzeCk)
- [multiple plane gazebo sitl](https://youtu.be/aEzFKPMEfjc)
