### PR TITLE
Fix up helloworld to use correct location for log file

### DIFF
--- a/en/apps/hello_sky.md
+++ b/en/apps/hello_sky.md
@@ -1,8 +1,10 @@
 # First Application Tutorial (Hello Sky)
 
-This topic explains how to create and run your first onboard application. It covers all the basic concepts and APIs required for app development on PX4.
+This topic explains how to create and run your first onboard application.
+It covers all the basic concepts and APIs required for app development on PX4.
 
-> **Note** For simplicity, more advanced features like start/stop functionality and command-line arguments are omitted. These are covered in [Application/Module Template](../apps/module_template.md).
+> **Note** For simplicity, more advanced features like start/stop functionality and command-line arguments are omitted.
+These are covered in [Application/Module Template](../apps/module_template.md).
 
 
 ## Prerequisites
@@ -17,17 +19,19 @@ The source code [Firmware/src/examples/px4_simple_app](https://github.com/PX4/Fi
 
 ## Minimal Application
 
-In this section we create a *minimal application* that just prints out `Hello Sky!`. This consists of a single *C* file and a *cmake* definition (which tells the toolchain how to build the application). 
+In this section we create a *minimal application* that just prints out `Hello Sky!`.
+This consists of a single *C* file and a *cmake* definition (which tells the toolchain how to build the application).
 
 1. Create a new directory **Firmware/src/examples/px4_simple_app**.
 1. Create a new C file in that directory named **px4_simple_app.c**:
 
-   * Copy in the default header to the top of the page. This should be present in all contributed files!
+   * Copy in the default header to the top of the page.
+     This should be present in all contributed files!
 
      ```c
      /****************************************************************************
       *
-      *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+      *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
       *
       * Redistribution and use in source and binary forms, with or without
       * modification, are permitted provided that the following conditions
@@ -59,7 +63,8 @@ In this section we create a *minimal application* that just prints out `Hello Sk
       ****************************************************************************/
      ```
 
-   * Copy the following code below the default header. This code style should be used for all files.
+   * Copy the following code below the default header.
+     This should be present in all contributed files!
 
      ```c
      /**
@@ -68,24 +73,26 @@ In this section we create a *minimal application* that just prints out `Hello Sk
       *
       * @author Example User <mail@example.com>
       */
-
-     #include <px4_log.h>
-
+     
+     #include <px4_platform_common/log.h>
+     
      __EXPORT int px4_simple_app_main(int argc, char *argv[]);
-
+     
      int px4_simple_app_main(int argc, char *argv[])
      {
      	PX4_INFO("Hello Sky!");
      	return OK;
      }
      ```
-
+     
      > **Tip** The main function must be named `<module_name>_main` and exported from the module as shown.
      
      <span></span>
-     > **Tip** `PX4_INFO` is the equivalent of `printf` for the PX4 shell (included from **px4_log.h**). There are different log levels: `PX4_INFO`, `PX4_WARN`, `PX4_ERR`, `PX4_DEBUG`. Warnings and errors are additionally added to the [ULog](../log/ulog_file_format.md) and shown on [Flight Review](https://logs.px4.io/).
+     > **Tip** `PX4_INFO` is the equivalent of `printf` for the PX4 shell (included from **px4_platform_common/log.h**).
+       There are different log levels: `PX4_INFO`, `PX4_WARN`, `PX4_ERR`, `PX4_DEBUG`.
+       Warnings and errors are additionally added to the [ULog](../log/ulog_file_format.md) and shown on [Flight Review](https://logs.px4.io/).
 
-1. Create and open a new *cmake* definition file named **CMakeLists.txt**. 
+1. Create and open a new *cmake* definition file named **CMakeLists.txt**.
    Copy in the text below:
    ```cmake
    ############################################################################
@@ -129,11 +136,12 @@ In this section we create a *minimal application* that just prints out `Hello Sk
    	DEPENDS
    	)
    ```
-   The `px4_add_module()` method builds a static library from a module description. 
+   The `px4_add_module()` method builds a static library from a module description.
    The `MAIN` block lists the name of the module - this registers the command with NuttX so that it can be called from the PX4 shell or SITL console.
    
    > **Tip** The `px4_add_module()` format is documented in [Firmware/cmake/px4_add_module.cmake](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/cmake/px4_add_module.cmake).
    
+   <span></span>
    > **Note**
    > If you specify `DYNAMIC` as an option to `px4_add_module`, a *shared library* is created instead of a static library on POSIX platforms (these can be loaded without having to recompile PX4, and shared to others as binaries rather than source code).
    > Your app will not become a builtin command, but ends up in a separate file called `examples__px4_simple_app.px4mod`.
@@ -141,7 +149,8 @@ In this section we create a *minimal application* that just prints out `Hello Sk
 
 ## Build the Application/Firmware
 
-The application is now complete. In order to run it you first need to make sure that it is built as part of PX4. 
+The application is now complete.
+In order to run it you first need to make sure that it is built as part of PX4.
 Applications are added to the build/firmware in the appropriate board-level *cmake* file for your target: 
 
 * PX4 SITL (Simulator): [Firmware/boards/px4/sitl/default.cmake](https://github.com/PX4/Firmware/blob/master/boards/px4/sitl/default.cmake)
@@ -224,7 +233,8 @@ Builtin Apps:
   serdis
 ```
 
-Note that `px4_simple_app` is now part of the available commands. Start it by typing `px4_simple_app` and ENTER:
+Note that `px4_simple_app` is now part of the available commands.
+Start it by typing `px4_simple_app` and ENTER:
 
 ```sh
 nsh> px4_simple_app
@@ -235,7 +245,7 @@ The application is now correctly registered with the system and can be extended 
 
 ## Test App (SITL)
 
-If you're using SITL the *PX4 console* is automatically started (see [Building the Code > First Build (Using the jMAVSim Simulator)](../setup/building_px4.md#jmavsim_build)). 
+If you're using SITL the *PX4 console* is automatically started (see [Building the Code > First Build (Using the jMAVSim Simulator)](../setup/building_px4.md#jmavsim_build)).
 As with the *nsh console* (see previous section) you can type `help` to see the list of built-in apps.
 
 Enter `px4_simple_app` to run the minimal app.
@@ -250,9 +260,10 @@ The application can now be extended to actually perform useful tasks.
 
 ## Subscribing to Sensor Data
 
-To do something useful, the application needs to subscribe inputs and publish outputs (e.g. motor or servo commands). 
+To do something useful, the application needs to subscribe inputs and publish outputs (e.g. motor or servo commands).
 
-> **Tip** The benefits of the PX4 hardware abstraction comes into play here! There is no need to interact in any way with sensor drivers and no need to update your app if the board or sensors are updated.
+> **Tip** The benefits of the PX4 hardware abstraction comes into play here!
+  There is no need to interact in any way with sensor drivers and no need to update your app if the board or sensors are updated.
 
 Individual message channels between applications are called [topics](../middleware/uorb.md). For this tutorial, we are interested in the [sensor_combined](https://github.com/PX4/Firmware/blob/master/msg/sensor_combined.msg) topic, which holds the synchronized sensor data of the complete system.
 
@@ -264,7 +275,9 @@ Subscribing to a topic is straightforward:
 int sensor_sub_fd = orb_subscribe(ORB_ID(sensor_combined));
 ```
 
-The `sensor_sub_fd` is a topic handle and can be used to very efficiently perform a blocking wait for new data. The current thread goes to sleep and is woken up automatically by the scheduler once new data is available, not consuming any CPU cycles while waiting. To do this, we use the [poll()](http://pubs.opengroup.org/onlinepubs/007908799/xsh/poll.html) POSIX system call.
+The `sensor_sub_fd` is a topic handle and can be used to very efficiently perform a blocking wait for new data.
+The current thread goes to sleep and is woken up automatically by the scheduler once new data is available, not consuming any CPU cycles while waiting.
+To do this, we use the [poll()](http://pubs.opengroup.org/onlinepubs/007908799/xsh/poll.html) POSIX system call.
 
 Adding `poll()` to the subscription looks like (*pseudocode, look for the full implementation below*):
 
@@ -325,7 +338,8 @@ Your app will display 5 sensor values in the console and then exit:
 
 ## Publishing Data
 
-To use the calculated outputs, the next step is to *publish* the results. Below we show how to publish the attitude topic.
+To use the calculated outputs, the next step is to *publish* the results.
+Below we show how to publish the attitude topic.
 
 > **Note** We've chosen `attitude` because we know that the *mavlink* app forwards it to the ground control station - providing an easy way to look at the results.
 
@@ -353,7 +367,7 @@ The [complete example code](https://github.com/PX4/Firmware/blob/master/src/exam
 ```c
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -391,9 +405,9 @@ The [complete example code](https://github.com/PX4/Firmware/blob/master/src/exam
  * @author Example User <mail@example.com>
  */
 
-#include <px4_config.h>
-#include <px4_tasks.h>
-#include <px4_posix.h>
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/tasks.h>
+#include <px4_platform_common/posix.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <poll.h>
@@ -494,9 +508,9 @@ If you start *QGroundControl*, you can check the sensor values in the real time 
 
 ## Wrap-Up
 
-This tutorial covered everything needed to develop a basic PX4 autopilot application. Keep in mind that the full list of uORB messages/topics is [available here](https://github.com/PX4/Firmware/tree/master/msg/) and that the headers are well documented and serve as reference.
+This tutorial covered everything needed to develop a basic PX4 autopilot application.
+Keep in mind that the full list of uORB messages/topics is [available here](https://github.com/PX4/Firmware/tree/master/msg/) and that the headers are well documented and serve as reference.
 
 Further information and troubleshooting/common pitfalls can be found here: [uORB](../middleware/uorb.md).
 
 The next page presents a template for writing a full application with start and stop functionality.
-


### PR DESCRIPTION
@bkueng Following up from https://github.com/PX4/Devguide/pull/921#issuecomment-574102667 the only other instance of the following that I found was px4_log.h (by search).
```
#include <px4_log.h> -> #include <px4_platform_common/log.h>
#include <px4_config.h> -> #include <px4_platform_common/px4_config.h>
#include <px4_tasks.h> -> #include <px4_platform_common/tasks.h>
#include <px4_posix.h> -> #include <px4_platform_common/posix.h>
```
I've updated that in the example and merged. If you find others, let me know!