### PR TITLE
Add docs for setting gazebo world

### DIFF
--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -18,7 +18,7 @@ git clone https://github.com/PX4/Firmware.git --recursive
 
 > **Note** This is all you need to do just to build the latest code. 
   [GIT Examples > Contributing code to PX4](../contribute/git_examples.md#contributing-code-to-px4) provides a lot more information about using git to contribute to PX4. 
-  
+
 
 ## First Build (Using the jMAVSim Simulator) {#jmavsim_build}
 
@@ -369,7 +369,7 @@ This section shows how *make* options are constructed and how to find the availa
 
 The full syntax to call *make* with a particular configuration and initialization file is:
 ```sh
-make [VENDOR_][MODEL][_VARIANT] [VIEWER_MODEL_DEBUGGER]
+make [VENDOR_][MODEL][_VARIANT] [VIEWER_MODEL_DEBUGGER_WORLD]
 ```
 
 **VENDOR_MODEL_VARIANT**: (also known as `CONFIGURATION_TARGET`)
@@ -384,15 +384,18 @@ make [VENDOR_][MODEL][_VARIANT] [VIEWER_MODEL_DEBUGGER]
   make list_config_targets
   ```
 
-**VIEWER_MODEL_DEBUGGER:**
+**VIEWER_MODEL_DEBUGGER_WORLD:**
   
 - **VIEWER:** This is the simulator ("viewer") to launch and connect: `gazebo`, `jmavsim` <!-- , ?airsim -->
 - **MODEL:** The *vehicle* model to use (e.g. `iris` (*default*), `rover`, `tailsitter`, etc), which will be loaded by the simulator.
   The environment variable `PX4_SIM_MODEL` will be set to the selected model, which is then used in the [startup script](..\simulation\README.md#scripts) to select appropriate parameters. 
 - **DEBUGGER:** Debugger to use: `none` (*default*), `ide`, `gdb`, `lldb`, `ddd`, `valgrind`, `callgrind`. 
   For more information see [Simulation Debugging](../debug/simulation_debugging.md).
+- **WORLD:** (Gazebo only). Set a the world ([PX4/sitl_gazebo/worlds](https://github.com/PX4/sitl_gazebo/tree/master/worlds)) that is loaded.
+  Default is [empty.world](https://github.com/PX4/sitl_gazebo/blob/master/worlds/empty.world).
+  For more information see [Gazebo > Loading a Specific World](../simulation/gazebo.md#set_world).
 
-> **Tip** You can get a list of *all* available `VIEWER_MODEL_DEBUGGER` options using the command below:
+> **Tip** You can get a list of *all* available `VIEWER_MODEL_DEBUGGER_WORLD` options using the command below:
   ```sh
   make px4_sitl list_vmd_make_targets
   ```

--- a/en/simulation/gazebo.md
+++ b/en/simulation/gazebo.md
@@ -254,6 +254,24 @@ To enable/disable GPS noise:
 The next time you build/restart Gazebo it will use the new GPS noise setting.
 
 
+## Loading a Specific World {#set_world}
+
+By default Gazebo displays a flat featureless plane, as defined in [empty.world](https://github.com/PX4/sitl_gazebo/blob/master/worlds/empty.world).
+
+You can load any of the worlds in [PX4/sitl_gazebo/worlds](https://github.com/PX4/sitl_gazebo/tree/master/worlds)) by specifying them as the final option in the PX4 configuration target.
+For example, to load the *warehouse* world, you can append it as shown:
+```
+make px4_sitl_default gazebo_plane_cam__warehouse
+```
+
+> **Note** There are two underscores after the model (`plane_cam`) indicating that the default debugger is used (none).
+   See [Building the Code > PX4 Make Build Targets](../setup/building_px4.md#make_targets).
+
+
+You can also specify the full path to a world to load using the `PX4_SITL_WORLD` environment variable.
+This is useful if testing a new world that is not yet included with PX4.
+
+
 ## Starting Gazebo and PX4 Separately {#start_px4_sim_separately}
 
 For extended development sessions it might be more convenient to start Gazebo and PX4 separately or even from within an IDE.


### PR DESCRIPTION
Docs for https://github.com/PX4/Firmware/pull/14166

@Jaeyoung-Lim I haven't been able to fully test this because in my VM the video does not display the world. But I can see than the world is correctly set using the two underscores.

Can you please review this closely and confirm the docs are correct and sufficient?