### PR TITLE
test_and_ci: add instructions about MAVSDK tests

### DIFF
--- a/en/test_and_ci/README.md
+++ b/en/test_and_ci/README.md
@@ -1,13 +1,14 @@
 # Platform Testing and Continuous Integration
 
-PX4 offers extensive tests and testing facilities, including unit and integration tests run via continuous integration and "live" flight testing by our dedicated test team. 
+PX4 offers extensive tests and testing facilities, including unit and integration tests run via continuous integration and "live" flight testing by our dedicated test team.
 This page provides an overview.
 
 * [Test Flights](../test_and_ci/test_flights.md)
 * [Unit Tests](../test_and_ci/unit_tests.md)
 * [Continuous Integration (CI)](../test_and_ci/continous_integration.md)
 * [Jenkins CI](../test_and_ci/jenkins_ci.md)
-* [Integration Testing](../test_and_ci/integration_testing.md)
+* [ROS Integration Testing](../test_and_ci/integration_testing.md)
+* [MAVSDK Integration Testing](../test_and_ci/integration_testing_mavsdk.md)
 * [Docker](../test_and_ci/docker.md)
 * [Maintenance](../test_and_ci/maintenance.md)
 

--- a/en/test_and_ci/integration_testing_mavsdk.md
+++ b/en/test_and_ci/integration_testing_mavsdk.md
@@ -1,0 +1,61 @@
+# Integration Testing using MAVSDK
+
+PX4 can be tested end to end to using integration tests based on [MAVSDK](https://mavsdk.mavlink.io).
+
+The tests are primarily developed against SITL for now and run in continuous integration (CI). However, they are meant to generalize to real tests eventually.
+
+## Install the MAVSDK C++ library
+
+The tests need the MAVSDK C++ library installed system-wide (e.g. in `/usr/lib` or `/usr/local/lib`.
+
+### Installation of prebuilt library
+
+#### Ubuntu
+
+Download the matching .deb file (whichever is correct for your system) from [MAVSDK releases](https://github.com/mavlink/MAVSDK/releases).
+
+Install it using `dpkg`, e.g.:
+
+```sh
+sudo dpkg -i mavsdk_0.23.0_ubuntu18.04_amd64.deb
+```
+
+#### Fedora
+
+Download the matching .rpm file (whichever is correct for your system) from [MAVSDK releases](https://github.com/mavlink/MAVSDK/releases).
+
+Install it using `rpm`, e.g.:
+
+```sh
+sudo rpm -U mavsdk-0.23.0-1.fc30-x86_64.rpm
+```
+
+#### macOS
+
+Install the library using [brew](https://brew.sh/):
+
+```sh
+brew install mavsdk
+```
+
+## Prepare PX4 code
+
+To build the PX4 code, use:
+
+```sh
+DONT_RUN=1 make px4_sitl gazebo mavsdk_tests
+```
+
+### Run all tests
+
+To run all tests, use:
+
+```sh
+test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --gui
+```
+
+To see all possible command line arguments, check out:
+
+```sh
+test/mavsdk_tests/mavsdk_test_runner.py -h
+```

--- a/en/test_and_ci/integration_testing_mavsdk.md
+++ b/en/test_and_ci/integration_testing_mavsdk.md
@@ -8,6 +8,8 @@ The tests are primarily developed against SITL for now and run in continuous int
 
 The tests need the MAVSDK C++ library installed system-wide (e.g. in `/usr/lib` or `/usr/local/lib`.
 
+MAVSDK can either be installed as a prebuilt library or alternatively be built from source and installed system-wide.
+
 ### Installation of prebuilt library
 
 #### Ubuntu
@@ -36,6 +38,22 @@ Install the library using [brew](https://brew.sh/):
 
 ```sh
 brew install mavsdk
+```
+
+### Build and install library
+
+Instead of installing the latest pre-built release, the library can also be built from sources. This enables you to build the library if there is is no prebuilt package for your platform, or because you need to use the latest [develop branch](https://github.com/mavlink/MAVSDK/tree/develop), or some custom branch or pull request. Also, you can specifiy the compile options, e.g. to select a debug build.
+
+First fetch the sources from GitHub:
+
+```sh
+git clone https://github.com/mavlink/MAVSDK.git --recursive
+```
+
+Then build and install the library:
+```
+cd MAVSDK
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_BACKEND=OFF -Bbuild -H. && cmake --build build -j 8 && sudo cmake --build build --target install
 ```
 
 ## Prepare PX4 code


### PR DESCRIPTION
This adds first docs on how to build and run the PX4 integration tests based on the MAVSDK C++ library.