### PR TITLE
Linux_sbus - update to reflect current driver

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -116,7 +116,7 @@
   * [Ground Control Station](qgc/README.md)
   * [Video Streaming in QGC](qgc/video_streaming.md)
   * [Long-distance Video Streaming](qgc/video_streaming_wifi_broadcast.md)
-  * [Connecting an S.Bus Receiver on Linux](tutorials/linux_sbus.md)
+  * [Connecting an RC Receiver on Linux](tutorials/linux_sbus.md)
 * [Advanced Topics](advanced/README.md)
   * [Parameters & Configs](advanced/parameters_and_configurations.md)
   * [Parameter Reference](advanced/parameter_reference.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -116,7 +116,7 @@
   * [Ground Control Station](qgc/README.md)
   * [Video Streaming in QGC](qgc/video_streaming.md)
   * [Long-distance Video Streaming](qgc/video_streaming_wifi_broadcast.md)
-  * [S.Bus Driver for Linux](tutorials/linux_sbus.md)
+  * [Connecting an S.Bus Receiver on Linux](tutorials/linux_sbus.md)
 * [Advanced Topics](advanced/README.md)
   * [Parameters & Configs](advanced/parameters_and_configurations.md)
   * [Parameter Reference](advanced/parameter_reference.md)

--- a/en/tutorials/linux_sbus.md
+++ b/en/tutorials/linux_sbus.md
@@ -1,17 +1,22 @@
 # S.Bus Driver for Linux
 
-The *S.Bus Driver for Linux* allows a Linux-based autopilot to access up to 16 channels from a *Futaba S.Bus receiver* via a serial port. The driver should also work with other receivers that use the S.Bus protocol, including as FrSky, RadioLink, and even S.Bus encoders. 
+The *S.Bus Driver for Linux* allows a Linux-based autopilot to access up to 16 channels from a *Futaba S.Bus receiver* via a serial port.
+The driver should also work with other receivers that use the S.Bus protocol, including as FrSky, RadioLink, and even S.Bus encoders.
 
 A signal inverter circuit is required (described below) to enable the device serial port to read data from the receiver.
 
-> **Note** The driver has been tested on Raspberry Pi running Rasbian Linux, when connected to the receiver through the onboard serial port or via a USB to TTY serial cable. It is expected to work on all Linux versions, and through all serial ports.
+> **Note** The driver has been tested on Raspberry Pi running Rasbian Linux, when connected to the receiver through the onboard serial port or via a USB to TTY serial cable.
+  It is expected to work on all Linux versions, and through all serial ports.
 
 
 ## Signal inverter circuit
 
-S.Bus is an *inverted* UART communication signal. As many serial ports/flight controllers cannot read an inverted UART signal, a signal inverter circuit is required between the receiver and serial port un-invert the signal. This section shows how to create an appropriate circuit.
+S.Bus is an *inverted* UART communication signal.
+As many serial ports/flight controllers cannot read an inverted UART signal, a signal inverter circuit is required between the receiver and serial port un-invert the signal.
+This section shows how to create an appropriate circuit.
 
-> **Tip** This circuit is required for Raspberry Pi to read S.Bus remote control signals through the serial port or USB-to-TTY serial converter. It will also be required for many other flight controllers.
+> **Tip** This circuit is required for Raspberry Pi to read S.Bus remote control signals through the serial port or USB-to-TTY serial converter.
+  It will also be required for many other flight controllers.
 
 ### Required components
 
@@ -47,7 +52,7 @@ The image below shows the connections on a breadboard.
 
 ## Source code
 
-* [Firmware/src/drivers/linux_sbus](https://github.com/PX4/Firmware/tree/master/src/drivers/linux_sbus)
+* [Firmware/src/drivers/linux_sbus](https://github.com/PX4/Firmware/tree/master/src/drivers/linux_sbus) 
 
 ## Usage
 
@@ -63,5 +68,6 @@ So for example, to automatically start the driver listening to 8 channels on dev
 linux_sbus start -d /dev/ttyUSB0 -c 8
 ```
 
-> **Note** The original configuration files are located in **Firmware/posix-configs**. According to the official documentation, after you finish `make upload` related operations, all posix related configuration files will be placed in **/home/pi**. You can modify the file you want to use there.
-
+> **Note** The original configuration files are located in **Firmware/posix-configs**.
+  According to the official documentation, after you finish `make upload` related operations, all posix related configuration files will be placed in **/home/pi**.
+  You can modify the file you want to use there.

--- a/en/tutorials/linux_sbus.md
+++ b/en/tutorials/linux_sbus.md
@@ -1,36 +1,33 @@
-# S.Bus Driver for Linux
+# Connecting an S.Bus Receiver on Linux
 
-The *S.Bus Driver for Linux* allows a Linux-based autopilot to access up to 16 channels from a *Futaba S.Bus receiver* via a serial port.
-The driver should also work with other receivers that use the S.Bus protocol, including as FrSky, RadioLink, and even S.Bus encoders.
+This topic shows how to setup a linux-based autopilot to use an S.Bus reciever (or encoder - e.g. from Futaba, RadioLink, etc.) via any serial port.
 
-A signal inverter circuit is required (described below) to enable the device serial port to read data from the receiver.
+The main requirements are:
+- A [signal inverter circuit](#signal_inverter_circuit) is (usually) needed to connect the receiver and device.
+- [Start the generic PX4 RC driver](#start_driver) on the device.
 
-> **Note** The driver has been tested on Raspberry Pi running Rasbian Linux, when connected to the receiver through the onboard serial port or via a USB to TTY serial cable.
-  It is expected to work on all Linux versions, and through all serial ports.
+> **Note** The approach is expected to work for all Linux versions and through all serial ports, including via a USB to TTY serial cable (e.g. like PL2302 USB to Serial TTL converter).
 
-
-## Signal inverter circuit
+## Signal Inverter Circuit {#signal_inverter_circuit}
 
 S.Bus is an *inverted* UART communication signal.
-As many serial ports/flight controllers cannot read an inverted UART signal, a signal inverter circuit is required between the receiver and serial port un-invert the signal.
+
+While some serial ports/flight controllers can read an inverted UART signal, most require a signal inverter circuit between the receiver and serial port to un-invert the signal.
+
+> **Tip** This circuit is also required to read S.Bus remote control signals through the serial port or USB-to-TTY serial converter.
+
 This section shows how to create an appropriate circuit.
 
-> **Tip** This circuit is required for Raspberry Pi to read S.Bus remote control signals through the serial port or USB-to-TTY serial converter.
-  It will also be required for many other flight controllers.
+### Required Components
 
-### Required components
-
-* 1x NPN transistor (e.g. NPN S9014 TO92)  
+* 1x NPN transistor (e.g. NPN S9014 TO92)
 * 1x 10K resistor
 * 1x 1K resistor
 
 > **Note** Any type/model of transistor can be used because the current drain is very low.
 
-<span></span>
-> **Tip** Raspberry Pi only has a single serial port. If this is already being used you can alternatively connect your S.Bus receiver to the RaPi USB port, via a USB to TTY serial cable (e.g. PL2302 USB to TTL serial converter)
 
-
-### Circuit diagram/Connections
+### Circuit Diagram/Connections
 
 Connect the components as described below (and shown in the circuit diagram):
 
@@ -42,32 +39,15 @@ Connect the components as described below (and shown in the circuit diagram):
 
 ![Signal inverter circuit diagram](../../assets/driver_sbus_signal_inverter_circuit_diagram.png)
 
-
-### Breadboard image
-
 The image below shows the connections on a breadboard.
 
 ![Signal inverter breadboard](../../assets/driver_sbus_signal_inverter_breadboard.png)
 
+## Starting the Driver {#start_driver}
 
-## Source code
-
-* [Firmware/src/drivers/linux_sbus](https://github.com/PX4/Firmware/tree/master/src/drivers/linux_sbus) 
-
-## Usage
-
-The command syntax is:
-
+To start the RC driver on a particular UART (e.g. in this case `/dev/ttyS2`): 
 ```
-linux_sbus start|stop|status -d <device> -c <channel>
+rc_input start -d /dev/ttyS2
 ```
 
-So for example, to automatically start the driver listening to 8 channels on device `/dev/ttyUSB0`, you would add the following line to the startup configuration file.
-
-```
-linux_sbus start -d /dev/ttyUSB0 -c 8
-```
-
-> **Note** The original configuration files are located in **Firmware/posix-configs**.
-  According to the official documentation, after you finish `make upload` related operations, all posix related configuration files will be placed in **/home/pi**.
-  You can modify the file you want to use there.
+For other driver usage information see: [rc_input](../middleware/modules_driver.md#rcinput).

--- a/en/tutorials/linux_sbus.md
+++ b/en/tutorials/linux_sbus.md
@@ -1,14 +1,25 @@
-# Connecting an S.Bus Receiver on Linux
+# Connecting an RC Receiver on Linux (Including S.Bus)
 
-This topic shows how to setup a linux-based autopilot to use an S.Bus reciever (or encoder - e.g. from Futaba, RadioLink, etc.) via any serial port.
+This topic shows how to setup a PX4 Linux-based autopilot to connect and use a [supported RC receiver](https://docs.px4.io/master/en/getting_started/rc_transmitter_receiver.html) on any serial port.
 
-The main requirements are:
-- A [signal inverter circuit](#signal_inverter_circuit) is (usually) needed to connect the receiver and device.
-- [Start the generic PX4 RC driver](#start_driver) on the device.
+For RC types other than S.Bus, you can just connect the receiver directly to the serial ports, or to USB via a USB to TTY serial cable (e.g. like PL2302 USB to Serial TTL converter).
 
-> **Note** The approach is expected to work for all Linux versions and through all serial ports, including via a USB to TTY serial cable (e.g. like PL2302 USB to Serial TTL converter).
+> **Note** For an S.Bus reciever (or encoder - e.g. from Futaba, RadioLink, etc.) you will usually need to connect the receiver and device via a [signal inverter circuit](#signal_inverter_circuit), but otherwise the setup is the same.
 
-## Signal Inverter Circuit {#signal_inverter_circuit}
+Then [Start the PX4 RC Driver](#start_driver) on the device, as shown below.
+
+
+## Starting the Driver {#start_driver}
+
+To start the RC driver on a particular UART (e.g. in this case `/dev/ttyS2`): 
+```
+rc_input start -d /dev/ttyS2
+```
+
+For other driver usage information see: [rc_input](../middleware/modules_driver.md#rcinput).
+
+
+## Signal Inverter Circuit (S.Bus only) {#signal_inverter_circuit}
 
 S.Bus is an *inverted* UART communication signal.
 
@@ -42,12 +53,3 @@ Connect the components as described below (and shown in the circuit diagram):
 The image below shows the connections on a breadboard.
 
 ![Signal inverter breadboard](../../assets/driver_sbus_signal_inverter_breadboard.png)
-
-## Starting the Driver {#start_driver}
-
-To start the RC driver on a particular UART (e.g. in this case `/dev/ttyS2`): 
-```
-rc_input start -d /dev/ttyS2
-```
-
-For other driver usage information see: [rc_input](../middleware/modules_driver.md#rcinput).


### PR DESCRIPTION
@bkueng There is a link to source code broken in this: https://github.com/PX4/Firmware/tree/master/src/drivers/linux_sbus

Does this driver still exist?

If not, is this page still relevant? What needs to happen.

[Note, the actual changes to the page are minor, mostly this exists to determine what happened to the link]