### PR TITLE
Update install instructions and dependencies to Fast-RTPS

### DIFF
--- a/en/middleware/micrortps.md
+++ b/en/middleware/micrortps.md
@@ -3,7 +3,8 @@
 The *PX4-FastRTPS Bridge* adds a Real Time Publish Subscribe (RTPS) interface to PX4, enabling the exchange of [uORB messages](../middleware/uorb.md) between PX4 components and (offboard) *Fast RTPS* applications (including those built using the ROS2/ROS frameworks).
 
 > **Note** RTPS is the underlying protocol of the Object Management Group's (OMG) Data Distribution Service (DDS) standard.
-  It aims to enable scalable, real-time, dependable, high-performance and inter-operable data communication using the publish/subscribe pattern. *Fast RTPS* is a very lightweight cross-platform implementation of the latest version of the RTPS protocol and a minimum DDS API.
+  It aims to enable scalable, real-time, dependable, high-performance and inter-operable data communication using the publish/subscribe pattern.
+  *Fast RTPS* is a very lightweight cross-platform implementation of the latest version of the RTPS protocol and a minimum DDS API.
 
 RTPS has been adopted as the middleware for the ROS2 (Robot Operating System).
 The *Fast RTPS bridge* allows us to better integrate with ROS2, making it easy to share sensor values, commands, and other vehicle information.
@@ -54,9 +55,11 @@ The main elements of the architecture are the client and agent processes shown i
 ### ROS2/ROS application pipeline
 
 The application pipeline for ROS2 is very straightforward!
-Because ROS2 uses DDS/RTPS as its native communications middleware, you can create a ROS2 listener or advertiser node to publish and subscribe to uORB data on PX4, via the *PX4 Fast RTPS Bridge*. This is shown below.
+Because ROS2 uses DDS/RTPS as its native communications middleware, you can create a ROS2 listener or advertiser node to publish and subscribe to uORB data on PX4, via the *PX4 Fast RTPS Bridge*.
+This is shown below.
 
-> **Note** You do need to make sure that the message types, headers and source files used on both client and agent side (and consequently, on the ROS nodes) are generated from the same Interface Description Language (IDL) files. The `px4_ros_com` package provides the needed infrastructure for generating messages and headers needed by ROS2.
+> **Note** You do need to make sure that the message types, headers and source files used on both client and agent side (and consequently, on the ROS nodes) are generated from the same Interface Description Language (IDL) files.
+  The `px4_ros_com` package provides the needed infrastructure for generating messages and headers needed by ROS2.
 
 ![Architecture with ROS2](../../assets/middleware/micrortps/architecture_ros2.png)
 
