### PR TITLE
cygwin: revert back to 0.8 stable

### DIFF
--- a/en/setup/dev_env_windows_cygwin.md
+++ b/en/setup/dev_env_windows_cygwin.md
@@ -14,8 +14,8 @@ This topic explains how download and use the environment, and how it can be exte
 
 ## Installation Instructions {#installation}
 
-1. Download the latest version of the ready-to-use MSI installer from [Github](https://github.com/PX4/windows-toolchain/releases) or
-[S3](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.9.msi)
+1. Download the latest version of the ready-to-use MSI installer from [Github releases](https://github.com/PX4/windows-toolchain/releases) or
+[latest stable fast download from Amazon](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.8.msi)
 1. Run it, choose your desired installation location, let it install:
     ![jMAVSimOnWindows](../../assets/toolchain/cygwin_toolchain_installer.PNG)
 1. Tick the box at the end of the installation to *clone the PX4 repository, build and run simulation with jMAVSim* (this simplifies the process to get you started). 


### PR DESCRIPTION
Since this was changed before CI successfully builds in #979
See https://github.com/PX4/Firmware/pull/14401