### PR TITLE
Building PX4: Simple Instructions for Building

### DIFF
--- a/en/contribute/git_examples.md
+++ b/en/contribute/git_examples.md
@@ -6,65 +6,92 @@ Adding a feature to PX4 follows a defined workflow. In order to share your contr
 * [Sign up](https://github.com/join) for github if you haven't already
 * Fork the Firmware (see [here](https://help.github.com/articles/fork-a-repo/#fork-an-example-repository))
 * Clone your forked repository to your local computer<br>
-```sh
-cd ~/wherever/
-git clone https://github.com/<your git name>/Firmware.git
-```
+  ```sh
+  cd ~/wherever/
+  git clone https://github.com/<your git name>/Firmware.git
+  ```
 * Go into the new directory, initialize and update the submodules, and add the original upstream Firmware<br>
-```sh
-cd Firmware
-git submodule update --init --recursive
-git remote add upstream https://github.com/PX4/Firmware.git
-```
+  ```sh
+  cd Firmware
+  git submodule update --init --recursive
+  git remote add upstream https://github.com/PX4/Firmware.git
+  ```
 * You should have now two remote repositories: One repository is called upstream that points to the PX4 Firmware,
 and one repository that points to your forked repository of the PX4 repository.
 * This can be checked with the following command:
-```sh
-git remote -v
-```
+  ```sh
+  git remote -v
+  ```
 * Make the changes that you want to add to the current master.
 * Create a new branch with a meaningful name that represents your feature<br>
-```sh
-git checkout -b <your feature branch name>
-```
-you can use the command ```git branch``` to make sure you're on the right branch.
+  ```sh
+  git checkout -b <your feature branch name>
+  ```
+  you can use the command `git branch` to make sure you're on the right branch.
 * Add your changes that you want to be part of the commit by adding the respective files<br>
-```sh
-git add <file name>
-```
-If you prefer having a GUI to add your files see [Gitk](https://git-scm.com/book/en/v2/Git-in-Other-Environments-Graphical-Interfaces) or [```git add -p```](http://nuclearsquid.com/writings/git-add/).
+  ```sh
+  git add <file name>
+  ```
+  If you prefer having a GUI to add your files see [Gitk](https://git-scm.com/book/en/v2/Git-in-Other-Environments-Graphical-Interfaces) or [`git add -p`](http://nuclearsquid.com/writings/git-add/).
 * Commit the added files with a meaningful message explaining your changes<br>
-```sh
-git commit -m "<your commit message>"
-```
+  ```sh
+  git commit -m "<your commit message>"
+  ```
 For a good commit message, please refer to [Contributing](../contribute/README.md) section.
-* Some time might have passed and the [upstream master](https://github.com/PX4/Firmware.git) has changed. PX4 prefers a linear commit history and uses [git rebase](https://git-scm.com/book/de/v1/Git-Branching-Rebasing). To include the newest changes from upstream in your local branch, switch to your master branch<br>
-```sh
-git checkout master
-```
-Then pull the newest commits from upstream master<br>
-```sh
-git pull upstream master
-```
-Now your local master is up to date. Switch back to your feature branch<br>
-```sh
-git checkout <your feature branch name>
-```
-and rebase on your updated master<br>
-```sh
-git rebase master
-```
+* Some time might have passed and the [upstream master](https://github.com/PX4/Firmware.git) has changed.
+  PX4 prefers a linear commit history and uses [git rebase](https://git-scm.com/book/de/v1/Git-Branching-Rebasing).
+  To include the newest changes from upstream in your local branch, switch to your master branch<br>
+  ```sh
+  git checkout master
+  ```
+  Then pull the newest commits from upstream master<br>
+  ```sh
+  git pull upstream master
+  ```
+  Now your local master is up to date. Switch back to your feature branch<br>
+  ```sh
+  git checkout <your feature branch name>
+  ```
+  and rebase on your updated master<br>
+  ```sh
+  git rebase master
+  ```
 * Now you can push your local commits to your forked repository<br>
-```sh
-git push origin <your feature branch name>
-```
-* You can verify that the push was successful by going to your forked repository in your browser: ```https://github.com/<your git name>/Firmware.git```<br>
-There you should see the message that a new branch has been pushed to your forked repository.
-* Now it's time to create a pull request (PR). On the right hand side of the "new branch message" (see one step before), you should see a green button saying "Compare & Create Pull Request". Then it should list your changes and you can (must) add a meaningful title (in case of a one commit PR, it's usually the commit message) and message (<span style="color:orange">explain what you did for what reason</span>. Check [other pull requests](https://github.com/PX4/Firmware/pulls) for comparison)
-* You're done! Responsible members of PX4 will now have a look at your contribution and decide if they want to integrate it. Check if they have questions on your changes every once in a while.
+  ```sh
+  git push origin <your feature branch name>
+  ```
+* You can verify that the push was successful by going to your forked repository in your browser: `https://github.com/<your git name>/Firmware.git`<br>
+  There you should see the message that a new branch has been pushed to your forked repository.
+* Now it's time to create a pull request (PR).
+  On the right hand side of the "new branch message" (see one step before), you should see a green button saying "Compare & Create Pull Request".
+  Then it should list your changes and you can (must) add a meaningful title (in case of a one commit PR, it's usually the commit message) and message (<span style="color:orange">explain what you did for what reason</span>.
+  Check [other pull requests](https://github.com/PX4/Firmware/pulls) for comparison)
+* You're done! 
+  Responsible members of PX4 will now have a look at your contribution and decide if they want to integrate it.
+  Check if they have questions on your changes every once in a while.
+
+## Get a Specific Release
+
+To get the source code for a *specific older release*:
+* Clone the Firmware repo and navigate into Firmware directory:
+  ```sh
+  git clone https://github.com/PX4/Firmware.git
+  cd Firmware
+  ```
+* List all releases (tags)
+  ```sh
+  git tag -l
+  ```
+* Checkout code for particular tag (e.g. for tag 1.7.4beta)
+  ```sh
+  git checkout v1.7.4beta
+  ```
+
 
 ## Update Submodule
-There are several ways to update a submodule. Either you clone the repository or you go in the submodule directory and follow the same procedure as in [Contributing code to PX4](#Contributing-code-to-PX4).
+
+There are several ways to update a submodule.
+Either you clone the repository or you go in the submodule directory and follow the same procedure as in [Contributing code to PX4](#Contributing-code-to-PX4).
 
 ## Do a PR for a submodule update
 This is required after you have done a PR for a submodule X repository and the bug-fix / feature-add is in the current master of submodule X. Since the Firmware still points to a commit before your update, a submodule pull request is required such that the submodule used by the Firmware points to the newest commit.
@@ -72,25 +99,25 @@ This is required after you have done a PR for a submodule X repository and the b
 cd Firmware
 ```
 * Make a new branch that describes the fix / feature for the submodule update:
-```sh
-git checkout -b pr-some-fix
-```
+  ```sh
+  git checkout -b pr-some-fix
+  ```
 * Go to submodule subdirectory
-```sh
-cd <path to submodule>
-```
+  ```sh
+  cd <path to submodule>
+  ```
 * PX4 submodule might not necessarily point to the newest commit. Therefore, first checkout master and pull the newest upstream code.
-```sh
-git checkout master
-git pull upstream master
-```
+  ```sh
+  git checkout master
+  git pull upstream master
+  ```
 * Go back to Firmware directory, and as usual add, commit and push the changes.
-```sh
-cd -
-git add <path to submodule>
-git commit -m "Update submodule to include ..."
-git push upstream pr-some-fix
-```
+  ```sh
+  cd -
+  git add <path to submodule>
+  git commit -m "Update submodule to include ..."
+  git push upstream pr-some-fix
+  ```
 
 ## Checkout pull requests
 

--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -10,7 +10,13 @@ PX4 can be built on the console or in an IDE, for both simulated and hardware ta
 ## Downloading PX4 Source Code {#get_px4_code}
 
 The PX4 source code is stored on Github in the [PX4/Firmware](https://github.com/PX4/Firmware) repository.
-We recommend that you [fork](https://help.github.com/articles/fork-a-repo/) this repository (creating a copy associated with your own Github account), and then [clone](https://help.github.com/articles/cloning-a-repository/) the source to your local computer.
+If you just want to try out the latest code (and don't want to make any sort of permanent changes) you can enter the following into a terminal to clone the main Firmware repository (and then jump to [First Build](#jmavsim_build) section):
+
+```sh
+git clone https://github.com/PX4/Firmware.git --recursive
+```
+
+Developers who want to be able to customise the code should [fork](https://help.github.com/articles/fork-a-repo/) the PX4/Firmware repository (create a copy associated with your own Github account), and then [clone](https://help.github.com/articles/cloning-a-repository/) the source to your local computer.
 
 > **Tip** Forking the repository allows you to better manage your custom code.
   Later on you will be able to use *git* to share changes with the main project.
@@ -38,11 +44,6 @@ The steps to fork and clone the project source code are:
    ```
    git clone https://github.com/<youraccountname>/Firmware.git
    ```
-   
-   > **Tip** If you're just experimenting (and don't want to make any sort of permanent changes) you can simply clone the main Firmware repository as shown:
-   >  ```sh
-   >  git clone https://github.com/PX4/Firmware.git
-   >  ```
    
    Windows users [refer to the Github help](https://help.github.com/desktop/guides/getting-started-with-github-desktop/installing-github-desktop/). 
    You can use a *git* command line client as above or instead perform the same actions with the *Github for Windows* app.

--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -7,73 +7,22 @@ PX4 can be built on the console or in an IDE, for both simulated and hardware ta
 <span></span>
 > **Tip** For solutions to common build problems see [Troubleshooting](#troubleshooting) below.
 
-## Downloading PX4 Source Code {#get_px4_code}
+## Download the PX4 Source Code {#get_px4_code}
 
 The PX4 source code is stored on Github in the [PX4/Firmware](https://github.com/PX4/Firmware) repository.
-If you just want to try out the latest code (and don't want to make any sort of permanent changes) you can enter the following into a terminal to clone the main Firmware repository (and then jump to [First Build](#jmavsim_build) section):
+To get the *very latest* version onto your computer, enter the following command into a terminal:
 
 ```sh
 git clone https://github.com/PX4/Firmware.git --recursive
 ```
 
-Developers who want to be able to customise the code should [fork](https://help.github.com/articles/fork-a-repo/) the PX4/Firmware repository (create a copy associated with your own Github account), and then [clone](https://help.github.com/articles/cloning-a-repository/) the source to your local computer.
-
-> **Tip** Forking the repository allows you to better manage your custom code.
-  Later on you will be able to use *git* to share changes with the main project.
-
-The steps to fork and clone the project source code are:
-
-1. [Sign up](https://github.com/) to Github.
-1. Go to the [Firmware](https://github.com/PX4/Firmware) repository and click the **Fork** button near the upper right corner.
-   This will create and open the forked repository.
-
-   ![Github Fork button](../../assets/toolchain/github_fork.png)
-1. Copy the repository URL for your *Firmware* repository fork.
-   The easiest way to do this is to click the **Clone or download** button and then copy the URL:
-
-   ![Github Clone or download button](../../assets/toolchain/github_clone_or_download.png)
-1. Install *git* (if you haven't already done so as part of setting up the development environment):
-   * On macOS use the terminal command: `brew install git`
-   * On Ubuntu use the terminal command: `sudo apt install git`
-   * For other platforms see the [git documentation](https://git-scm.com/downloads).
-1. Open a command prompt/terminal on your computer
-   * On OS X, hit ⌘-space and search for 'terminal'.
-   * On Ubuntu, click the launch bar and search for 'terminal'.
-   * On Windows, find the PX4 folder in the start menu and click on 'PX4 Console'.
-1. Clone the repository fork using the copied URL. This will look something like:
-   ```
-   git clone https://github.com/<youraccountname>/Firmware.git
-   ```
-   
-   Windows users [refer to the Github help](https://help.github.com/desktop/guides/getting-started-with-github-desktop/installing-github-desktop/). 
-   You can use a *git* command line client as above or instead perform the same actions with the *Github for Windows* app.
-
-This will copy *most* of the *very latest* version of PX4 source code onto your computer 
-(the rest of the code is automatically fetched from other [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) when you build PX4).
-
-<span id="specific_version_source"></span>
-
-### Get a Specific Release
-
-To get the source code for a *specific older release*:
-1. Clone the Firmware repo and navigate into Firmware directory:
-   ```sh
-   git clone https://github.com/PX4/Firmware.git
-   cd Firmware
-   ```
-1. List all releases (tags)
-   ```sh
-   git tag -l
-   ```
-1. Checkout code for particular tag (e.g. for tag 1.7.4beta)
-   ```sh
-   git checkout v1.7.4beta
-   ```
-
+> **Note** This is all you need to do just to build the latest code. 
+  [GIT Examples > Contributing code to PX4](../contribute/git_examples.md#contributing-code-to-px4) provides a lot more information about using git to contribute to PX4. 
+  
 
 ## First Build (Using the jMAVSim Simulator) {#jmavsim_build}
 
-For the first build we'll build for a simulated target using a console environment.
+First we'll build a simulated target using a console environment.
 This allows us to validate the system setup before moving on to real hardware and an IDE.
 
 Navigate into the **Firmware** directory and start [jMAVSim](../simulation/jmavsim.md) using the following command:


### PR DESCRIPTION
This very much reduces the building topic by assuming:
1. User followed our developer setup instructions, so they have git.
2. They just want to build, not "contribute", so they don't need to fork etc.

It throws most of the "proper" contributor setup and moves it to Git Examples (including bit on "how to get a specific release").

My assumption is that there is quite a big separation between someone who wants to just play around/get started and someone ready to contribute. The getting started person only needs to be exposed to the bare minimum. So this should be "more accessible". 

FYI @marilig @bkueng @julianoes 