### PR TITLE
SIK Radio - clarify supported firmware in repo

### DIFF
--- a/en/data_links/sik_radio.md
+++ b/en/data_links/sik_radio.md
@@ -6,6 +6,25 @@ Information about *using* SiK Radio can be found it the *PX4 User Guide*: [Telem
 
 The ("developer") information below explains how to build SiK firmware from source and configure it using AT commands.
 
+## Supported Radio Hardware
+
+The SiK repository includes bootloaders and firmware for the following telemetry radios (2020-02-25):
+- HopeRF HM-TRP
+- HopeRF RF50-DEMO
+- RFD900
+- RFD900a
+- RFD900p
+- RFD900pe
+- RFD900u
+- RFD900ue
+
+> **Note** The SiK repository does not currently firmware for RFD900x or RFD900ux telemetry radios**.
+>  In order to update firmware on these radios (for instance, in order to support MAVLink v2.0), the following process is suggested:
+>
+>  1. Download the appropriate firmware from the [RFDesign website](https://files.rfdesign.com.au/firmware/).
+>  1. On a Windows PC, download and install [RFD Modem Tools](https://files.rfdesign.com.au/tools/).
+>  1. Use the RFD Modem Tools GUI to upload the firmware to your RFD900x or RFD900ux telemetry radio.
+
 
 ## Build Instructions
 


### PR DESCRIPTION
This lists the firmware that can be built using the Sik firmware repo. It is the "non controversial" section of docs in https://github.com/PX4/Devguide/pull/960

I've separated this, because it is useful to know what is "supported" by the repo (prevents people wasting time targetting boards that can't work).