### PR TITLE
Mavlink: Point to startup script locations

### DIFF
--- a/en/middleware/mavlink.md
+++ b/en/middleware/mavlink.md
@@ -118,9 +118,7 @@ nullptr
 };
 ```
 
-Then make sure to enable the stream, for example by adding the following line to
-the startup script (`-r` configures the streaming rate, `-u` identifies the
-MAVLink channel on UDP port 14556):
+Then make sure to enable the stream, for example by adding the following line to the [startup script](../concept/system_startup.md) (e.g. [/ROMFS/px4fmu_common/init.d-posix/rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS) on NuttX or [ROMFS/px4fmu_common/init.d-posix/rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS)) on SITL. Note that `-r` configures the streaming rate and `-u` identifies the MAVLink channel on UDP port 14556).
 
 ```
 mavlink stream -r 50 -s CA_TRAJECTORY -u 14556


### PR DESCRIPTION
@julianoes As discussed on slack with @RicardoM17 this makes it more clear what startup file you should add mavlink startup to - pointing to startup scripts doc and some example files you might update.

I figure rcs file is right place, but actually you could put it in any of the linked configs including the airframe right?

Anything else to add. 