### PR TITLE
Updates GPS failsafe description

### DIFF
--- a/en/simulation/failsafes.md
+++ b/en/simulation/failsafes.md
@@ -43,5 +43,5 @@ To control how fast the battery depletes to the minimal value use the parameter 
 
 ## GPS Loss
 
-To make simulate losing and regaining GPS information you can just stop/restart the GPS driver.
-This is done by running the `gpssim stop` and `gpssim start` commands on your SITL instance *pxh shell*.
+To simulate losing and regaining GPS information you can just stop the publication of GPS messages.
+This is done by running the `param set SIM_GPS_BLOCK 1` and `param set SIM_GPS_BLOCK 0` commands on your SITL instance *pxh shell* to block and unblock messages respectively.


### PR DESCRIPTION
With the removal of DriverFramework there is now a new way to simulate GPS failure through the SIM_X_BLOCK parameter, so this just updates the documentation to reflect that.