### PR TITLE
jmavsim: add Java > 8 error to troubleshoot

### DIFF
--- a/en/simulation/jmavsim.md
+++ b/en/simulation/jmavsim.md
@@ -194,6 +194,20 @@ rm -rf Tools/jMAVSim/out
 
 Alternatively you could [download Oracle Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and install it manually.
 
+### An illegal reflective access operation has occured
+
+If you see an error similar to the one below, it's likely that you're using a Java version later than 8:
+
+```
+WARNING: An illegal reflective access operation has occurred
+WARNING: Illegal reflective access by javax.media.j3d.JoglPipeline (rsrc:j3dcore.jar) to method sun.awt.AppContext.getAppContext()
+WARNING: Please consider reporting this to the maintainers of javax.media.j3d.JoglPipeline
+WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+WARNING: All illegal access operations will be denied in a future release
+Inconsistency detected by ld.so: dl-lookup.c: 112: check_match: Assertion version->filename == NULL || ! _dl_name_match_p (version->filename, map)' failed!
+```
+
+Follow the steps above to make sure Java 8 is installed and selected.
 
 ### java.awt.AWTError: Assistive Technology not found: org.GNOME.Accessibility.AtkWrapper
 


### PR DESCRIPTION
This adds an error case happening with Ubuntu 18.04 that we previously missed.