### PR TITLE
Devenv - use get-pip to get pip.

### DIFF
--- a/en/setup/dev_env_mac.md
+++ b/en/setup/dev_env_mac.md
@@ -44,7 +44,11 @@ brew cask install xquartz java
 Install pip if you don't already have it and use it to install the required packages:
 
 ```sh
-sudo easy_install pip
+# get pip
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python get-pip.py
+
+#install required packages
 sudo -H pip install pyserial empy toml numpy pandas jinja2 pyyaml
 ```
 

--- a/en/setup/dev_env_mac.md
+++ b/en/setup/dev_env_mac.md
@@ -48,7 +48,7 @@ Install pip if you don't already have it and use it to install the required pack
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python get-pip.py
 
-#install required packages
+# install required packages
 sudo -H pip install pyserial empy toml numpy pandas jinja2 pyyaml
 ```
 


### PR DESCRIPTION
easy_intstall usually used to get pip on systems that don't have it. But this is now deprecated. Update to use the recommended method.