### PR TITLE
Video Streaming in QGC Odroid - Still Useful?

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -114,7 +114,7 @@
   * [ULog File Format](log/ulog_file_format.md)
 * [Tutorials](tutorials/tutorials.md)
   * [Ground Control Station](qgc/README.md)
-  * [Video Streaming in QGC](qgc/video_streaming.md)
+  * [Video Streaming from Odroid C1 to QGC](qgc/video_streaming.md)
   * [Long-distance Video Streaming](qgc/video_streaming_wifi_broadcast.md)
   * [S.Bus Driver for Linux](tutorials/linux_sbus.md)
 * [Advanced Topics](advanced/README.md)

--- a/en/qgc/video_streaming.md
+++ b/en/qgc/video_streaming.md
@@ -2,7 +2,8 @@
 
 This page shows how to set up a a companion computer (Odroid C1) with a camera (Logitech C920) such that the video stream is transferred via the Odroid C1 to a network computer and displayed in the application QGroundControl that runs on this computer.
 
-The whole hardware setup is shown in the figure below. It consists of the following parts:
+The whole hardware setup is shown in the figure below.
+It consists of the following parts:
 * Odroid C1
 * Logitech camera C920
 * WiFi module TP-LINK TL-WN722N
@@ -11,22 +12,25 @@ The whole hardware setup is shown in the figure below. It consists of the follow
 
 ## Install Linux environment in Odroid C1
 
