### PR TITLE
uorb_graph: disable this page for now

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -62,7 +62,6 @@
   * [Companion Computers](companion_computer/pixhawk_companion.md)
 * [Middleware](middleware/README.md)
   * [uORB Messaging](middleware/uorb.md)
-  * [uORB Graph](middleware/uorb_graph.md)
   * [MAVLink Messaging](middleware/mavlink.md)
   * [RTPS/ROS2 Interface](middleware/micrortps.md)
     * [Throughput Test](middleware/micrortps_throughput_test.md)

--- a/en/middleware/uorb_graph.md
+++ b/en/middleware/uorb_graph.md
@@ -1,4 +1,7 @@
 # uORB Publication/Subscription Graph
+<!--
+Note: this page is disabled for now, as the graph is too incomplete and requires support for uORB::Subscription, uORB::Publication and library code
+-->
 
 This page provides a uORB publication/subscription graph that
 shows the communication between modules. It is based on information that is


### PR DESCRIPTION
It has become less and less complete due to:
- switching API to uORB::Subscription and uORB::Publication
- increasing amount of libraries that use uORB

Both are solvable by extending the parser, but requires some effort, so we don't remove it completely.