@@ -88,11 +91,14 @@ The *Agent* must be separately/manually compiled for the target computer.
 The [px4_ros_com](https://github.com/PX4/px4_ros_com) package, when built, generates everything needed to access PX4 uORB messages from a ROS2 node (for ROS you also need [ros1_bridge](https://github.com/ros2/ros1_bridge)).
 This includes all the required components of the *PX4 RTPS bridge*, including the `micrortps_agent` and the IDL files (required by the `micrortps_agent`).
 
-The ROS and ROS2 message definition headers and interfaces are generated from the [px4_msgs](https://github.com/PX4/px4_msgs) package, which match the uORB messages counterparts under PX4 Firmware. These are required by `px4_ros_com` when generating the IDL files to be used by the `micrortps_agent`.
+The ROS and ROS2 message definition headers and interfaces are generated from the [px4_msgs](https://github.com/PX4/px4_msgs) package, which match the uORB messages counterparts under PX4 Firmware.
+These are required by `px4_ros_com` when generating the IDL files to be used by the `micrortps_agent`.
 
 Both `px4_ros_com` and `px4_msgs` packages have two separate branches:
-- a `master` branch, used with ROS2. It contains code to generate all the required ROS2 messages and IDL files to bridge PX4 with ROS2 nodes.
-- a `ros1` branch, used with ROS. It contains code to generate the ROS message headers and source files, which can be used *with* the `ros1_bridge` to share data between PX4 and ROS.
+- a `master` branch, used with ROS2.
+  It contains code to generate all the required ROS2 messages and IDL files to bridge PX4 with ROS2 nodes.
+- a `ros1` branch, used with ROS.
+  It contains code to generate the ROS message headers and source files, which can be used *with* the `ros1_bridge` to share data between PX4 and ROS.
 
 Both branches in `px4_ros_com` additionally include some example listener and advertiser example nodes.
 
@@ -102,7 +108,8 @@ Both branches in `px4_ros_com` additionally include some example listener and ad
 The generated bridge code will enable a specified subset of uORB topics to be published/subscribed via RTPS.
 This is true for both ROS or non-ROS applications.
 
-For *automatic code generation* there's a *yaml* definition file in the PX4 **Firmware/msg/tools/** directory called **uorb_rtps_message_ids.yaml**. This file defines the set of uORB messages to be used with RTPS, whether the messages are to be sent, received or both, and the RTPS ID for the message to be used in DDS/RTPS middleware.
+For *automatic code generation* there's a *yaml* definition file in the PX4 **Firmware/msg/tools/** directory called **uorb_rtps_message_ids.yaml**.
+This file defines the set of uORB messages to be used with RTPS, whether the messages are to be sent, received or both, and the RTPS ID for the message to be used in DDS/RTPS middleware.
 
 > **Note** An RTPS ID must be set for all messages.
 
@@ -292,7 +299,9 @@ As an example:
 
 The directory `px4_ros_com/scripts` contains multiple scripts that can be used to build both workspaces.
 
-To build both workspaces with a single script, use the `build_all.bash`. Check the usage with `source build_all.bash --help`. The most common way of using it is by passing the ROS(1) workspace directory path and also the PX4 Firmware directory path:
+To build both workspaces with a single script, use the `build_all.bash`.
+Check the usage with `source build_all.bash --help`.
+The most common way of using it is by passing the ROS(1) workspace directory path and also the PX4 Firmware directory path:
 
 ```sh
 $ source build_all.bash --ros1_ws_dir <path/to/px4_ros_com_ros1/ws>
@@ -472,7 +481,8 @@ To create a listener node on ROS2, lets take as an example the `sensor_combined_
 #include <px4_msgs/msg/sensor_combined.hpp>
 ```
 
-The above brings to use the required C++ libraries to interface with the ROS2 middleware. It also includes the required message header file.
+The above brings to use the required C++ libraries to interface with the ROS2 middleware.
+It also includes the required message header file.
 
 ```c++
 /**
@@ -697,7 +707,9 @@ And it should also get data being printed to the console output.
 
 ### Client reports that selected UART port is busy
 
-If the selected UART port is busy, it's possible that the MAVLink application is already being used. If both MAVLink and RTPS connections are required you will have to either move the connection to use another port or configure the port so that it can be shared. <!-- https://github.com/PX4/Devguide/issues/233 -->
+If the selected UART port is busy, it's possible that the MAVLink application is already being used.
+If both MAVLink and RTPS connections are required you will have to either move the connection to use another port or configure the port so that it can be shared.
+<!-- https://github.com/PX4/Devguide/issues/233 -->
 
 > **Tip** A quick/temporary fix to allow bridge testing during development is to stop MAVLink from *NuttShell*:
   ```sh

--- a/en/middleware/micrortps.md
+++ b/en/middleware/micrortps.md
@@ -70,8 +70,7 @@ This is needed because the first version of ROS does not support RTPS.
 
 ## Code generation
 
-> **Note** [Fast RTPS 1.8.2 or later must be installed](../setup/fast-rtps-installation.md) in order to generate the required code!
-> *Fast RTPS* is installed *by default* if you use the normal installers/scripts for [macOS](../setup/dev_env_mac.md), or [Windows Cygwin](../setup/dev_env_windows_cygwin.md) (but not [Ubuntu](../setup/dev_env_linux_ubuntu.md) at time of writing).
+> **Note** [Fast RTPS 1.8.2 and FastRTPSGen 1.0.4 or later must be installed](../setup/fast-rtps-installation.md) in order to generate the required code!
 
 ### ROS-independent applications
 
@@ -258,7 +257,7 @@ In order to install ROS Melodic and ROS2 Dashing (officially supported) on a Ubu
    ```sh
    sudo pip3 install -U setuptools
    ```
-   
+
    > **Caution** Do not install the `ros1_bridge` package through the deb repository.
      The package must be built from source.
 

--- a/en/setup/fast-rtps-installation.md
+++ b/en/setup/fast-rtps-installation.md
@@ -15,15 +15,6 @@ For more information see: [RTPS/ROS2 Interface: PX4-FastRTPS Bridge](../middlewa
   - [Installation from Sources](http://eprosima-fast-rtps.readthedocs.io/en/latest/sources.html#installation-from-sources)
   - [Installation from Binaries](http://eprosima-fast-rtps.readthedocs.io/en/latest/binaries.html#installation-from-binaries)
 
-## Standard Installations
-
-Fast RTPS is installed as part of the PX4 developer environment on some platforms:
-
-* [Development Environment on Mac](../setup/dev_env_mac.md) (FastRTPS included in common tools)
-* [Development Environment on Windows > Bash on Windows](../setup/dev_env_windows_bash_on_win.md) (FastRTPS included in install script)
-
-The instruction below are useful for adding FastRTPS support in other environments.
-
 
 ## Requirements
 
@@ -36,7 +27,6 @@ The instruction below are useful for adding FastRTPS support in other environmen
 
 Java is required to use our built-in code generation tool - *fastrtpsgen*. [Java JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) is recommended.
 
-
 ### Windows 7 32-bit and 64-bit
 
 #### Visual C++ 2013 or 2015 Redistributable Package
@@ -47,6 +37,8 @@ The installer gives you the option of downloading and installing them.
 
 
 ## Installation from Sources
+
+### Fast-RTPS
 
 Clone the project from Github:
 
@@ -61,37 +53,46 @@ $ mkdir build && cd build
 If you are on Linux, execute:
 
 ```sh
-$ cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON ..
+$ cmake -DTHIRDPARTY=ON -DSECURITY=ON ..
 $ make
 $ sudo make install
 ```
-This will install Fast RTPS to `/usr/local`.
-You can use `-DCMAKE_INSTALL_PREFIX=<path>` to install to a custom location.
-Afterwards make sure the `fastrtpsgen` application is in your `PATH`.
-You can check with `which fastrtpsgen`.
 
-Then install Fast-RTPS-Gen (Gradle is required for this): 
-```
-git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.2 ~/Fast-RTPS-Gen \
-    && cd ~/Fast-RTPS-Gen \
-    && gradle assemble \
-    && sudo cp share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/ \
-    && sudo cp scripts/fastrtpsgen /usr/local/bin/
-```
+This will install Fast RTPS to `/usr/local`, with secure communications support.
+You can use `-DCMAKE_INSTALL_PREFIX=<path>` to install to a custom location.
 
 If you are on Windows, choose your version of *Visual Studio*:
 
 ```sh
-> cmake -G "Visual Studio 14 2015 Win64" -DTHIRDPARTY=ON -DBUILD_JAVA=ON ..
+> cmake -G "Visual Studio 14 2015 Win64" -DTHIRDPARTY=ON -DSECURITY=ON ..
 > cmake --build . --target install
 ```
+
+#### Compile options
+
 If you want to compile the examples, you will need to add the argument `-DCOMPILE_EXAMPLES=ON` when calling *CMake*.
 
 If you want to compile the performance tests, you will need to add the argument `-DPERFORMANCE_TESTS=ON` when calling *CMake*.
 
+### Fast-RTPS-Gen
+
+*Fast-RTPS-Gen* is the Fast RTPS IDL code generator tool. It should be installed after Fast RTPS and made sure the `fastrtpsgen` application is in your `PATH`.
+You can check with `which fastrtpsgen`.
+
+Then install Fast-RTPS-Gen 1.0.4 (Gradle is required for this):
+```
+git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.4 ~/Fast-RTPS-Gen \
+    && cd ~/Fast-RTPS-Gen \
+    && gradle assemble \
+    && gradle install
+```
+
+> **Note** You might require `sudo` permissions on the "install" step
 
 
 ## Installation from Binaries
+
+> **Note** Although the binaries are available, we recommend to build and install the code from source, given that the binaries may not come with required components and dependencies in place.
 
 You can always download the latest binary release of *eProsima Fast RTPS* from the [company website](http://www.eprosima.com/).
 
@@ -107,6 +108,7 @@ Execute the installer and follow the instructions, choosing your preferred *Visu
 *eProsima Fast RTPS* requires the following environmental variable setup in order to function properly
 
 * `FASTRTPSHOME`: Root folder where *eProsima Fast RTPS* is installed.
+* `FASTRTPSGEN_DIR`: Root folder where *eProsima FastRTPSGen* is installed.
 * Additions to the `PATH`: the **/bin** folder and the subfolder for your Visual Studio version of choice should be appended to the PATH.
 
 These variables are set automatically by checking the corresponding box during the installation process.
@@ -134,3 +136,7 @@ After configuring the project compile and install the library:
 ```sh
 $ sudo make install
 ```
+
+#### Environmental Variables
+
+* `FASTRTPSGEN_DIR`: Root folder where *eProsima FastRTPSGen* is installed, usually set to `/usr/local`, which is the default installation directory. If the user sets a different install directory in the `gradle install` step, it must set it here as well.


### PR DESCRIPTION
@hamishwillee this is an update to the install instructions for Fast-RTPS. Some changes/notes:

1.  We do not install Fast-RTPS or Fast-RTPS-Gen with the Windows toolchain - that's actually something that I asked @MaEtUgR if he could take care of in his spare time - so I removed references to it;
2.  Fast-RTPS (and consequently, Fast-RTPS-Gen) that comes with with the `px4-dev` homebrew formula is quite outdated and I am already taking care of updating it in https://github.com/PX4/homebrew-px4/pull/52 - so I removed references to it;
3. I updated FastRTPSGen version to 1.0.4, which comes with an handy update, already used in PX4 Firmware master - https://github.com/PX4/Firmware/pull/14590.

So for an effective use of the microRTPS bridge, with or without ROS2, people should have installed Fast-RTPS 1.8.2 or later and Fast-RTPS-Gen 1.0.4 (or later).