-To install the Linux environment (Ubuntu 14.04), follow the instruction given in the [Odroid C1 tutorial](https://pixhawk.org/peripherals/onboard_computers/odroid_c1). In this tutorial it is also shown how to access the Odroid C1 with a UART cable and how to establish Ethernet connection.
+To install the Linux environment (Ubuntu 14.04), follow the instruction given in the [Odroid C1 tutorial](https://pixhawk.org/peripherals/onboard_computers/odroid_c1).
+In this tutorial it is also shown how to access the Odroid C1 with a UART cable and how to establish Ethernet connection.
 
 ## Set up alternative power connection
 
-The Odroid C1 can be powered via the 5V DC jack. If the Odroid is mounted on a drone, it is recommended to solder two pins next to the 5V DC jack by applying the through-hole soldering [method](https://learn.sparkfun.com/tutorials/how-to-solder---through-hole-soldering) as shown in the figure below. The power is delivered by connecting the DC voltage source (5 V) via a jumper cable (red in the image above) with the Odroid C1 and connect the ground of the circuit with a jumper cable (black in the image above) with a ground pin of the Odroid C1 in the example setup. 
+The Odroid C1 can be powered via the 5V DC jack.
+If the Odroid is mounted on a drone, it is recommended to solder two pins next to the 5V DC jack by applying the through-hole soldering [method](https://learn.sparkfun.com/tutorials/how-to-solder---through-hole-soldering) as shown in the figure below. The power is delivered by connecting the DC voltage source (5 V) via a jumper cable (red in the image above) with the Odroid C1 and connect the ground of the circuit with a jumper cable (black in the image above) with a ground pin of the Odroid C1 in the example setup. 
 
 ![Power Pins](../../assets/videostreaming/power-pins.jpg)
 
 ## Enable WiFi connection for Odroid C1
 
-In this this tutorial the WiFi module TP-LINK TL-WN722N is used. To enable WiFi connection for the Odroid C1, follow the steps described in the [Odroid C1 tutorial](https://pixhawk.org/peripherals/onboard_computers/odroid_c1) in the section Establishing wifi connection with antenna.
+In this this tutorial the WiFi module TP-LINK TL-WN722N is used.
+To enable WiFi connection for the Odroid C1, follow the steps described in the [Odroid C1 tutorial](https://pixhawk.org/peripherals/onboard_computers/odroid_c1) in the section Establishing wifi connection with antenna.
 
 
 ## Configure as WiFi Access Point
 
-This sections shows how to set up the Odroid C1 such that it is an access point. 
+This sections shows how to set up the Odroid C1 such that it is an access point.
 The content is taken from the pixhawk.org "access point" tutorial (no longer available) with some small adaptions.
 To enable to stream the video from the camera via the Odroid C1 to the QGroundControl that runs on a computer it is not required to follow this section. However, it is shown here because setting up the Odroid C1 as an access point allows to use the system in a stand-alone fashion. The TP-LINK TL-WN722N is used as a WiFi module.
 In the ensuing steps it is assumed that the Odroid C1 assigns the name wlan0 to your WiFi module. Change all occurrences of wlan0 to the appropriate interface if different (e.g. wlan1).

--- a/en/qgc/video_streaming.md
+++ b/en/qgc/video_streaming.md
@@ -1,8 +1,8 @@
 # Video streaming in QGroundControl
 
-This page shows how to set up a a companion computer (Odroid C1) with a camera (Logitech C920) such that the video stream is transferred via the Odroid C1 to a network computer and displayed in the application QGroundControl that runs on this computer.
+This topic shows how to set up a companion computer (Odroid C1) with a camera (Logitech C920) such that the video stream is transferred via the Odroid C1, over wifi to a computer, and then displayed on that computer in *QGroundControl*.
 
-The whole hardware setup is shown in the figure below.
+The hardware setup is shown in the figure below.
 It consists of the following parts:
 * Odroid C1
 * Logitech camera C920
@@ -10,19 +10,23 @@ It consists of the following parts:
 
 ![Setup](../../assets/videostreaming/setup_whole.jpg)
 
-## Install Linux environment in Odroid C1
+> **Note** The instructions were tested on Ubuntu 14.04 but a similar approach should work for later Ubuntu versions.
+
+
+## Install Linux Environment in Odroid C1
 
 To install the Linux environment (Ubuntu 14.04), follow the instruction given in the [Odroid C1 tutorial](https://pixhawk.org/peripherals/onboard_computers/odroid_c1).
 In this tutorial it is also shown how to access the Odroid C1 with a UART cable and how to establish Ethernet connection.
 
-## Set up alternative power connection
+## Set up Alternative Power Connection
 
 The Odroid C1 can be powered via the 5V DC jack.
-If the Odroid is mounted on a drone, it is recommended to solder two pins next to the 5V DC jack by applying the through-hole soldering [method](https://learn.sparkfun.com/tutorials/how-to-solder---through-hole-soldering) as shown in the figure below. The power is delivered by connecting the DC voltage source (5 V) via a jumper cable (red in the image above) with the Odroid C1 and connect the ground of the circuit with a jumper cable (black in the image above) with a ground pin of the Odroid C1 in the example setup. 
+If the Odroid is mounted on a drone, it is recommended to solder two pins next to the 5V DC jack by applying the through-hole soldering [method](https://learn.sparkfun.com/tutorials/how-to-solder---through-hole-soldering) as shown in the figure below.
+The power is delivered by connecting the DC voltage source (5 V) via a jumper cable (red in the image above) with the Odroid C1 and connect the ground of the circuit with a jumper cable (black in the image above) with a ground pin of the Odroid C1 in the example setup.
 
 ![Power Pins](../../assets/videostreaming/power-pins.jpg)
 
-## Enable WiFi connection for Odroid C1
+## Enable WiFi Connection for Odroid C1
 
 In this this tutorial the WiFi module TP-LINK TL-WN722N is used.
 To enable WiFi connection for the Odroid C1, follow the steps described in the [Odroid C1 tutorial](https://pixhawk.org/peripherals/onboard_computers/odroid_c1) in the section Establishing wifi connection with antenna.
@@ -32,8 +36,11 @@ To enable WiFi connection for the Odroid C1, follow the steps described in the [
 
 This sections shows how to set up the Odroid C1 such that it is an access point.
 The content is taken from the pixhawk.org "access point" tutorial (no longer available) with some small adaptions.
-To enable to stream the video from the camera via the Odroid C1 to the QGroundControl that runs on a computer it is not required to follow this section. However, it is shown here because setting up the Odroid C1 as an access point allows to use the system in a stand-alone fashion. The TP-LINK TL-WN722N is used as a WiFi module.
-In the ensuing steps it is assumed that the Odroid C1 assigns the name wlan0 to your WiFi module. Change all occurrences of wlan0 to the appropriate interface if different (e.g. wlan1).
+To enable to stream the video from the camera via the Odroid C1 to the QGroundControl that runs on a computer it is not required to follow this section.
+However, it is shown here because setting up the Odroid C1 as an access point allows to use the system in a stand-alone fashion.
+The TP-LINK TL-WN722N is used as a WiFi module.
+In the ensuing steps it is assumed that the Odroid C1 assigns the name wlan0 to your WiFi module.
+Change all occurrences of wlan0 to the appropriate interface if different (e.g. wlan1).
 
 ### Onboard Computer as Access Point
 
@@ -46,7 +53,8 @@ Install the necessary software
 sudo apt-get install hostapd udhcpd
 ```
 
-Configure DHCP. Edit the file `/etc/udhcpd.conf`
+Configure DHCP.
+Edit the file `/etc/udhcpd.conf`
 
 ```bash
 start 192.168.2.100 # This is the range of IPs that the hotspot will give to client devices.
@@ -72,7 +80,8 @@ to
 #DHCPD_ENABLED="no"
 ```
 
-You will need to give the Onboard Computer a static IP address. Edit the file `/etc/network/interfaces` and replace the line `iface wlan0 inet dhcp` (or `iface wlan0 inet manual`) to:
+You will need to give the Onboard Computer a static IP address.
+Edit the file `/etc/network/interfaces` and replace the line `iface wlan0 inet dhcp` (or `iface wlan0 inet manual`) to:
 
 ```sh
 auto wlan0
@@ -84,7 +93,8 @@ broadcast 192.168.2.255
 wireless-power off
 ```
 
-Disable the original (WiFi Client) auto configuration. Change the lines (they probably will not be all next to each other or may not even be there at all):
+Disable the original (WiFi Client) auto configuration.
+Change the lines (they probably will not be all next to each other or may not even be there at all):
 
 ```sh
 allow-hotplug wlan0
@@ -99,7 +109,8 @@ to:
 #iface default inet dhcp
 ```
 
-If you have followed the *Odroid C1 tutorial* (originally pixhawk.org) to set up the WiFi connection, you might have created the file `/etc/network/intefaces.d/wlan0`. Please comment out all lines in that file such that those configurations have no effect anymore.
+If you have followed the *Odroid C1 tutorial* (originally pixhawk.org) to set up the WiFi connection, you might have created the file `/etc/network/intefaces.d/wlan0`.
+Please comment out all lines in that file such that those configurations have no effect anymore.
 
 Configure HostAPD: To create a WPA-secured network, edit the file `/etc/hostapd/hostapd.conf` (create it if it does not exist) and add the following lines: 
 
@@ -120,11 +131,13 @@ driver=nl80211
 # Change these to something else if you want
 ssid=OdroidC1
 wpa_passphrase=QGroundControl
-
 ```
 
-Change `ssid=`, `channel=`, and `wpa_passphrase=` to values of your choice. SSID is the hotspot's name which is broadcast to other devices, channel is what frequency the hotspot will run on, wpa_passphrase is the password for the wireless network. For many more options see the file `/usr/share/doc/hostapd/examples/hostapd.conf.gz`.
-Look for a channel that is not in use in the area. You can use tools such as *wavemon* for that. 
+Change `ssid=`, `channel=`, and `wpa_passphrase=` to values of your choice.
+SSID is the hotspot's name which is broadcast to other devices, channel is what frequency the hotspot will run on, wpa_passphrase is the password for the wireless network.
+For many more options see the file `/usr/share/doc/hostapd/examples/hostapd.conf.gz`.
+Look for a channel that is not in use in the area.
+You can use tools such as *wavemon* for that.
 
 Edit the file `/etc/default/hostapd` and change the line:
 
@@ -135,14 +148,16 @@ to:
 ```
 DAEMON_CONF="/etc/hostapd/hostapd.conf"
 ```
-Your Onboard Computer should now be hosting a wireless hotspot. To get the hotspot to start on boot, run these additional commands: 
+Your Onboard Computer should now be hosting a wireless hotspot.
+To get the hotspot to start on boot, run these additional commands: 
 
 ```
 sudo update-rc.d hostapd enable
 sudo update-rc.d udhcpd enable
 ```
 
-This is enough to have the Onboard Computer present itself as an Access Point and allow your ground station to connect. If you truly want to make it work as a real Access Point (routing the WiFi traffic to the Onboard Computer’s Ethernet connection), we need to configure the routing and network address translation (NAT). 
+This is enough to have the Onboard Computer present itself as an Access Point and allow your ground station to connect.
+If you truly want to make it work as a real Access Point (routing the WiFi traffic to the Onboard Computer’s Ethernet connection), we need to configure the routing and network address translation (NAT).
 Enable IP forwarding in the kernel: 
 
 ```sh
@@ -171,22 +186,23 @@ up iptables-restore < /etc/iptables.ipv4.nat
 
 # Gstreamer Installation
 
-To install gstreamer packages on the computer and on the Odroid C1 and start the stream, follow the instruction given in the [QGroundControl README](https://github.com/mavlink/qgroundcontrol/blob/master/src/VideoStreaming/README.md). 
+To install gstreamer packages on the computer and on the Odroid C1 and start the stream, follow the instruction given in the [QGroundControl README](https://github.com/mavlink/qgroundcontrol/blob/master/src/VideoStreaming/README.md).
 
 If you cannot start the stream on the Odroid with the uvch264s plugin, you can also try to start it with the v4l2src plugin:
 
 ```sh
 gst-launch-1.0 v4l2src device=/dev/video0 ! video/x-h264,width=1920,height=1080,framerate=24/1 ! h264parse ! rtph264pay ! udpsink host=xxx.xxx.xxx.xxx port=5000
 ```
-Where `xxx.xxx.xxx.xxx` is the IP address where QGC is running. 
+Where `xxx.xxx.xxx.xxx` is the IP address where QGC is running.
 
-> **Tip** If you get the system error: `Permission denied`, you might need to prepend `sudo` to the command above. Alternatively add the current user to the `video` group as shown below (and then logout/login): 
+> **Tip** If you get the system error: `Permission denied`, you might need to prepend `sudo` to the command above.
+Alternatively add the current user to the `video` group as shown below (and then logout/login): 
   ```sh
   sudo usermod -aG video $USER
   ```
 
-If everything works, you should see the video stream on the bottom left corner in the flight-mode window of QGroundControl as shown in the screenshot below. 
+If everything works, you should see the video stream on the bottom left corner in the flight-mode window of QGroundControl as shown in the screenshot below.
 
-![](../../assets/videostreaming/qgc-screenshot.png)
+![QGC Video Streaming](../../assets/videostreaming/qgc-screenshot.png)
 
 If you click on the video stream, the satellite map is shown in the left bottom corner and the video is shown in the whole background.

--- a/en/qgc/video_streaming.md
+++ b/en/qgc/video_streaming.md
@@ -1,6 +1,9 @@
-# Video streaming in QGroundControl
+# Video Streaming from Odroid C1 to QGroundControl
 
-This topic shows how to set up a companion computer (Odroid C1) with a camera (Logitech C920) such that the video stream is transferred via the Odroid C1, over wifi to a computer, and then displayed on that computer in *QGroundControl*.
+> **Tip** This article is somewhat out of date. 
+  Community members are encouraged to retest the instructions on a more recent Ubuntu version, and to import Odroid setup instructions into the wiki.
+
+This topic shows how to stream video from a camera (Logitech C920) attached to a companion computer ([Odroid C1](https://magazine.odroid.com/wp-content/uploads/odroid-c1-user-manual.pdf)) to another computer (over wifi) and display in *QGroundControl*.
 
 The hardware setup is shown in the figure below.
 It consists of the following parts:
@@ -10,13 +13,12 @@ It consists of the following parts:
 
 ![Setup](../../assets/videostreaming/setup_whole.jpg)
 
-> **Note** The instructions were tested on Ubuntu 14.04 but a similar approach should work for later Ubuntu versions.
-
+The instructions were tested on Ubuntu 14.04 but a similar approach should work for later Ubuntu versions.
 
 ## Install Linux Environment in Odroid C1
 
-To install the Linux environment (Ubuntu 14.04), follow the instruction given in the [Odroid C1 tutorial](https://pixhawk.org/peripherals/onboard_computers/odroid_c1).
-In this tutorial it is also shown how to access the Odroid C1 with a UART cable and how to establish Ethernet connection.
+To install the Linux environment (Ubuntu 14.04), follow the instruction given in the [Odroid C1 tutorial](http://web.archive.org/web/20180617111122/http://pixhawk.org/peripherals/onboard_computers/odroid_c1) (wayback machine).
+The tutorial also shows how to access the Odroid C1 with a UART cable and how to establish Ethernet connection.
 
 ## Set up Alternative Power Connection
 
@@ -29,7 +31,7 @@ The power is delivered by connecting the DC voltage source (5 V) via a jumper ca
 ## Enable WiFi Connection for Odroid C1
 
 In this this tutorial the WiFi module TP-LINK TL-WN722N is used.
-To enable WiFi connection for the Odroid C1, follow the steps described in the [Odroid C1 tutorial](https://pixhawk.org/peripherals/onboard_computers/odroid_c1) in the section Establishing wifi connection with antenna.
+To enable WiFi connection for the Odroid C1, follow the steps described in the [Odroid C1 tutorial](http://web.archive.org/web/20180617111122/http://pixhawk.org/peripherals/onboard_computers/odroid_c1) in the section Establishing wifi connection with antenna.
 
 
 ## Configure as WiFi Access Point
@@ -39,7 +41,8 @@ The content is taken from the pixhawk.org "access point" tutorial (no longer ava
 To enable to stream the video from the camera via the Odroid C1 to the QGroundControl that runs on a computer it is not required to follow this section.
 However, it is shown here because setting up the Odroid C1 as an access point allows to use the system in a stand-alone fashion.
 The TP-LINK TL-WN722N is used as a WiFi module.
-In the ensuing steps it is assumed that the Odroid C1 assigns the name wlan0 to your WiFi module.
+
+In the following steps it is assumed that the Odroid C1 assigns the name wlan0 to your WiFi module.
 Change all occurrences of wlan0 to the appropriate interface if different (e.g. wlan1).
 
 ### Onboard Computer as Access Point
@@ -206,6 +209,5 @@ Alternatively add the current user to the `video` group as shown below (and then
 If everything works, you should see the video stream on the bottom left corner in the flight-mode window of *QGroundControl* as shown in the screenshot below. 
 
 ![QGC displaying video stream](../../assets/videostreaming/qgc-screenshot.png)
-
 
 If you click on the video stream, the satellite map is shown in the left bottom corner and the video is shown in the whole background.


### PR DESCRIPTION
@bkueng This links to/relies on a link to now dead tutorial: https://pixhawk.org/peripherals/onboard_computers/odroid_c1 

The bit it references is setting up Ubuntu 14.04 on Odroid C1
Does this article still have value? i.e. could we reasonably remove it, and if we did, what would we lose?

My feeling is that generally it is useful to understand how to set up a camera to attach to a companion computer and stream to QGC. Not sure whether this particular computer is popular, whether the transmitter is still available, or that this article is up to date enough to be useful. 

Thoughts? If it is useful? If so, would it be recoverable by replacing the links with these (say)
- https://www.hardkernel.com/blog-2/ubuntu-18-04-lts-for-odroid-c1/
- https://wiki.odroid.com/odroid-c1/os_images/ubuntu/minimal

Or is there anyone else you know who might help
