### PR TITLE
Windows: switch to Cygwin toolchain v0.9

### DIFF
--- a/en/setup/dev_env_windows_cygwin.md
+++ b/en/setup/dev_env_windows_cygwin.md
@@ -14,8 +14,9 @@ This topic explains how download and use the environment, and how it can be exte
 
 ## Installation Instructions {#installation}
 
-1. Download the latest version of the ready-to-use MSI installer from [Github releases](https://github.com/PX4/windows-toolchain/releases) or
-[latest stable fast download from Amazon](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.8.msi)
+1. Download the latest version of the ready-to-use MSI installer from:
+[Github releases](https://github.com/PX4/windows-toolchain/releases) or
+[latest stable fast download from Amazon](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.9.msi)
 1. Run it, choose your desired installation location, let it install:
     ![jMAVSimOnWindows](../../assets/toolchain/cygwin_toolchain_installer.PNG)
 1. Tick the box at the end of the installation to *clone the PX4 repository, build and run simulation with jMAVSim* (this simplifies the process to get you started). 

--- a/en/setup/dev_env_windows_cygwin.md
+++ b/en/setup/dev_env_windows_cygwin.md
@@ -14,9 +14,7 @@ This topic explains how download and use the environment, and how it can be exte
 
 ## Installation Instructions {#installation}
 
-1. Download the latest version of the ready-to-use MSI installer from:
-[Github releases](https://github.com/PX4/windows-toolchain/releases) or
-[latest stable fast download from Amazon](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.9.msi)
+1. Download the latest version of the ready-to-use MSI installer from: [Github releases](https://github.com/PX4/windows-toolchain/releases) or [Amazon S3](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.9.msi) (fast download).
 1. Run it, choose your desired installation location, let it install:
     ![jMAVSimOnWindows](../../assets/toolchain/cygwin_toolchain_installer.PNG)
 1. Tick the box at the end of the installation to *clone the PX4 repository, build and run simulation with jMAVSim* (this simplifies the process to get you started). 


### PR DESCRIPTION
Follow up to #979  finally switching the stable link after it has been fixed and verified https://github.com/PX4/windows-toolchain/releases/tag/v0.9 and is now running in CI for master with the merge of https://github.com/PX4/Firmware/pull/14401

@hamishwillee Sorry for any churn. I'll clearly declare the experimental builds in the GitHub releases and update the docs to stable ones.