### PR TITLE
Drivers: adding define to force debug build

### DIFF
--- a/en/middleware/drivers.md
+++ b/en/middleware/drivers.md
@@ -143,4 +143,4 @@ px4_add_module(
 	)
 ```
 
-> **Tip** Verbose logging can also be enabled by adding `#define DEBUG_BUILD` at the very top of a .cpp file (before any includes).
+> **Tip** Verbose logging can also be enabled on a per-file basis, by adding `#define DEBUG_BUILD` at the very top of a .cpp file (before any includes).

--- a/en/middleware/drivers.md
+++ b/en/middleware/drivers.md
@@ -142,3 +142,5 @@ px4_add_module(
 		modules__uORB
 	)
 ```
+
+> **Tip** Verbose logging can also be enabled by adding `#define DEBUG_BUILD` at the very top of a .cpp file (before any includes).


### PR DESCRIPTION
Suggestion from here: https://github.com/PX4/Devguide/pull/976#discussion_r394139986

@bkueng Are there pros/cons to each method? I.e. why/when would you do this instead of updating the cmake info? My assumption is that in either case this is a temporary testing change, so perhaps it doesn't matter?