### PR TITLE
setup: use bash instead of source

### DIFF
--- a/en/setup/dev_env_linux_arch.md
+++ b/en/setup/dev_env_linux_arch.md
@@ -13,13 +13,13 @@ To get and run the scripts, do either of:
 * [Download PX4 Source Code](../setup/building_px4.md) and run the scripts in place:
   ```
   git clone https://github.com/PX4/Firmware.git
-  source Firmware/Tools/setup/arch.sh
+  bash Firmware/Tools/setup/arch.sh
   ```
 * Download just the needed scripts and then run them:
   ```sh
   wget https://raw.githubusercontent.com/PX4/Firmware/master/Tools/setup/arch.sh
   wget https://raw.githubusercontent.com/PX4/Firmware/master/Tools/setup/requirements.txt
-  source arch.sh
+  bash arch.sh
   ```
 
 The script takes the following optional parameters:

--- a/en/setup/dev_env_linux_ubuntu.md
+++ b/en/setup/dev_env_linux_ubuntu.md
@@ -24,7 +24,7 @@ To install the toolchain:
    <br>`wget https://raw.githubusercontent.com/PX4/Firmware/{{ book.px4_version }}/Tools/setup/requirements.txt`
 1. Run the **ubuntu.sh** with no arguments (in a bash shell) to install everything:
    ```bash
-   source ubuntu.sh
+   bash ubuntu.sh
    ```
    - Acknowledge any prompts as the script progress.
    - You can use the `--no-nuttx` and `--no-sim-tools` to omit the nuttx and/or simulation tools.
@@ -34,7 +34,7 @@ To install the toolchain:
 > **Note** You can alternatively [Download PX4 Source Code](../setup/building_px4.md) and run the scripts in place:
   ```
   git clone https://github.com/PX4/Firmware.git
-  source Firmware/Tools/setup/ubuntu.sh
+  bash Firmware/Tools/setup/ubuntu.sh
   ```
 
 Notes:
@@ -44,7 +44,7 @@ Notes:
 - You can verify the the NuttX installation by confirming the gcc version as shown:
   ```bash
    $arm-none-eabi-gcc --version
-   
+
    arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 7-2017-q4-major) 7.2.1 20170904 (release) [ARM/embedded-7-branch revision 255204]
    Copyright (C) 2017 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
@@ -70,10 +70,10 @@ To get the build toolchain for Raspberry Pi:
    <br>`wget https://raw.githubusercontent.com/PX4/Firmware/{{ book.px4_version }}/Tools/setup/requirements.txt`
 1. Run **ubuntu.sh** in a terminal to get just the common dependencies:
    ```bash
-   source ubuntu.sh --no-nuttx --no-sim-tools
+   bash ubuntu.sh --no-nuttx --no-sim-tools
    ```
 1. Then setup an ARMv7 cross-compiler (either GCC or clang) as described in the following sections.
- 
+
 ### GCC
 
 The current recommended toolchain for raspbian can be cloned from `https://github.com/raspberrypi/tools.git` (at time of writing 4.9.3).
@@ -134,11 +134,11 @@ To install the development toolchain:
    <br>`wget https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_melodic.sh`
 1. Run the script:
    ```bash
-   source ubuntu_sim_ros_melodic.sh
+   bash ubuntu_sim_ros_melodic.sh
    ```
    You may need to acknowledge some prompts as the script progresses.
 
