### PR TITLE
Add hardfault debugging video

### DIFF
--- a/en/debug/gdb_debugging.md
+++ b/en/debug/gdb_debugging.md
@@ -70,12 +70,32 @@ The numbers in the graph will all be zero, because they are in MB. Just look at 
 See the [gperftools docs](https://htmlpreview.github.io/?https://github.com/gperftools/gperftools/blob/master/docs/heapprofile.html) for more information.
 
 
-## Debugging Hard Faults in NuttX
+## Hard Fault Debugging
 
-A hard fault is a state when the operating system detects that it has no valid instructions to execute. This is typically the case when key areas in RAM have been corrupted. A typical scenario is when incorrect memory access smashed the stack and the processor sees that the address in memory is not a valid address for the microprocessors's RAM.
+A hard fault is a state when the operating system detects that it has no valid instructions to execute.
+This is typically the case when key areas in RAM have been corrupted.
+
+
+### Video
+
+The following video demonstrates hardfault debugging on PX4 using Eclipse and a JTAG debugger.
+It was presented at the PX4 Developer Conference 2019.
+
+{% youtube %}
+https://www.youtube.com/watch?v=KZkAM_PVOi0
+{% endyoutube %}
+
+
+### Debugging Hard Faults in NuttX
+
+A typical scenario is when incorrect memory access smashed the stack and the processor sees that the address in memory is not a valid address for the microprocessors's RAM.
+
+A hard fault is a state when the operating system detects that it has no valid instructions to execute. This is typically the case when key areas in RAM have been corrupted.
+A typical scenario is when incorrect memory access smashed the stack and the processor sees that the address in memory is not a valid address for the microprocessors's RAM.
 
 * NuttX maintains two stacks: The IRQ stack for interrupt processing and the user stack
-* The stack grows downward. So the highest address in the example below is 0x20021060, the size is 0x11f4 (4596 bytes) and consequently the lowest address is 0x2001fe6c.
+* The stack grows downward.
+  So the highest address in the example below is 0x20021060, the size is 0x11f4 (4596 bytes) and consequently the lowest address is 0x2001fe6c.
 
 ```bash
 Assertion failed at file:armv7-m/up_hardfault.c line: 184 task: ekf_att_pos_estimator
@@ -130,7 +150,8 @@ To decode the hard fault, load the *exact* binary into the debugger:
 arm-none-eabi-gdb build/px4_fmu-v2_default/px4_fmu-v2_default.elf
 ```
 
-Then in the GDB prompt, start with the last instructions in R8, with the first address in flash (recognizable because it starts with `0x080`, the first is `0x0808439f`). The execution is left to right. So one of the last steps before the hard fault was when ```mavlink_log.c``` tried to publish something,
+Then in the GDB prompt, start with the last instructions in R8, with the first address in flash (recognizable because it starts with `0x080`, the first is `0x0808439f`).
+The execution is left to right. So one of the last steps before the hard fault was when ```mavlink_log.c``` tried to publish something,
 
 ```gdb
 (gdb) info line *0x0808439f


### PR DESCRIPTION
Adds @davids5 hard fault debugging video from PX4 2019 dev conference into docs. 

FYI only Other than new video none of the content actually changed - though I did add some structure/layout stuff. This is a quick and dirty kind of fix - the info should be properly integrated at some point. 