### PR TITLE
Extend NuttX board porting page

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -42,6 +42,7 @@
 * [Hardware](hardware/README.md)
   * [Flight Controller Reference Design](hardware/reference_design.md)
   * [Flight Controller Porting Guide](hardware/porting_guide.md)
+    * [NuttX Board Porting Guide](hardware/porting_guide_nuttx.md)
   * [Airframes](airframes/README.md)
     * [Airframes Reference](airframes/airframe_reference.md)
     * [Adding a New Airframe](airframes/adding_a_new_frame.md)

--- a/en/hardware/porting_guide.md
+++ b/en/hardware/porting_guide.md
@@ -45,7 +45,6 @@ This section describes the various middleware components, and the configuration 
 * The start script is located in [posix-configs/](https://github.com/PX4/Firmware/tree/master/posix-configs).
 * The OS configuration is part of the default Linux image (TODO: Provide location of LINUX IMAGE and flash instructions).
 * The PX4 middleware configuration is located in [src/boards](https://github.com/PX4/Firmware/tree/master/boards). TODO: ADD BUS CONFIG 
-* Drivers: [DriverFramework](https://github.com/px4/DriverFramework). 
 * Reference config: Running `make eagle_default` builds the Snapdragon Flight reference config.
 
 

--- a/en/hardware/porting_guide.md
+++ b/en/hardware/porting_guide.md
@@ -27,7 +27,7 @@ This section describes the purpose and location of the configuration files requi
 
 ### NuttX
 
-See [here](porting_guide_nuttx.md) for NuttX.
+See [NuttX Board Porting Guide](porting_guide_nuttx.md).
 
 ### Linux
 
@@ -45,7 +45,7 @@ This section describes the various middleware components, and the configuration 
 * The start script is located in [posix-configs/](https://github.com/PX4/Firmware/tree/master/posix-configs).
 * The OS configuration is part of the default Linux image (TODO: Provide location of LINUX IMAGE and flash instructions).
 * The PX4 middleware configuration is located in [src/boards](https://github.com/PX4/Firmware/tree/master/boards). TODO: ADD BUS CONFIG 
-* Drivers: [DriverFramework](https://github.com/px4/DriverFramework).
+* Drivers: [DriverFramework](https://github.com/px4/DriverFramework). 
 * Reference config: Running `make eagle_default` builds the Snapdragon Flight reference config.
 
 

--- a/en/hardware/porting_guide.md
+++ b/en/hardware/porting_guide.md
@@ -27,49 +27,7 @@ This section describes the purpose and location of the configuration files requi
 
 ### NuttX
 
-In order to port PX4 on NuttX to a new hardware target, that hardware target must be supported by NuttX.
-The NuttX project maintains an excellent [porting guide](http://www.nuttx.org/Documentation/NuttxPortingGuide.html) for porting NuttX to a new computing platform.
-
-For all NuttX based flight controllers (e.g. the Pixhawk series) the OS is loaded as part of the application build.
-
-The configuration files for all boards, including linker scripts and other required settings, are located under [/boards](https://github.com/PX4/Firmware/tree/master/boards/) in a vendor- and board-specific directory (i.e. **boards/_VENDOR_/_MODEL_/**)).
-
-The following example uses FMUv5 as it is a recent [reference configuration](../hardware/reference_design.md) for NuttX based flight controllers:
-* Running `make px4_fmu-v5_default` from the **Firmware** directory will build the FMUv5 config
-* The base FMUv5 configuration files are located in: [/boards/px4/fmu-v5](https://github.com/PX4/Firmware/tree/master/boards/px4/fmu-v5).
-* Board specific header: [/boards/px4/fmu-v5/nuttx-config/include/board.h](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/nuttx-config/include/board.h). 
-* NuttX OS config (created with Nuttx menuconfig): [/boards/px4/fmu-v5/nuttx-config/nsh/defconfig](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/nuttx-config/nsh/defconfig).
-* Build configuration: [boards/px4/fmu-v5/default.cmake](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/default.cmake).
-
-The function of each of these files, and perhaps more, will need to be duplicated for a new flight controller board.
-
-#### NuttX Menuconfig
-
-If you need to modify the NuttX OS configuration, you can do this via [menuconfig](https://bitbucket.org/nuttx/nuttx) using the PX4 shortcuts:
-```sh
-make px4_fmu-v5_default menuconfig
-make px4_fmu-v5_default qconfig
-```
-
-For fresh installs of PX4 onto Ubuntu using [ubuntu_sim_nuttx.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_nuttx.sh) you will also need to install *kconfig* tools from [NuttX tools](https://bitbucket.org/nuttx/tools/src/master/).
-
-> **Note** The following steps are not required if using the [px4-dev-nuttx](https://hub.docker.com/r/px4io/px4-dev-nuttx/) docker container or have installed to macOS using our normal instructions (as these include`kconfig-mconf`). 
-
-Run the following commands from any directory:
-```sh
-git clone https://bitbucket.org/nuttx/tools.git
-cd tools/kconfig-frontends
-sudo apt install gperf
-./configure --enable-mconf --disable-nconf --disable-gconf --enable-qconf --prefix=/usr
-make
-sudo make install
-```
-
-The `--prefix=/usr` determines the specific installation location (which must be in the `PATH` environment variable).
-The `--enable-mconf` and `--enable-qconf` options will enable the `menuconfig` and `qconfig` options respectively.
-
-To run `qconfig` you may need to install additional Qt dependencies.
-
+See [here](porting_guide_nuttx.md) for NuttX.
 
 ### Linux
 

--- a/en/hardware/porting_guide.md
+++ b/en/hardware/porting_guide.md
@@ -21,10 +21,6 @@ For example, for FMUv5:
     It may also be used to set a board's default parameters, UART mappings, and any other special cases.
   - For FMUv5 you can see all the Pixhawk 4 sensors being started, and it also sets a larger LOGGER_BUF. 
 
-In addition there are several groups of configuration files for each board located throughout the code base:
-* The boot file system (startup script) is located in: [ROMFS/px4fmu\_common](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common)
-* Driver files are located in: [src/drivers](https://github.com/PX4/Firmware/tree/master/src/drivers).
-
 ## Host Operating System Configuration
 
 This section describes the purpose and location of the configuration files required for each supported host operating system to port them to new flight controller hardware.
@@ -69,7 +65,7 @@ make
 sudo make install
 ```
 
-The `--prefix=/usr` is essential as it determines the specific installation location where PX4 is hardcoded to look for `kconfig-tools`.
+The `--prefix=/usr` determines the specific installation location (which must be in the `PATH` environment variable).
 The `--enable-mconf` and `--enable-qconf` options will enable the `menuconfig` and `qconfig` options respectively.
 
 To run `qconfig` you may need to install additional Qt dependencies.
@@ -80,7 +76,7 @@ To run `qconfig` you may need to install additional Qt dependencies.
 Linux boards do not include the OS and kernel configuration. 
 These are already provided by the Linux image available for the board (which needs to support the inertial sensors out of the box).
 
-* [boards/px4/raspberrypi/cross.cmake](https://github.com/PX4/Firmware/blob/master/boards/px4/raspberrypi/cross.cmake) - RPI cross-compilation. 
+* [boards/px4/raspberrypi/default.cmake](https://github.com/PX4/Firmware/blob/master/boards/px4/raspberrypi/default.cmake) - RPI cross-compilation. 
 
 ## Middleware Components and Configuration
 

--- a/en/hardware/porting_guide_nuttx.md
+++ b/en/hardware/porting_guide_nuttx.md
@@ -43,6 +43,7 @@ The `--enable-mconf` and `--enable-qconf` options will enable the `menuconfig` a
 To run `qconfig` you may need to install additional Qt dependencies.
 
 ### Bootloader
+
 First you will need a bootloader, which depends on the hardware target:
 - STM32H7: the bootloader is based on NuttX, and is included in the PX4 Firmware.
   See [here](https://github.com/PX4/Firmware/tree/master/boards/holybro/durandal-v1/nuttx-config/bootloader) for an example.
@@ -50,28 +51,30 @@ First you will need a bootloader, which depends on the hardware target:
   Then checkout the [buiding and flashing instructions](../software_update/stm32_bootloader.md).
 
 ### Firmware Porting Steps
+
 1. Make sure you have a working [development setup](../setup/dev_env.md) and installed the NuttX menuconfig tool (see above).
 1. Download the source code and make sure you can build an existing target:
-  ```bash
-git clone --recursive https://github.com/PX4/Firmware.git
-cd Firmware
-make px4_fmu-v5
-  ```
+   ```bash
+   git clone --recursive https://github.com/PX4/Firmware.git
+   cd Firmware
+   make px4_fmu-v5
+   ```
 1. Find an existing target that uses the same (or a closely related) CPU type and copy it.
-  For example for STM32F7:
-  ```bash
-  mkdir boards/manufacturer
-  cp -r boards/px4/fmu-v5 boards/manufacturer/my-target-v1
-  ```
-  Change **manufacturer** to the manufacturer name and **my-target-v1** to your board name.
-  Next you need to go through all files under **boards/manufacturer/my-target-v1** and update them according to your board.
-  1. **firmware.prototype**: update the board ID and name
-  1. **default.cmake**: update the **VENDOR** and **MODEL** to match the directory names (**my-target-v1**). 
-    Configure the serial ports.
-  1. Configure NuttX (**defconfig**) via `make manufacturer_my-target-v1 menuconfig`: Adjust the CPU and chip, configure the peripherals (UART's, SPI, I2C, ADC).
-  1. **nuttx-config/include/board.h**: Configure the NuttX pins.
-    For all peripherals with multiple pin options, NuttX needs to know the pin.
-	They are defined in the chip-specific pinmap header file, for example [stm32f74xx75xx_pinmap.h](https://github.com/PX4/NuttX/blob/px4_firmware_nuttx-8.2/arch/arm/src/stm32f7/hardware/stm32f74xx75xx_pinmap.h).
-  1. **src**: go through all files under **src** and update them as needed, in particular **board_config.h**.
-  1. **init/rc.board_sensors**: start the sensors that are attached to the board.
+   For example for STM32F7:
+   ```bash
+   mkdir boards/manufacturer
+   cp -r boards/px4/fmu-v5 boards/manufacturer/my-target-v1
+   ```
+   Change **manufacturer** to the manufacturer name and **my-target-v1** to your board name.
+   
+Next you need to go through all files under **boards/manufacturer/my-target-v1** and update them according to your board.
+1. **firmware.prototype**: update the board ID and name
+1. **default.cmake**: update the **VENDOR** and **MODEL** to match the directory names (**my-target-v1**). 
+   Configure the serial ports.
+1. Configure NuttX (**defconfig**) via `make manufacturer_my-target-v1 menuconfig`: Adjust the CPU and chip, configure the peripherals (UART's, SPI, I2C, ADC).
+1. **nuttx-config/include/board.h**: Configure the NuttX pins.
+   For all peripherals with multiple pin options, NuttX needs to know the pin.
+   They are defined in the chip-specific pinmap header file, for example [stm32f74xx75xx_pinmap.h](https://github.com/PX4/NuttX/blob/px4_firmware_nuttx-8.2/arch/arm/src/stm32f7/hardware/stm32f74xx75xx_pinmap.h).
+1. **src**: go through all files under **src** and update them as needed, in particular **board_config.h**.
+1. **init/rc.board_sensors**: start the sensors that are attached to the board.
 

--- a/en/hardware/porting_guide_nuttx.md
+++ b/en/hardware/porting_guide_nuttx.md
@@ -1,0 +1,77 @@
+# NuttX Board Porting Guide
+
+In order to port PX4 on NuttX to a new hardware target, that hardware target must be supported by NuttX.
+The NuttX project maintains an excellent [porting guide](http://www.nuttx.org/Documentation/NuttxPortingGuide.html) for porting NuttX to a new computing platform.
+
+The following guide assumes you are using an already supported hardware target or have ported NuttX (including the [PX4 base layer](https://github.com/PX4/Firmware/tree/master/platforms/nuttx/src/px4)) already.
+
+The configuration files for all boards, including linker scripts and other required settings, are located under [/boards](https://github.com/PX4/Firmware/tree/master/boards/) in a vendor- and board-specific directory (i.e. **boards/_VENDOR_/_MODEL_/**)).
+
+The following example uses FMUv5 as it is a recent [reference configuration](../hardware/reference_design.md) for NuttX based flight controllers:
+* Running `make px4_fmu-v5_default` from the **Firmware** directory will build the FMUv5 config
+* The base FMUv5 configuration files are located in: [/boards/px4/fmu-v5](https://github.com/PX4/Firmware/tree/master/boards/px4/fmu-v5).
+  * Board specific header (NuttX pins and clock configuration): [/boards/px4/fmu-v5/nuttx-config/include/board.h](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/nuttx-config/include/board.h). 
+  * Board specific header (PX4 configuration): [/boards/px4/fmu-v5/src/board_config.h](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/src/board_config.h). 
+  * NuttX OS config (created with NuttX menuconfig): [/boards/px4/fmu-v5/nuttx-config/nsh/defconfig](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/nuttx-config/nsh/defconfig).
+  * Build configuration: [boards/px4/fmu-v5/default.cmake](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v5/default.cmake).
+
+## NuttX Menuconfig Setup
+
+To modify the NuttX OS configuration, you can use [menuconfig](https://bitbucket.org/nuttx/nuttx) using the PX4 shortcuts:
+```sh
+make px4_fmu-v5_default menuconfig
+make px4_fmu-v5_default qconfig
+```
+
+For fresh installs of PX4 onto Ubuntu using [ubuntu_sim_nuttx.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_nuttx.sh) you will also need to install *kconfig* tools from [NuttX tools](https://bitbucket.org/nuttx/tools/src/master/).
+
+> **Note** The following steps are not required if using the [px4-dev-nuttx](https://hub.docker.com/r/px4io/px4-dev-nuttx/) docker container or have installed to macOS using our normal instructions (as these include`kconfig-mconf`). 
+
+Run the following commands from any directory:
+```sh
+git clone https://bitbucket.org/nuttx/tools.git
+cd tools/kconfig-frontends
+sudo apt install gperf
+./configure --enable-mconf --disable-nconf --disable-gconf --enable-qconf --prefix=/usr
+make
+sudo make install
+```
+
+The `--prefix=/usr` determines the specific installation location (which must be in the `PATH` environment variable).
+The `--enable-mconf` and `--enable-qconf` options will enable the `menuconfig` and `qconfig` options respectively.
+
+To run `qconfig` you may need to install additional Qt dependencies.
+
+### Bootloader
+First you will need a bootloader, which depends on the hardware target:
+- STM32H7: the bootloader is based on NuttX, and is included in the PX4 Firmware.
+  See [here](https://github.com/PX4/Firmware/tree/master/boards/holybro/durandal-v1/nuttx-config/bootloader) for an example.
+- For all other targets, https://github.com/PX4/Bootloader is used. See [here](https://github.com/PX4/Bootloader/pull/155/files) for an example how to add a new target.
+  Then checkout the [buiding and flashing instructions](../software_update/stm32_bootloader.md).
+
+### Firmware Porting Steps
+1. Make sure you have a working [development setup](../setup/dev_env.md) and installed the NuttX menuconfig tool (see above).
+1. Download the source code and make sure you can build an existing target:
+  ```bash
+git clone --recursive https://github.com/PX4/Firmware.git
+cd Firmware
+make px4_fmu-v5
+  ```
+1. Find an existing target that uses the same (or a closely related) CPU type and copy it.
+  For example for STM32F7:
+  ```bash
+  mkdir boards/manufacturer
+  cp -r boards/px4/fmu-v5 boards/manufacturer/my-target-v1
+  ```
+  Change **manufacturer** to the manufacturer name and **my-target-v1** to your board name.
+  Next you need to go through all files under **boards/manufacturer/my-target-v1** and update them according to your board.
+  1. **firmware.prototype**: update the board ID and name
+  1. **default.cmake**: update the **VENDOR** and **MODEL** to match the directory names (**my-target-v1**). 
+    Configure the serial ports.
+  1. Configure NuttX (**defconfig**) via `make manufacturer_my-target-v1 menuconfig`: Adjust the CPU and chip, configure the peripherals (UART's, SPI, I2C, ADC).
+  1. **nuttx-config/include/board.h**: Configure the NuttX pins.
+    For all peripherals with multiple pin options, NuttX needs to know the pin.
+	They are defined in the chip-specific pinmap header file, for example [stm32f74xx75xx_pinmap.h](https://github.com/PX4/NuttX/blob/px4_firmware_nuttx-8.2/arch/arm/src/stm32f7/hardware/stm32f74xx75xx_pinmap.h).
+  1. **src**: go through all files under **src** and update them as needed, in particular **board_config.h**.
+  1. **init/rc.board_sensors**: start the sensors that are attached to the board.
+

--- a/en/hardware/porting_guide_nuttx.md
+++ b/en/hardware/porting_guide_nuttx.md
@@ -23,7 +23,7 @@ make px4_fmu-v5_default menuconfig
 make px4_fmu-v5_default qconfig
 ```
 
-For fresh installs of PX4 onto Ubuntu using [ubuntu_sim_nuttx.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_nuttx.sh) you will also need to install *kconfig* tools from [NuttX tools](https://bitbucket.org/nuttx/tools/src/master/).
+For fresh installs of PX4 onto Ubuntu using [ubuntu.sh](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/Tools/setup/ubuntu.sh) you will also need to install *kconfig* tools from [NuttX tools](https://bitbucket.org/nuttx/tools/src/master/).
 
 > **Note** The following steps are not required if using the [px4-dev-nuttx](https://hub.docker.com/r/px4io/px4-dev-nuttx/) docker container or have installed to macOS using our normal instructions (as these include`kconfig-mconf`). 
 


### PR DESCRIPTION
This extends the NuttX board porting page and splits it into a separate page.
It is on purpose minimalistic, as we are still improving the Firmware side (e.g. https://github.com/PX4/Firmware/pull/13871), and so that manufacturers can test it and specifically point to things where they need more info.

@jinger26 