-Note: 
+Note:
 * ROS Melodic is installed with Gazebo9 by default.
 * Your catkin (ROS build system) workspace is created at **~/catkin_ws/**.
 * The script uses instructions from the ROS Wiki "Melodic" [Ubuntu page](http://wiki.ros.org/melodic/Installation/Ubuntu).
@@ -168,7 +168,7 @@ tar -xzf requiredcomponents/eProsima_FastCDR-1.0.8-Linux.tar.gz
 ```
 
 > **Note** In the following lines where we compile the FastCDR and FastRTPS libraries, the `make` command is issued with the `-j2` option.
-  This option defines the number of parallel threads (or `j`obs) that are used to compile the source code. 
+  This option defines the number of parallel threads (or `j`obs) that are used to compile the source code.
   Change `-j2` to `-j<number_of_cpu_cores_in_your_system>` to speed up the compilation of the libraries.
 
 ```sh

--- a/en/setup/dev_env_windows_bash_on_win.md
+++ b/en/setup/dev_env_windows_bash_on_win.md
@@ -3,7 +3,7 @@
 > **Note** The [Windows Cygwin Toolchain](../setup/dev_env_windows_cygwin.md) is the (only) officially supported toolchain for Windows development.
 
 Windows users can alternatively install a *slightly modified* Ubuntu Linux PX4 development environment within [Bash on Windows](https://github.com/Microsoft/BashOnWindows), and use it to:
-* Build firmware for NuttX/Pixhawk targets. 
+* Build firmware for NuttX/Pixhawk targets.
 * Run the PX4 JMAVSim simulation (using a Windows-hosted X-Windows app to display the UI)
 
 > **Note** This mechanism only works on Windows 10. It essentially runs the toolchain in a virtual machine, and is relatively slow compared to other solutions.
@@ -15,14 +15,14 @@ The easiest way to setup the environment is to use the <strong><a href="https://
 
 To setup the development environment:
 1. Install [Bash on Windows](https://github.com/Microsoft/BashOnWindows).
-1. Open the bash shell. 
+1. Open the bash shell.
 1. Download the **windows_bash_nuttx.sh**:<br>
    `wget https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/windows_bash_nuttx.sh`
 1. Run the script using the command below (acknowledging any prompts as required):
   ```sh
-  source windows_bash_nuttx.sh
+  bash windows_bash_nuttx.sh
   ```
-  
+
 ### Build Firmware
 
 To build the firmware (i.e. for px4_fmu-v4):
@@ -32,9 +32,9 @@ To build the firmware (i.e. for px4_fmu-v4):
    make px4_fmu-v4_default
    ```
    On successful completion you'll find the firmware here: `Firmware/build/px4_fmu-v4_default/px4_fmu-v4_default.px4`
-   
+
    > **Note** The `make` commands to build firmware for other boards can be found in [Building the Code](../setup/building_px4.md#nuttx)
-   
+
 1. You can flash the custom firmware on Windows using *QGroundControl* or *Mission Planner* (it is not possible to directly flash the firmware from within the bash shell using the `upload` command).
 
 
@@ -54,9 +54,9 @@ To run JMAVSim:
    make px4_sitl jmavsim
    ```
    The JMAVSim UI is then displayed in XMing as shown below:
-   
+
    ![jMAVSimOnWindows](../../assets/simulation/JMAVSim_on_Windows.PNG)
-   
+
 > **Caution** Gazebo can similarly be run within Ubuntu Bash for Windows, but too slow to be useful. To try this, follow the [ROS kinetic install guide](http://wiki.ros.org/kinetic/Installation/Ubuntu) and run Gazebo in the Bash shell as shown:
   ```sh
   export DISPLAY=:0
@@ -67,9 +67,9 @@ To run JMAVSim:
 
 ### Build Script Details {#build_script_details}
 
-The <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/windows_bash_nuttx.sh">windows_bash_nuttx.sh</a> build script modifies the Ubuntu build instructions to remove Ubuntu-specific and UI-dependent components, including the *Qt Creator* IDE and the simulators. 
+The <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/windows_bash_nuttx.sh">windows_bash_nuttx.sh</a> build script modifies the Ubuntu build instructions to remove Ubuntu-specific and UI-dependent components, including the *Qt Creator* IDE and the simulators.
 
-In addition, it uses a [64 bit arm-none-eabi compiler](https://github.com/SolinGuo/arm-none-eabi-bash-on-win10-.git) 
+In addition, it uses a [64 bit arm-none-eabi compiler](https://github.com/SolinGuo/arm-none-eabi-bash-on-win10-.git)
 since BashOnWindows doesn't run 32 bit ELF programs (and the default compiler from `https://launchpad.net/gcc-arm-embedded` is 32 bit).
 
 To add this compiler to your environment manually:


### PR DESCRIPTION
As far as I know the command source is usually to include functions and variables defined in a script but not to run script.

I find it more intuitive to use bash to call a script.