### PR TITLE
Fix user guide links to point to master branch

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -3,11 +3,11 @@
 [![Releases](https://img.shields.io/badge/release-{{ book.px4_version }}-blue.svg)](https://github.com/PX4/Firmware/releases) [![Discuss](https://img.shields.io/badge/discuss-px4-ff69b4.svg)](http://discuss.px4.io/) [![Slack](https://px4-slack.herokuapp.com/badge.svg)](http://slack.px4.io)
 
 > **Info** This guide is for primarily for software developers and (new) hardware integrators.
-> To fly, build and modify vehicles using supported hardware see the [PX4 User Guide](https://docs.px4.io/en/).
+> To fly, build and modify vehicles using supported hardware see the [PX4 User Guide](https://docs.px4.io/master/en/).
 
 This guide explains how to:
 
-* Get a [minimum developer setup](setup/config_initial.md), [build PX4 from source](setup/building_px4.md) and deploy on [numerous supported autopilots](https://docs.px4.io/en/flight_controller/).
+* Get a [minimum developer setup](setup/config_initial.md), [build PX4 from source](setup/building_px4.md) and deploy on [numerous supported autopilots](https://docs.px4.io/master/en/flight_controller/).
 * Understand the [PX4 System Architecture](concept/architecture.md) and other core concepts.
 * Learn how to modify the flight stack and middleware:
   - Modify flight algorithms and add new [flight modes](concept/flight_modes.md).

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -152,7 +152,7 @@
 
 ## Dronecode Shortcuts
 
-* [PX4 User Guide](https://docs.px4.io/en/)
+* [PX4 User Guide](https://docs.px4.io/master/en/)
 * [QGroundControl User Guide](https://docs.qgroundcontrol.com/en/)
 * [QGroundControl Developer Guide](https://dev.qgroundcontrol.com/en/)
 * [MAVLink Guide](https://mavlink.io/en/)

--- a/en/advanced/computer_vision.md
+++ b/en/advanced/computer_vision.md
@@ -8,8 +8,8 @@ PX4 uses computer vision systems (primarily running on [Companion Computers](../
   It is primarily used for indoor navigation.
 - [Visual Inertial Odometry](#vio) provides 3D pose and velocity estimation using an onboard vision system and IMU. 
   It is used for navigation when global position information is absent or unreliable.
-- [Obstacle Avoidance](https://docs.px4.io/en/computer_vision/obstacle_avoidance.html) provides navigation around obstacles when flying a planned path (currently missions are supported). This uses [PX4/avoidance](https://github.com/PX4/avoidance) running on a companion computer.
-- [Collision Prevention](https://docs.px4.io/en/computer_vision/collision_prevention.html) is used to stop vehicles before they can crash into an obstacle (primarily when flying in manual modes).
+- [Obstacle Avoidance](https://docs.px4.io/master/en/computer_vision/obstacle_avoidance.html) provides navigation around obstacles when flying a planned path (currently missions are supported). This uses [PX4/avoidance](https://github.com/PX4/avoidance) running on a companion computer.
+- [Collision Prevention](https://docs.px4.io/master/en/computer_vision/collision_prevention.html) is used to stop vehicles before they can crash into an obstacle (primarily when flying in manual modes).
 
 > **Tip** The [PX4 Vision Autonomy Development Kit](https://docs.px4.io/master/en/complete_vehicles/px4_vision_kit.html) (Holybro) is a robust and inexpensive kit for developers working with computer vision on PX4.
   It comes with [PX4 avoidance](https://github.com/PX4/avoidance#obstacle-detection-and-avoidance) software pre-installed, and can be used as the base for your own algorithms.
@@ -44,11 +44,11 @@ For information about VIO see:
 
 ## Optical Flow {#optical_flow}
 
-[Optical Flow](https://docs.px4.io/en/sensor/optical_flow.html) provides 2D velocity estimation (using a downward facing camera and a downward facing distance sensor).
+[Optical Flow](https://docs.px4.io/master/en/sensor/optical_flow.html) provides 2D velocity estimation (using a downward facing camera and a downward facing distance sensor).
 
 For information about optical flow see:
-- [Optical Flow](https://docs.px4.io/en/sensor/optical_flow.html)
-  - [PX4Flow Smart Camera](https://docs.px4.io/en/sensor/px4flow.html)
+- [Optical Flow](https://docs.px4.io/master/en/sensor/optical_flow.html)
+  - [PX4Flow Smart Camera](https://docs.px4.io/master/en/sensor/px4flow.html)
 - [EKF > Optical Flow](https://docs.px4.io/master/en/advanced_config/tuning_the_ecl_ekf.html#optical-flow)
 
 ## External Resources

--- a/en/advanced/gimbal_control.md
+++ b/en/advanced/gimbal_control.md
@@ -1,22 +1,22 @@
 # Gimbal Control Setup
 
-If you want to control a gimbal with a camera (or any other payload) attached to the vehicle, you need to configure how you want to control it and how PX4 can command it. 
+If you want to control a gimbal with a camera (or any other payload) attached to the vehicle, you need to configure how you want to control it and how PX4 can command it.
 This page explains the setup.
 
-PX4 contains a generic mount/gimbal control driver with different input and output methods. 
-The input defines how you control the gimbal: via RC or via MAVLink commands (for example in missions or surveys). 
+PX4 contains a generic mount/gimbal control driver with different input and output methods.
+The input defines how you control the gimbal: via RC or via MAVLink commands (for example in missions or surveys).
 The output defines how the gimbal is connected: some support MAVLink commands, others use PWM 
-(described as AUX output in the following). 
-Any input method can be selected to drive any output. 
+(described as AUX output in the following).
+Any input method can be selected to drive any output.
 Both have to be configured via parameters.
 
 ## Parameters
-[These parameters](../advanced/parameter_reference.md#mount) are used to setup the mount driver. 
-The most important ones are the input (`MNT_MODE_IN`) and the output (`MNT_MODE_OUT`) mode. 
-By default, the input is disabled and the driver does not run. 
+[These parameters](../advanced/parameter_reference.md#mount) are used to setup the mount driver.
+The most important ones are the input (`MNT_MODE_IN`) and the output (`MNT_MODE_OUT`) mode.
+By default, the input is disabled and the driver does not run.
 After selecting the input mode, reboot the vehicle so that the mount driver starts.
 
-If the input mode is set to `AUTO`, the mode will automatically be switched based on the latest input. 
+If the input mode is set to `AUTO`, the mode will automatically be switched based on the latest input.
 To switch from MAVLink to RC, a large stick motion is required.
 
 ## AUX output
@@ -59,7 +59,7 @@ S: 2 2  10000  10000      0 -10000  10000
 
 ## SITL
 
-The Typhoon H480 model comes with a preconfigured simulated gimbal. 
+The Typhoon H480 model comes with a preconfigured simulated gimbal.
 To run it, use:
 ```
 make px4_sitl gazebo_typhoon_h480

--- a/en/advanced/rtk_gps.md
+++ b/en/advanced/rtk_gps.md
@@ -2,7 +2,7 @@
 
 [Real Time Kinematic](https://en.wikipedia.org/wiki/Real_Time_Kinematic) (RTK) provides centimeter-level GPS accuracy. This page explains how RTK is integrated into PX4.
 
-> **Note** Instructions for *using* RTK GPS are provided in the [PX4 User Guide](https://docs.px4.io/en/advanced_features/rtk-gps.html).
+> **Note** Instructions for *using* RTK GPS are provided in the [PX4 User Guide](https://docs.px4.io/master/en/advanced_features/rtk-gps.html).
 
 ## Overview
 

--- a/en/airframes/README.md
+++ b/en/airframes/README.md
@@ -14,4 +14,4 @@ This section provides information that is relevant to developers who want to add
 > **Tip** PX4 is also well-suited for use in other vehicle types and general robots, ranging from submarine, boats, or amphibious vehicles, through to experimental aircraft and rockets. *Let us know* if you have a new vehicle or frame-type you want to help support in PX4.
 
 <span></span>
-> **Note** Build logs for some of the supported airframes can be found in [PX4 User Guide > Airframes](https://docs.px4.io/en/airframes/).
+> **Note** Build logs for some of the supported airframes can be found in [PX4 User Guide > Airframes](https://docs.px4.io/master/en/airframes/).

--- a/en/airframes/adding_a_new_frame.md
+++ b/en/airframes/adding_a_new_frame.md
@@ -209,7 +209,7 @@ S: 0 3      0  20000 -10000 -10000  10000
 
 ## Adding a New Airframe Group
 
-Airframe "groups" are used to group similar airframes for selection in [QGroundControl](https://docs.qgroundcontrol.com/en/SetupView/Airframe.html) and in the *Airframe Reference* documentation ([PX4 DevGuide](../airframes/airframe_reference.md) and [PX4 UserGuide](https://docs.px4.io/en/airframes/airframe_reference.html)).
+Airframe "groups" are used to group similar airframes for selection in [QGroundControl](https://docs.qgroundcontrol.com/en/SetupView/Airframe.html) and in the *Airframe Reference* documentation ([PX4 DevGuide](../airframes/airframe_reference.md) and [PX4 UserGuide](https://docs.px4.io/master/en/airframes/airframe_reference.html)).
 Every group has a name, and an associated svg image which shows the common geometry, number of motors, and direction of motor rotation for the grouped airframes.
 
 The airframe metadata files used by *QGroundControl* and the documentation source code are generated from the airframe description, via a script, using the build command: `make airframe_metadata`
@@ -254,14 +254,14 @@ If the airframe is for a **new group** you additionally need to:
 
 The following *PX4 User Guide* topics explain how to tune the parameters that will be specified in the config file:
 
-* [Multicopter PID Tuning Guide](https://docs.px4.io/en/advanced_config/pid_tuning_guide_multicopter.html)
-* [Fixed Wing PID Tuning Guide](https://docs.px4.io/en/advanced_config/pid_tuning_guide_fixedwing.html)
-* [VTOL Configuration](https://docs.px4.io/en/config_vtol/)
+* [Multicopter PID Tuning Guide](https://docs.px4.io/master/en/advanced_config/pid_tuning_guide_multicopter.html)
+* [Fixed Wing PID Tuning Guide](https://docs.px4.io/master/en/advanced_config/pid_tuning_guide_fixedwing.html)
+* [VTOL Configuration](https://docs.px4.io/master/en/config_vtol/)
 
 
 ## Add New Airframe to QGroundControl
 
-To make a new airframe available for section in the *QGroundControl* [airframe configuration](https://docs.px4.io/en/config/airframe.html):
+To make a new airframe available for section in the *QGroundControl* [airframe configuration](https://docs.px4.io/master/en/config/airframe.html):
 
 1. Make a clean build (e.g. by running `make clean` and then `make px4_fmu-v5_default`)
 1. Open QGC and select **Custom firmware file...** as shown below:

--- a/en/airframes/adding_a_new_frame.md
+++ b/en/airframes/adding_a_new_frame.md
@@ -32,7 +32,7 @@ This is used in the [Airframes Reference](../airframes/airframe_reference.md) an
 #
 # @name Wing Wing (aka Z-84) Flying Wing
 #
-# @url https://docs.px4.io/en/framebuild_plane/wing_wing_z84.html
+# @url https://docs.px4.io/master/en/framebuild_plane/wing_wing_z84.html
 #
 # @type Flying Wing
 # @class Plane
@@ -106,7 +106,7 @@ A typical mixer file is shown below ([original file here](https://github.com/PX4
 A mixer filename, in this case `wingwing.main.mix`, gives important information about the type of airframe (`wingwing`), the type of output (`.main` or `.aux`) and lastly that it is a mixer file (`.mix`).
 
 The mixer file contains several blocks of code, each of which refers to one actuator or ESC.
-So if you have e.g. two servos and one ESC, the mixer file will contain three blocks of code. 
+So if you have e.g. two servos and one ESC, the mixer file will contain three blocks of code.
 
 > **Note** The plugs of the servos / motors go in the order of the mixers in this file.
 
@@ -169,7 +169,7 @@ Elevon mixers
 Three scalers total (output, roll, pitch).
 
 The scaling factor for roll inputs is adjusted to implement differential travel
-for the elevons. 
+for the elevons.
 
 This first block of code is for Servo 0...
 
@@ -185,8 +185,8 @@ O:      10000  10000      0 -10000  10000
 S: 0 0  -6000  -6000      0 -10000  10000
 S: 0 1  -6500  -6500      0 -10000  10000
 
-Note that in principle, you could implement left/right wing asymmetric mixing, but in general the two blocks of code will be numerically equal, and just differ by the sign of the third line (S: 0 1), since to roll the plane, the two ailerons must move in OPPOSITE directions. 
-The signs of the second lines (S: 0 0) are indentical, since to pitch the plane, both servos need to move in the SAME direction. 
+Note that in principle, you could implement left/right wing asymmetric mixing, but in general the two blocks of code will be numerically equal, and just differ by the sign of the third line (S: 0 1), since to roll the plane, the two ailerons must move in OPPOSITE directions.
+The signs of the second lines (S: 0 0) are indentical, since to pitch the plane, both servos need to move in the SAME direction.
 
 Output 2
 --------
@@ -247,7 +247,7 @@ If the airframe is for a **new group** you additionally need to:
         <file alias="Airframe/FlyingWing">src/AutoPilotPlugins/Common/Images/FlyingWing.svg</file>
         ...
      ```
-   > **Note** The remaining airframe metadata should be automatically included in the firmware (once **srcparser.py** is updated). 
+   > **Note** The remaining airframe metadata should be automatically included in the firmware (once **srcparser.py** is updated).
 
 
 ## Tuning Gains
@@ -268,7 +268,7 @@ To make a new airframe available for section in the *QGroundControl* [airframe c
 
   ![QGC flash custom firmware](../../assets/gcs/qgc_flash_custom_firmware.png)
   
-  You will be asked to choose the **.px4** firmware file to flash (this file is a zipped JSON file and contains the airframe metadata). 
+  You will be asked to choose the **.px4** firmware file to flash (this file is a zipped JSON file and contains the airframe metadata).
 1. Navigate to the build folder and select the firmware file (e.g. **Firmware/build/px4_fmu-v5_default/px4_fmu-v5_default.px4**).
 1. Press **OK** to start flashing the firmware.
 1. Restart *QGroundControl*.

--- a/en/companion_computer/pixhawk_companion.md
+++ b/en/companion_computer/pixhawk_companion.md
@@ -4,7 +4,7 @@ Interfacing a companion computer (Raspberry Pi, Odroid, Tegra K1) to Pixhawk-fam
 
 ## Pixhawk Setup
 
-Enable MAVLink on any [configurable serial port](https://docs.px4.io/en/peripherals/serial_configuration.html).
+Enable MAVLink on any [configurable serial port](https://docs.px4.io/master/en/peripherals/serial_configuration.html).
 
 > **Tip** Typically the `TELEM 2` port is used for a companion computer.
 
@@ -13,7 +13,7 @@ To set up the default companion computer message stream on `TELEM 2`, set the fo
 * [MAV_1_MODE](../advanced/parameter_reference.md#MAV_1_MODE) = `Onboard`
 * [SER_TEL2_BAUD](../advanced/parameter_reference.md#SER_TEL2_BAUD) = `921600` (921600 or higher recommended for applications like log streaming or FastRTPS)
 
-For more information see [MAVLink Peripherals (GCS/OSD/Companion)](https://docs.px4.io/en/peripherals/mavlink_peripherals.html).
+For more information see [MAVLink Peripherals (GCS/OSD/Companion)](https://docs.px4.io/master/en/peripherals/mavlink_peripherals.html).
 
 
 ## Companion Computer Setup

--- a/en/data_links/sik_radio.md
+++ b/en/data_links/sik_radio.md
@@ -2,7 +2,7 @@
 
 [SiK radio](https://github.com/LorenzMeier/SiK) is a collection of firmware and tools for telemetry radios.
 
-Information about *using* SiK Radio can be found it the *PX4 User Guide*: [Telemetry > SiK Radio](http://docs.px4.io/en/telemetry/sik_radio.html)
+Information about *using* SiK Radio can be found it the *PX4 User Guide*: [Telemetry > SiK Radio](https://docs.px4.io/master/en/telemetry/sik_radio.html)
 
 The ("developer") information below explains how to build SiK firmware from source and configure it using AT commands.
 

--- a/en/data_links/telemetry.md
+++ b/en/data_links/telemetry.md
@@ -5,7 +5,7 @@ This section contains topics about advanced use of supported radios and integrat
 
 ## Supported Radio Systems 
 
-[PX4 User Guide > Telemetry](http://docs.px4.io/en/telemetry/) contains information about telemetry radio systems already supported by PX4. 
+[PX4 User Guide > Telemetry](https://docs.px4.io/master/en/telemetry/) contains information about telemetry radio systems already supported by PX4. 
 This includes radios that use the *SiK Radio* firmware and *3DR WiFi Telemetry Radios*.
 
 ## Integrating Telemetry Systems

--- a/en/data_links/telemetry.md
+++ b/en/data_links/telemetry.md
@@ -1,6 +1,7 @@
 # Telemetry Radios/Modems
 
-Telemetry Radios can (optionally) be used to provide a wireless MAVLink connection between a ground control station like *QGroundControl* and a vehicle running PX4. This section contains topics about advanced use of supported radios and integrating new telemetry systems into PX4. 
+Telemetry Radios can (optionally) be used to provide a wireless MAVLink connection between a ground control station like *QGroundControl* and a vehicle running PX4.
+This section contains topics about advanced use of supported radios and integrating new telemetry systems into PX4. 
 
 ## Supported Radio Systems 
 
@@ -9,6 +10,9 @@ This includes radios that use the *SiK Radio* firmware and *3DR WiFi Telemetry R
 
 ## Integrating Telemetry Systems
 
-PX4 enables MAVLink-based telemetry via the telemetry port of a Pixhawk-based flight controller. Provided that a telemetry radio supports MAVLink and provides a UART interface with compatible voltage levels/connector, no further integration is required.
+PX4 enables MAVLink-based telemetry via the telemetry port of a Pixhawk-based flight controller.
+Provided that a telemetry radio supports MAVLink and provides a UART interface with compatible voltage levels/connector, no further integration is required.
 
-Telemetry systems that communicate using some other protocol will need more extensive integration, potentially covering both software (e.g. device drivers) and hardware (connectors etc.). While this has been done for specific cases (e.g. [FrSky Telemetry](https://docs.px4.io/en/peripherals/frsky_telemetry.html) enables sending vehicle status to an RC controller via an FrSky receiver) providing general advice is difficult. We recommend you start by [discussing with the development team](../README.md#support).
+Telemetry systems that communicate using some other protocol will need more extensive integration, potentially covering both software (e.g. device drivers) and hardware (connectors etc.).
+While this has been done for
+specific cases (e.g. [FrSky Telemetry](https://docs.px4.io/master/en/peripherals/frsky_telemetry.html) enables sending vehicle status to an RC controller via an FrSky receiver) providing general advice is difficult. We recommend you start by [discussing with the development team](../README.md#support).

--- a/en/debug/faq.md
+++ b/en/debug/faq.md
@@ -6,7 +6,7 @@
 ### Flash Overflow
 
 > **Tip** Use the FMUv4 architecture to obtain double the flash.
-  The first available board from this generation is the [Pixracer](https://docs.px4.io/en/flight_controller/pixracer.html).
+  The first available board from this generation is the [Pixracer](https://docs.px4.io/master/en/flight_controller/pixracer.html).
 
 The amount of code that can be loaded onto a board is limited by the amount of flash memory it has.
 When adding additional modules or code its possible that the addition exceeds the flash memory.

--- a/en/flight_stack/controller_diagrams.md
+++ b/en/flight_stack/controller_diagrams.md
@@ -11,7 +11,7 @@ The diagrams use the standard [PX4 notation](../contribute/notation.md) (and eac
 <!-- The drawing is on draw.io: https://drive.google.com/open?id=13Mzjks1KqBiZZQs15nDN0r0Y9gM_EjtX
 Request access from dev team. -->
 
-* Estimates come from [EKF2](https://docs.px4.io/en/advanced_config/tuning_the_ecl_ekf.html).
+* Estimates come from [EKF2](https://docs.px4.io/master/en/advanced_config/tuning_the_ecl_ekf.html).
 * This is a standard cascaded position-velocity loop.
 * Depending on the mode, the outer (position) loop is bypassed (shown as a multiplexer after the outer loop). The position loop is only used when holding position or when the requested velocity in an axis is null.
 * The integrator in the inner loop (velocity) controller includes an anti-reset windup (ARW) using a clamping method.
@@ -117,7 +117,7 @@ For tailsitters, during transition the multicopter attitude controller is runnin
 The outputs of the VTOL attitude block are separate torque and force commands for the multicopter (typically `actuator_controls_0`) and fixed-wing (typically `actuator_controls_1`) actuators. 
 These are handled in an airframe-specific mixer file (see [Mixing](../concept/mixing.md)). 
 
-For more information on the tuning of the transition logic inside the VTOL block, see [VTOL Configuration](https://docs.px4.io/en/config_vtol/).
+For more information on the tuning of the transition logic inside the VTOL block, see [VTOL Configuration](https://docs.px4.io/master/en/config_vtol/).
 
 
 

--- a/en/hardware/README.md
+++ b/en/hardware/README.md
@@ -5,7 +5,7 @@ This section contains topics about:
 * Modifying PX4 to work with _new_ [flight controller hardware](../hardware/porting_guide.md) and [vehicles/airframes](../airframes/README.md)
 * Integrating new [sensors and actuators](../sensor_bus/README.md), [telemetry radio](../data_links/telemetry.md), and other peripherals. 
 
-> **Tip** The [PX4 User Guide](https://docs.px4.io/en/) contains topics about using and configuring _existing/supported_ hardware.
+> **Tip** The [PX4 User Guide](https://docs.px4.io/master/en/) contains topics about using and configuring _existing/supported_ hardware.
 
 
 

--- a/en/hardware/porting_guide.md
+++ b/en/hardware/porting_guide.md
@@ -59,7 +59,7 @@ One example is [px4fmu-v5](https://github.com/PX4/Firmware/blob/master/boards/px
 ## Officially Supported Hardware
 
 The PX4 project supports and maintains the [FMU standard reference hardware](../hardware/reference_design.md) and any boards that are compatible with the standard.
-This includes the [Pixhawk-series](https://docs.px4.io/en/flight_controller/pixhawk_series.html) (see the user guide for a [full list of officially supported hardware](https://docs.px4.io/en/flight_controller/)).
+This includes the [Pixhawk-series](https://docs.px4.io/master/en/flight_controller/pixhawk_series.html) (see the user guide for a [full list of officially supported hardware](https://docs.px4.io/master/en/flight_controller/)).
 
 Every officially supported board benefits from:
 * PX4 Port available in the PX4 repository
@@ -93,6 +93,6 @@ You can reach out to the core developer team and community on the official [Foru
 * [Device Drivers](../middleware/drivers.md) - How to support new peripheral hardware (device drivers)
 * [Building the Code](../setup/building_px4.md) - How to build source and upload firmware 
 * Supported Flight Controllers:
-  * [Autopilot Hardware](https://docs.px4.io/en/flight_controller/) (PX4 User Guide)
+  * [Autopilot Hardware](https://docs.px4.io/master/en/flight_controller/) (PX4 User Guide)
   * [Supported boards list](https://github.com/PX4/Firmware/#supported-hardware) (Github)
-* [Supported Peripherals](https://docs.px4.io/en/peripherals/) (PX4 User Guide)
+* [Supported Peripherals](https://docs.px4.io/master/en/peripherals/) (PX4 User Guide)

--- a/en/hardware/reference_design.md
+++ b/en/hardware/reference_design.md
@@ -1,6 +1,6 @@
 # PX4 Reference Flight Controller Design
 
-The PX4 reference design is the [Pixhawk series](https://docs.px4.io/en/flight_controller/pixhawk_series.html) of flight controllers. First released in 2011, this design is now in its 5th [generation](#reference_design_generations) (with the 6th generation board design in progress).
+The PX4 reference design is the [Pixhawk series](https://docs.px4.io/master/en/flight_controller/pixhawk_series.html) of flight controllers. First released in 2011, this design is now in its 5th [generation](#reference_design_generations) (with the 6th generation board design in progress).
 
 ## Binary Compatibility
 

--- a/en/log/flight_log_analysis.md
+++ b/en/log/flight_log_analysis.md
@@ -2,6 +2,6 @@
 
 Information about Flight Log Analysis is covered in the PX4 User Guide:
 
-- [Flight Reporting](https://docs.px4.io/en/getting_started/flight_reporting.html) - How to download a log and report/discuss issues about a flight.
-- [Log Analysis using Flight Review](https://docs.px4.io/en/log/flight_review.html) - How to analyse many common vehicle problems using the [Flight Review](https://logs.px4.io/) online tool.
-- [Flight Log Analysis](https://docs.px4.io/en/log/flight_log_analysis.html) - Introduction to flight analysis and links to a number of analysis tools.
+- [Flight Reporting](https://docs.px4.io/master/en/getting_started/flight_reporting.html) - How to download a log and report/discuss issues about a flight.
+- [Log Analysis using Flight Review](https://docs.px4.io/master/en/log/flight_review.html) - How to analyse many common vehicle problems using the [Flight Review](https://logs.px4.io/) online tool.
+- [Flight Log Analysis](https://docs.px4.io/master/en/log/flight_log_analysis.html) - Introduction to flight analysis and links to a number of analysis tools.

--- a/en/middleware/modules_estimator.md
+++ b/en/middleware/modules_estimator.md
@@ -49,7 +49,7 @@ Source: [modules/ekf2](https://github.com/PX4/Firmware/tree/master/src/modules/e
 ### Description
 Attitude and position estimator using an Extended Kalman Filter. It is used for Multirotors and Fixed-Wing.
 
-The documentation can be found on the [ECL/EKF Overview & Tuning](https://docs.px4.io/en/advanced_config/tuning_the_ecl_ekf.html) page.
+The documentation can be found on the [ECL/EKF Overview & Tuning](https://docs.px4.io/master/en/advanced_config/tuning_the_ecl_ekf.html) page.
 
 ekf2 can be started in replay mode (`-r`): in this mode it does not access the system time, but only uses the
 timestamps from the sensor topics.

--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -42,14 +42,16 @@ The following MAVLink "vision" messages are not currently supported by PX4:
 
 ## Reference Frames
 
-PX4 uses FRD (X **F**orward, Y **R**ight and Z **D**own) for the local body frame as well for the reference frame. When using the heading of the magnetometer, the PX4 reference frame x axis will be aligned with north, so therefore it is called NED (X **N**orth, Y **E**ast, Z **D**own). The heading of the reference frame of the PX4 estimator and the one of the external pose estimate will not match in most cases. Therefore the reference frame of the external pose estimate is named differently, it is called [MAV_FRAME_LOCAL_FRD](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_FRD).
+PX4 uses FRD (X **F**orward, Y **R**ight and Z **D**own) for the local body frame as well for the reference frame. When using the heading of the magnetometer, the PX4 reference frame x axis will be aligned with north, so therefore it is called NED (X **N**orth, Y **E**ast, Z **D**own). The heading of the reference frame of the PX4 estimator and the one of the external pose estimate will not match in most cases.
+Therefore the reference frame of the external pose estimate is named differently, it is called [MAV_FRAME_LOCAL_FRD](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_FRD).
 
-Depending on the source of your reference frame, you will need to apply a custom transformation to the pose estimate before sending the MAVLink Vision/MoCap message. This is necessary to change the orientation of the parent and child frame of the pose estimate, such that it fits the PX4 convention. Have a look at the MAVROS [*odom* plugin](https://github.com/mavlink/mavros/blob/master/mavros_extras/src/plugins/odom.cpp) for the necessary transformations.
+Depending on the source of your reference frame, you will need to apply a custom transformation to the pose estimate before sending the MAVLink Vision/MoCap message.
+This is necessary to change the orientation of the parent and child frame of the pose estimate, such that it fits the PX4 convention. Have a look at the MAVROS [*odom* plugin](https://github.com/mavlink/mavros/blob/master/mavros_extras/src/plugins/odom.cpp) for the necessary transformations.
 
 > **Tip** ROS users can find more detailed instructions below in [Reference Frames and ROS](#ros_reference_frames).
 
-For example, if using the Optitrack framework the local frame has $$x$$ and $$z$$ on the horizontal plane (*x* front and *z* right) while *y* axis is vertical and pointing up. 
-A simple trick is swapping axis in order to obtained NED convention. 
+For example, if using the Optitrack framework the local frame has $$x$$ and $$z$$ on the horizontal plane (*x* front and *z* right) while *y* axis is vertical and pointing up.
+A simple trick is swapping axis in order to obtained NED convention.
 
 If `x_{mav}`, `y_{mav}` and `z_{mav}` are the coordinates that are sent through MAVLink as position feedback, then we obtain:
 ```
@@ -58,7 +60,7 @@ y_{mav} = z_{mocap}
 z_{mav} = - y_{mocap}
 ```
 
-Regarding the orientation, keep the scalar part *w* of the quaternion the same and swap the vector part *x*, *y* and *z* in the same way. 
+Regarding the orientation, keep the scalar part *w* of the quaternion the same and swap the vector part *x*, *y* and *z* in the same way.
 You can apply this trick with every system - if you need to obtain a NED frame, look at your MoCap output and swap axis accordingly.
 
 
@@ -82,8 +84,8 @@ Parameter | Setting for External Position Estimation
 
 Or in other words, it is the difference between the vision system timestamp and the "actual" capture time that would have been recorded by the IMU clock (the "base clock" for EKF2).
 
-Technically this can be set to 0 if there is correct timestamping (not just arrival time) and timesync (e.g NTP) between MoCap and (for example) ROS computers. 
-In reality, this needs some empirical tuning since delays in the entire MoCap->PX4 chain are very setup-specific. 
+Technically this can be set to 0 if there is correct timestamping (not just arrival time) and timesync (e.g NTP) between MoCap and (for example) ROS computers.
+In reality, this needs some empirical tuning since delays in the entire MoCap->PX4 chain are very setup-specific.
 It is rare that a system is setup with an entirely synchronised chain!
 
 A rough estimate of the delay can be obtained from logs by checking the offset between IMU rates and the EV rates:
@@ -109,7 +111,7 @@ The following parameters must be set to use external position information with L
 Parameter | Setting for External Position Estimation
 --- | ---
 [LPE_FUSION](../advanced/parameter_reference.md#LPE_FUSION) | Vision integration is enabled if *fuse vision position* is checked (it is enabled by default).
-[ATT_EXT_HDG_M](../advanced/parameter_reference.md#ATT_EXT_HDG_M) | Set to 1 or 2 to enable external heading integration. Setting it to 1 will cause vision to be used, while 2 enables MoCap heading use. 
+[ATT_EXT_HDG_M](../advanced/parameter_reference.md#ATT_EXT_HDG_M) | Set to 1 or 2 to enable external heading integration. Setting it to 1 will cause vision to be used, while 2 enables MoCap heading use.
  
 
 ### Disabling Barometer Fusion
@@ -120,11 +122,11 @@ This can be done by in *QGroundControl* by unchecking the *fuse baro* option in 
 
 ### Tuning Noise Parameters
 
-If your vision or MoCap data is highly accurate, and you just want the estimator to track it tightly, you should reduce the standard deviation parameters: [LPE_VIS_XY](../advanced/parameter_reference.md#LPE_VIS_XY) and [LPE_VIS_Z](../advanced/parameter_reference.md#LPE_VIS_Z) (for VIO) or [LPE_VIC_P](../advanced/parameter_reference.md#LPE_VIC_P) (for MoCap). 
-Reducing them will cause the estimator to trust the incoming pose estimate more. 
-You may need to set them lower than the allowed minimum and force-save. 
+If your vision or MoCap data is highly accurate, and you just want the estimator to track it tightly, you should reduce the standard deviation parameters: [LPE_VIS_XY](../advanced/parameter_reference.md#LPE_VIS_XY) and [LPE_VIS_Z](../advanced/parameter_reference.md#LPE_VIS_Z) (for VIO) or [LPE_VIC_P](../advanced/parameter_reference.md#LPE_VIC_P) (for MoCap).
+Reducing them will cause the estimator to trust the incoming pose estimate more.
+You may need to set them lower than the allowed minimum and force-save.
 
-> **Tip** If performance is still poor, try increasing the [LPE_PN_V](../advanced/parameter_reference.md#LPE_PN_V) parameter. 
+> **Tip** If performance is still poor, try increasing the [LPE_PN_V](../advanced/parameter_reference.md#LPE_PN_V) parameter.
   This will cause the estimator to trust measurements more during velocity estimation.
 
 
@@ -137,7 +139,7 @@ PX4 must already have been set up as above.
 
 VIO and MoCap systems have different ways of obtaining pose data, and have their own setup and topics.
 
-The setup for specific systems is covered [below](#setup_specific_systems). 
+The setup for specific systems is covered [below](#setup_specific_systems).
 For other systems consult the vendor setup documentation.
 
 
@@ -152,11 +154,11 @@ ROS | MAVLink | uORB
 /mavros/mocap/pose | [ATT_POS_MOCAP](https://mavlink.io/en/messages/common.html#ATT_POS_MOCAP) | `vehicle_mocap_odometry`
 /mavros/odometry/odom | [ODOMETRY](https://mavlink.io/en/messages/common.html#ODOMETRY) (`frame_id =` [MAV_FRAME_MOCAP_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_MOCAP_NED)) | `vehicle_mocap_odometry`
 
-You can use any of the above pipelines with LPE. 
+You can use any of the above pipelines with LPE.
 
-If you're working with EKF2, only the "vision" pipelines are supported. 
+If you're working with EKF2, only the "vision" pipelines are supported.
 To use MoCap data with EKF2 you will have to [remap](http://wiki.ros.org/roslaunch/XML/remap) the pose topic that you get from MoCap:
-- MoCap ROS topics of type `geometry_msgs/PoseStamped` or `geometry_msgs/PoseWithCovarianceStamped` must be remapped to `/mavros/vision_pose/pose`. 
+- MoCap ROS topics of type `geometry_msgs/PoseStamped` or `geometry_msgs/PoseWithCovarianceStamped` must be remapped to `/mavros/vision_pose/pose`.
   The `geometry_msgs/PoseStamped` topic is most common as MoCap doesn't usually have associated covariances to the data.
 - If you get data through a `nav_msgs/Odometry` ROS message then you will need to remap it to `/mavros/odometry/odom`.
 
@@ -178,35 +180,44 @@ Both frames are shown in the image below (FLU on left/FRD on right).
 
 With EKF2 when using external heading estimation, magnetic north can either be ignored and or the heading offset to magnetic north can be calculated and compensated. Depending on your choice the yaw angle is given with respect to either magnetic north or local *x*.
 
-> **Note** When creating the rigid body in the MoCap software, remember to first align the robot's local *x* axis with the world *x* axis otherwise the yaw estimate will have an offset. This can stop the external pose estimate fusion from working properly. Yaw angle should be zero when body and reference frame align.
+> **Note** When creating the rigid body in the MoCap software, remember to first align the robot's local *x* axis with the world *x* axis otherwise the yaw estimate will have an offset. This can stop the external pose estimate fusion from working properly.
+Yaw angle should be zero when body and reference frame align.
 
-Using MAVROS, this operation is straightforward. 
-ROS uses ENU frames as convention, therefore position feedback must be provided in ENU. 
-If you have an Optitrack system you can use [mocap_optitrack](https://github.com/ros-drivers/mocap_optitrack) node which streams the object pose on a ROS topic already in ENU. 
+Using MAVROS, this operation is straightforward.
+ROS uses ENU frames as convention, therefore position feedback must be provided in ENU.
+If you have an Optitrack system you can use [mocap_optitrack](https://github.com/ros-drivers/mocap_optitrack) node which streams the object pose on a ROS topic already in ENU.
 With a remapping you can directly publish it on `mocap_pose_estimate` as it is without any transformation and MAVROS will take care of NED conversions.
 
-The MAVROS odometry plugin makes it easy to handle the coordinate frames. It uses ROS's tf package. Your external pose system might have a completely different frame convention that does not match the one of PX4. The body frame of the external pose estimate can depend on how you set the body frame in the MOCAP software or on how you mount the VIO sensor on the drone. The MAVROS odometry plugin needs to know how the external pose's child frame is oriented with respect to either the airframe's FRD or FLU body frame known by MAVROS. You therefore have to add the external pose's body frame to the tf tree. This can be done by including an adapted version of the following line into your ROS launch file.
+The MAVROS odometry plugin makes it easy to handle the coordinate frames.
+It uses ROS's tf package. Your external pose system might have a completely different frame convention that does not match the one of PX4.
+The body frame of the external pose estimate can depend on how you set the body frame in the MOCAP software or on how you mount the VIO sensor on the drone.
+The MAVROS odometry plugin needs to know how the external pose's child frame is oriented with respect to either the airframe's FRD or FLU body frame known by MAVROS.
+You therefore have to add the external pose's body frame to the tf tree. This can be done by including an adapted version of the following line into your ROS launch file.
 
 ```
   <node pkg="tf" type="static_transform_publisher" name="tf_baseLink_externalPoseChildFrame"
         args="0 0 0 <yaw> <pitch> <roll> base_link <external_pose_child_frame> 1000"/>
 ```
-Make sure that you change the values of yaw, pitch and roll such that it properly attaches the external pose's body frame to the `base_link` or `base_link_frd`. Have a look at the [tf package](http://wiki.ros.org/tf#static_transform_publisher) for further help on how to specify the transformation between the frames. You can use rviz to check if you attached the frame right. The name of the `external_pose_child_frame` has to match the child_frame_id of your `nav_msgs/Odometry` message.
+Make sure that you change the values of yaw, pitch and roll such that it properly attaches the external pose's body frame to the `base_link` or `base_link_frd`.
+Have a look at the [tf package](http://wiki.ros.org/tf#static_transform_publisher) for further help on how to specify the transformation between the frames.
+You can use rviz to check if you attached the frame right. The name of the `external_pose_child_frame` has to match the child_frame_id of your `nav_msgs/Odometry` message.
 The same also applies for the reference frame of the external pose. You have to attach the reference frame of the external pose as child to either the `odom` or `odom_frd` frame. Adapt therefore the following code line accordingly.
 ```
   <node pkg="tf" type="static_transform_publisher" name="tf_odom_externalPoseParentFrame"
         args="0 0 0 <yaw> <pitch> <roll> odom <external_pose_parent_frame> 1000"/>
 ```
-If the reference frame has the z axis pointing upwards you can attached it without any rotation (yaw=0, pitch=0, roll=0) to the `odom` frame. The name of `external_pose_parent_frame` has to match the frame_id of the odometry message.
+If the reference frame has the z axis pointing upwards you can attached it without any rotation (yaw=0, pitch=0, roll=0) to the `odom` frame.
+The name of `external_pose_parent_frame` has to match the frame_id of the odometry message.
 
-> **Note** When using the MAVROS *odom* plugin, it is important that no other node is publishing a transform between the external pose's reference and child frame. This might break the *tf* tree.
+> **Note** When using the MAVROS *odom* plugin, it is important that no other node is publishing a transform between the external pose's reference and child frame.
+  This might break the *tf* tree.
 
 ## Specific System Setups {#setup_specific_systems}
 
 ### OptiTrack MoCap
 
-The following steps explain how to feed position estimates from an [OptiTrack](https://optitrack.com/motion-capture-robotics/) system to PX4. 
-It is assumed that the MoCap system is calibrated. 
+The following steps explain how to feed position estimates from an [OptiTrack](https://optitrack.com/motion-capture-robotics/) system to PX4.
+It is assumed that the MoCap system is calibrated.
 See [this video](https://www.youtube.com/watch?v=cNZaFEghTBU) for a tutorial on the calibration process.
 
 #### Steps on the *Motive* MoCap software
@@ -228,9 +239,9 @@ If you named the rigidbody as `robot1`, you will get a topic like `/vrpn_client_
 
 #### Relaying/remapping Pose Data
 
-MAVROS provides a plugin to relay pose data published on `/mavros/vision_pose/pose` to PX4. 
-Assuming that MAVROS is running, you just need to **remap** the pose topic that you get from MoCap `/vrpn_client_node/<rigid_body_name>/pose` directly to `/mavros/vision_pose/pose`. 
-Note that there is also a `mocap` topic that MAVROS provides to feed `ATT_POS_MOCAP` to PX4, but it is not applicable for EKF2. 
+MAVROS provides a plugin to relay pose data published on `/mavros/vision_pose/pose` to PX4.
+Assuming that MAVROS is running, you just need to **remap** the pose topic that you get from MoCap `/vrpn_client_node/<rigid_body_name>/pose` directly to `/mavros/vision_pose/pose`.
+Note that there is also a `mocap` topic that MAVROS provides to feed `ATT_POS_MOCAP` to PX4, but it is not applicable for EKF2.
 However, it is applicable with LPE.
 
 > **Note** Remapping pose topics is covered above [Relaying pose data to PX4](#relaying_pose_data_to_px4)
@@ -251,9 +262,14 @@ The instructions below show how to do so for MoCap and VIO systems
 Be sure to perform the following checks before your first flight:
 
 * Set the PX4 parameter `MAV_ODOM_LP` to 1. PX4 will therefore stream back the received external pose as MAVLink [ODOMETRY](https://mavlink.io/en/messages/common.html#ODOMETRY) messages.
-* It is recommended to check these MAVLink messages with e.g. the *Analyze* Widget of *QGroundControl*. In order to do this, yaw the vehicle until the quaternion of the ODOMETRY message is very close to a unit quaternion. (w=1, x=y=z=0)
+* It is recommended to check these MAVLink messages with e.g. the *Analyze* Widget of *QGroundControl*.
+  In order to do this, yaw the vehicle until the quaternion of the ODOMETRY message is very close to a unit quaternion. (w=1, x=y=z=0)
 * At this point the body frame is aligned with the reference frame of the external pose system. If you do not manage to get a quaternion close to the unit quaternion without rolling or pitching your vehicle, your frame probably still have a pitch or roll offset. Do not proceed if this is the case and check your coordinate frames again.
-* Once aligned you can pick the vehicle up from the ground and you should see the position's z coordinate decrease. Moving the vehicle in forward direction, should increase the position's x coordinate. While moving the vehicle to the right should increase the y coordinate. In the case you send also linear velocities from the external pose system, you should also check the linear velocities. Check that the linear velocities are in expressed in the *FRD* body frame reference frame.
+* Once aligned you can pick the vehicle up from the ground and you should see the position's z coordinate decrease.
+  Moving the vehicle in forward direction, should increase the position's x coordinate.
+  While moving the vehicle to the right should increase the y coordinate.
+  In the case you send also linear velocities from the external pose system, you should also check the linear velocities.
+  Check that the linear velocities are in expressed in the *FRD* body frame reference frame.
 * Set the PX4 parameter `MAV_ODOM_LP` back to 0. PX4 will stop streaming this message back.
 
 If those steps are consistent, you can try your first flight.
@@ -261,14 +277,14 @@ If those steps are consistent, you can try your first flight.
 Put the robot on the ground and start streaming MoCap feedback.
 Lower your left (throttle) stick and arm the motors.
 
-At this point, with the left stick at the lowest position, switch to position control. 
-You should have a green light. 
-The green light tells you that position feedback is available and position control is now activated. 
+At this point, with the left stick at the lowest position, switch to position control.
+You should have a green light.
+The green light tells you that position feedback is available and position control is now activated.
 
 Put your left stick at the middle, this is the dead zone.
 With this stick value, the robot maintains its altitude;
 raising the stick will increase the reference altitude while lowering the value will decrease it.
-Same for right stick on x and y. 
+Same for right stick on x and y.
 
 Increase the value of the left stick and the robot will take off, 
 put it back to the middle right after. Check if it is able to keep its position.

--- a/en/ros/offboard_control.md
+++ b/en/ros/offboard_control.md
@@ -1,6 +1,6 @@
 # Offboard Control
 
-> **Warning** [Offboard control](https://docs.px4.io/en/flight_modes/offboard.html) is dangerous.
+> **Warning** [Offboard control](https://docs.px4.io/master/en/flight_modes/offboard.html) is dangerous.
   It is the responsibility of the developer to ensure adequate preparation, testing and safety precautions are taken before offboard flights.
 
 The idea behind off-board control is to be able to control the PX4 flight stack using software running outside of the autopilot. This is done through the MAVLink protocol, specifically the [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED) and the [SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET) messages.

--- a/en/sensor_bus/i2c.md
+++ b/en/sensor_bus/i2c.md
@@ -29,7 +29,7 @@ drivers/sf1xx
 To find I2C driver examples, search for **i2c.h** in [/src/drivers/](https://github.com/PX4/Firmware/tree/master/src/drivers).
 
 Just a few examples are:
-* [drivers/sf1xx](https://github.com/PX4/Firmware/tree/master/src/drivers/distance_sensor/sf1xx) - I2C Driver for [Lightware SF1XX LIDAR](https://docs.px4.io/en/sensor/sfxx_lidar.html).
+* [drivers/sf1xx](https://github.com/PX4/Firmware/tree/master/src/drivers/distance_sensor/sf1xx) - I2C Driver for [Lightware SF1XX LIDAR](https://docs.px4.io/master/en/sensor/sfxx_lidar.html).
 * [drivers/ms5611](https://github.com/PX4/Firmware/tree/master/src/drivers/barometer/ms5611) - I2C Driver for the MS5611 and MS6507 barometric pressure sensor connected via I2C (or SPI).
 
 ## Further Information

--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -80,19 +80,19 @@ A successful run will end with similar output to:
 
 The following list shows the build commands for common boards:
 * Pixhawk 4: `make px4_fmu-v5_default`
-* [Pixracer](https://docs.px4.io/en/flight_controller/pixracer.html): `make px4_fmu-v4_default`
-* [Pixhawk 3 Pro](https://docs.px4.io/en/flight_controller/pixhawk3_pro.html): `make px4_fmu-v4pro_default`
-* [Pixhawk Mini](https://docs.px4.io/en/flight_controller/pixhawk_mini.html): `make px4_fmu-v3_default`
-* [Pixhawk 2](https://docs.px4.io/en/flight_controller/pixhawk-2.html): `make px4_fmu-v3_default`
-* [mRo Pixhawk](https://docs.px4.io/en/flight_controller/mro_pixhawk.html): `make px4_fmu-v3_default` (supports 2MB Flash)
-* [HKPilot32](https://docs.px4.io/en/flight_controller/HKPilot32.html): `make px4_fmu-v2_default`
-* [Pixfalcon](https://docs.px4.io/en/flight_controller/pixfalcon.html): `make px4_fmu-v2_default`
-* [Dropix](https://docs.px4.io/en/flight_controller/dropix.html): `make px4_fmu-v2_default`
-* [MindPX](https://docs.px4.io/en/flight_controller/mindpx.html)/[MindRacer](https://docs.px4.io/en/flight_controller/mindracer.html): `make airmind_mindpx-v2_default`
-* [mRo X-2.1](https://docs.px4.io/en/flight_controller/mro_x2.1.html): `make mro_x21_default` 
-* [Crazyflie 2.0](https://docs.px4.io/en/flight_controller/crazyflie2.html): `make bitcraze_crazyflie_default`
-* [Intel® Aero Ready to Fly Drone](https://docs.px4.io/en/flight_controller/intel_aero.html): `make intel_aerofc-v1_default`
-* [Pixhawk 1](https://docs.px4.io/en/flight_controller/pixhawk.html): `make px4_fmu-v2_default`
+* [Pixracer](https://docs.px4.io/master/en/flight_controller/pixracer.html): `make px4_fmu-v4_default`
+* [Pixhawk 3 Pro](https://docs.px4.io/master/en/flight_controller/pixhawk3_pro.html): `make px4_fmu-v4pro_default`
+* [Pixhawk Mini](https://docs.px4.io/master/en/flight_controller/pixhawk_mini.html): `make px4_fmu-v3_default`
+* [Pixhawk 2](https://docs.px4.io/master/en/flight_controller/pixhawk-2.html): `make px4_fmu-v3_default`
+* [mRo Pixhawk](https://docs.px4.io/master/en/flight_controller/mro_pixhawk.html): `make px4_fmu-v3_default` (supports 2MB Flash)
+* [HKPilot32](https://docs.px4.io/master/en/flight_controller/HKPilot32.html): `make px4_fmu-v2_default`
+* [Pixfalcon](https://docs.px4.io/master/en/flight_controller/pixfalcon.html): `make px4_fmu-v2_default`
+* [Dropix](https://docs.px4.io/master/en/flight_controller/dropix.html): `make px4_fmu-v2_default`
+* [MindPX](https://docs.px4.io/master/en/flight_controller/mindpx.html)/[MindRacer](https://docs.px4.io/master/en/flight_controller/mindracer.html): `make airmind_mindpx-v2_default`
+* [mRo X-2.1](https://docs.px4.io/master/en/flight_controller/mro_x2.1.html): `make mro_x21_default` 
+* [Crazyflie 2.0](https://docs.px4.io/master/en/flight_controller/crazyflie2.html): `make bitcraze_crazyflie_default`
+* [Intel® Aero Ready to Fly Drone](https://docs.px4.io/master/en/flight_controller/intel_aero.html): `make intel_aerofc-v1_default`
+* [Pixhawk 1](https://docs.px4.io/master/en/flight_controller/pixhawk.html): `make px4_fmu-v2_default`
   > **Warning** You **must** use a supported version of GCC to build this board (e.g. the same as used by [CI/docker](../test_and_ci/docker.md)) or remove modules from the build. Building with an unsupported GCC may fail, as PX4 is close to the board's 1MB flash limit.
 * Pixhawk 1 with 2 MB flash: `make px4_fmu-v3_default`
 
@@ -125,7 +125,7 @@ The following boards have more complicated build and/or deployment instructions.
 
 ### Raspberry Pi 2/3 Boards
 
-The command below builds the target for [Raspberry Pi 2/3 Navio2](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html).
+The command below builds the target for [Raspberry Pi 2/3 Navio2](https://docs.px4.io/master/en/flight_controller/raspberry_pi_navio2.html).
 
 #### Cross-compiler Build
 
@@ -208,14 +208,14 @@ cd /home/pi && ./bin/px4 -d -s px4.config > px4.log
 
 ### OcPoC-Zynq Mini
 
-Build instructions for the [OcPoC-Zynq Mini](https://docs.px4.io/en/flight_controller/ocpoc_zynq.html) are covered in:
+Build instructions for the [OcPoC-Zynq Mini](https://docs.px4.io/master/en/flight_controller/ocpoc_zynq.html) are covered in:
 * [Aerotenna OcPoC-Zynq Mini Flight Controller > Building PX4 for OcPoC-Zynq](https://docs.px4.io/master/en/flight_controller/ocpoc_zynq.html#building-px4-for-ocpoc-zynq) (PX4 User Guide)
 * [OcPoC PX4 Setup Page](https://aerotenna.readme.io/docs/px4-setup)
 
 
 ### QuRT / Snapdragon Based Boards
 
-This section shows how to build for the [Qualcomm Snapdragon Flight](https://docs.px4.io/en/flight_controller/snapdragon_flight.html).
+This section shows how to build for the [Qualcomm Snapdragon Flight](https://docs.px4.io/master/en/flight_controller/snapdragon_flight.html).
 
 #### Build
 

--- a/en/setup/config_initial.md
+++ b/en/setup/config_initial.md
@@ -26,5 +26,5 @@ The equipment below is highly recommended:
 To configure the vehicle:
 
 1. Download the [QGroundControl Daily Build](https://docs.qgroundcontrol.com/en/releases/daily_builds.html) for your development platform.
-1. [Basic Configuration](https://docs.px4.io/en/config/) (PX4 User Guide) explains how to to perform basic configuration. 
-1. [Parameter Configuration](https://docs.px4.io/en/advanced_config/parameters.html) (PX4 User Guide) explains how you can find and modify individual parameters.
+1. [Basic Configuration](https://docs.px4.io/master/en/config/) (PX4 User Guide) explains how to to perform basic configuration. 
+1. [Parameter Configuration](https://docs.px4.io/master/en/advanced_config/parameters.html) (PX4 User Guide) explains how you can find and modify individual parameters.

--- a/en/setup/dev_env.md
+++ b/en/setup/dev_env.md
@@ -8,9 +8,9 @@ The table below show what PX targets you can build on each OS.
 
 Target | Linux (Ubuntu) | Mac | Windows
 --|:--:|:--:|:--:
-**NuttX based hardware:** [Pixhawk Series](https://docs.px4.io/en/flight_controller/pixhawk_series.html), [Crazyflie](https://docs.px4.io/en/flight_controller/crazyflie2.html), [Intel® Aero Ready to Fly Drone](https://docs.px4.io/en/flight_controller/intel_aero.html) | X | X | X
-[Qualcomm Snapdragon Flight hardware](https://docs.px4.io/en/flight_controller/snapdragon_flight.html) | X | | 
-**Linux-based hardware:** [Raspberry Pi 2/3](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html) | X | | 
+**NuttX based hardware:** [Pixhawk Series](https://docs.px4.io/master/en/flight_controller/pixhawk_series.html), [Crazyflie](https://docs.px4.io/master/en/flight_controller/crazyflie2.html), [Intel® Aero Ready to Fly Drone](https://docs.px4.io/master/en/flight_controller/intel_aero.html) | X | X | X
+[Qualcomm Snapdragon Flight hardware](https://docs.px4.io/master/en/flight_controller/snapdragon_flight.html) | X | | 
+**Linux-based hardware:** [Raspberry Pi 2/3](https://docs.px4.io/master/en/flight_controller/raspberry_pi_navio2.html) | X | | 
 **Simulation:** [jMAVSim SITL](../simulation/jmavsim.md) | X | X | X
 **Simulation:** [Gazebo SITL](../simulation/gazebo.md) | X | X | 
 **Simulation:** [ROS with Gazebo](../simulation/ros_interface.md) | X | | 

--- a/en/setup/dev_env_linux_ubuntu.md
+++ b/en/setup/dev_env_linux_ubuntu.md
@@ -118,7 +118,7 @@ make
 
 ### Native Builds
 
-Additional developer information for using PX4 on Raspberry Pi (including building PX4 natively) can be found here: [Raspberry Pi 2/3 Navio2 Autopilot](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html).
+Additional developer information for using PX4 on Raspberry Pi (including building PX4 natively) can be found here: [Raspberry Pi 2/3 Navio2 Autopilot](https://docs.px4.io/master/en/flight_controller/raspberry_pi_navio2.html).
 
 
 ## ROS/Gazebo {#rosgazebo}
@@ -145,9 +145,9 @@ Note:
 ## Snapdragon Flight
 
 Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
-* [Development Environment](https://docs.px4.io/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
-* [Software Installation](https://docs.px4.io/en/flight_controller/snapdragon_flight_software_installation.html)
-* [Configuration](https://docs.px4.io/en/flight_controller/snapdragon_flight_configuration.html)
+* [Development Environment](https://docs.px4.io/master/en/flight_controller/snapdragon_flight_dev_environment_installation.html)
+* [Software Installation](https://docs.px4.io/master/en/flight_controller/snapdragon_flight_software_installation.html)
+* [Configuration](https://docs.px4.io/master/en/flight_controller/snapdragon_flight_configuration.html)
 
 
 ## Fast RTPS installation {#fast_rtps}

--- a/en/setup/dev_env_windows_cygwin.md
+++ b/en/setup/dev_env_windows_cygwin.md
@@ -1,6 +1,6 @@
 # Windows Cygwin Toolchain
 
-This toolchain is portable, easy to install, and easy to use. 
+This toolchain is portable, easy to install, and easy to use.
 It is the newest and best performing toolchain for developing PX4 on Windows.
 
 > **Tip** This is the only officially supported toolchain for building PX4 on Windows (i.e. it is tested in our continuous integration system).
@@ -17,7 +17,7 @@ This topic explains how download and use the environment, and how it can be exte
 1. Download the latest version of the ready-to-use MSI installer from: [Github releases](https://github.com/PX4/windows-toolchain/releases) or [Amazon S3](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.9.msi) (fast download).
 1. Run it, choose your desired installation location, let it install:
     ![jMAVSimOnWindows](../../assets/toolchain/cygwin_toolchain_installer.PNG)
-1. Tick the box at the end of the installation to *clone the PX4 repository, build and run simulation with jMAVSim* (this simplifies the process to get you started). 
+1. Tick the box at the end of the installation to *clone the PX4 repository, build and run simulation with jMAVSim* (this simplifies the process to get you started).
 
    > **Note** If you missed this step you will need to [clone the PX4 Firmware repository manually](#getting_started).
 
@@ -73,7 +73,7 @@ You may wish to halt them temporarily during builds (at your own risk).
 #### Windows CR+LF vs Unix LF Line Endings
 
 We recommend that you force Unix style LF endings for every repository you're working with using this toolchain (and use an editor which preserves them when saving your changes - e.g. Eclipse or VS Code).
-Compilation of source files also works with CR+LF endings checked out locally, but there are cases in Cygwin (e.g. execution of shell scripts) that require Unix line endings ( otherwise you get errors like `$'\r': Command not found.`).
+Compilation of source files also works with CR+LF endings checked out locally, but there are cases in Cygwin (e.g. execution of shell scripts) that require Unix line endings (otherwise you get errors like `$'\r': Command not found.`).
 Luckily git can do this for you when you execute the two commands in the root directory of your repo:
 ```
 git config core.autocrlf false
@@ -88,9 +88,9 @@ This is not recommended because it may affect any other (unrelated) git use on y
 
 #### Unix Permissions Execution Bit
 
-Under Unix there's a flag in the permissions of each file that tells the OS whether or not the file is allowed to be executed. 
-*git* under Cygwin supports and cares about that bit (even though the Windows NTFS file system does not use it). 
-This often results in *git* finding "false-positive" differences in permissions. 
+Under Unix there's a flag in the permissions of each file that tells the OS whether or not the file is allowed to be executed.
+*git* under Cygwin supports and cares about that bit (even though the Windows NTFS file system does not use it).
+This often results in *git* finding "false-positive" differences in permissions.
 The resulting diff might look like this:
 ```
 diff --git ...
@@ -144,7 +144,8 @@ git clone https://github.com/PX4/windows-toolchain PX4
 
 ### Manual Installation (for Toolchain Developers) {#manual_setup}
 
-This section describes how to setup the Cygwin toolchain manually yourself while pointing to the corresponding scripts from the script based installation repo. The result should be the same as using the scripts or MSI installer.
+This section describes how to setup the Cygwin toolchain manually yourself while pointing to the corresponding scripts from the script based installation repo.
+The result should be the same as using the scripts or MSI installer.
 
 > **Note** The toolchain gets maintained and hence these instructions might not cover every detail of all the future changes.
 
@@ -180,9 +181,9 @@ This section describes how to setup the Cygwin toolchain manually yourself while
    <span></span>
    > **Note** That's what [cygwin64/install-cygwin-px4.bat](https://github.com/MaEtUgR/PX4Toolchain/blob/master/toolchain/cygwin64/install-cygwin-px4.bat) does.
 
-1. Write up or copy the **batch scripts** [`run-console.bat`](https://github.com/MaEtUgR/PX4Toolchain/blob/master/run-console.bat) and [`setup-environment.bat`](https://github.com/PX4/windows-toolchain/blob/master/toolchain/scripts/setup-environment.bat). 
+1. Write up or copy the **batch scripts** [`run-console.bat`](https://github.com/MaEtUgR/PX4Toolchain/blob/master/run-console.bat) and [`setup-environment.bat`](https://github.com/PX4/windows-toolchain/blob/master/toolchain/scripts/setup-environment.bat).
    
-   The reason to start all the development tools through the prepared batch script is they preconfigure the starting program to use the local, portable Cygwin environment inside the toolchain's folder. 
+   The reason to start all the development tools through the prepared batch script is they preconfigure the starting program to use the local, portable Cygwin environment inside the toolchain's folder.
    This is done by always first calling the script [**setup-environment.bat**](https://github.com/PX4/windows-toolchain/blob/master/toolchain/scripts/setup-environment.bat) and the desired application like the console after that.
 
    The script [setup-environment.bat](https://github.com/PX4/windows-toolchain/blob/master/toolchain/scripts/setup-environment.bat) locally sets environmental variables for the workspace root directory `PX4_DIR`, all binary locations `PATH`, and the home directory of the unix environment `HOME`.
@@ -232,4 +233,4 @@ This section describes how to setup the Cygwin toolchain manually yourself while
 
     > **Note** This is what the toolchain does in: [genromfs/install-genromfs.bat](https://github.com/MaEtUgR/PX4Toolchain/blob/master/toolchain/genromfs/install-genromfs.bat).
 
-1. Make sure all the binary folders of all the installed components are correctly listed in the `PATH` variable configured by [**setup-environment.bat**](https://github.com/PX4/windows-toolchain/blob/master/toolchain/scripts/setup-environment.bat). 
+1. Make sure all the binary folders of all the installed components are correctly listed in the `PATH` variable configured by [**setup-environment.bat**](https://github.com/PX4/windows-toolchain/blob/master/toolchain/scripts/setup-environment.bat).

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -198,7 +198,7 @@ This can be enabled/set up as described in [Gazebo > Video Streaming](../simulat
 
 The simulated camera is a gazebo plugin that implements the [MAVLink Camera Protocol](https://mavlink.io/en/protocol/camera.html)<!-- **Firmware/Tools/sitl_gazebo/src/gazebo_geotagged_images_plugin.cpp -->. PX4 connects/integrates with this camera in *exactly the same way* as it would with any other MAVLink camera:
 1. [TRIG_INTERFACE](../advanced/parameter_reference.md#TRIG_INTERFACE) must be set to `3` to configure the camera trigger driver for use with a MAVLink camera
-   > **Tip** In this mode the driver just sends a [CAMERA_TRIGGER](https://mavlink.io/en/messages/common.html#CAMERA_TRIGGER) message whenever an image capture is requested. For more information see [Camera](https://docs.px4.io/en/peripherals/camera.html).
+   > **Tip** In this mode the driver just sends a [CAMERA_TRIGGER](https://mavlink.io/en/messages/common.html#CAMERA_TRIGGER) message whenever an image capture is requested. For more information see [Camera](https://docs.px4.io/master/en/peripherals/camera.html).
 1. PX4 must forward all camera commands between the GCS and the (simulator) MAVLink Camera.
    You can do this by starting [MAVLink](../middleware/modules_communication.md#mavlink) with the `-f` flag as shown, specifying the UDP ports for the new connection.
    ```

--- a/en/simulation/failsafes.md
+++ b/en/simulation/failsafes.md
@@ -1,6 +1,6 @@
 # Simulate Failsafes
 
-[Failsafes](https://docs.px4.io/en/config/safety.html) define the safe limits/conditions under which you can safely use PX4, and the action that will be performed if a failsafe is triggered (for example, landing, holding position, or returning to a specified point).
+[Failsafes](https://docs.px4.io/master/en/config/safety.html) define the safe limits/conditions under which you can safely use PX4, and the action that will be performed if a failsafe is triggered (for example, landing, holding position, or returning to a specified point).
 
 In SITL some failsafes are disabled by default to enable easier simulation usage.
 This topic explains how you can test safety-critical behavior in SITL simulation before attempting it in the real world.

--- a/en/simulation/simulation-in-hardware.md
+++ b/en/simulation/simulation-in-hardware.md
@@ -22,8 +22,8 @@ Furthermore, the physical parameters representing the vehicle (such as mass, ine
 
 ## Requirements
 
-To run the SIH, you will need a [flight controller hardware](https://docs.px4.io/en/flight_controller/) (e.g. a Pixhawk-series board).
-If you are planning to use a [radio control transmitter and receiver pair](https://docs.px4.io/en/getting_started/rc_transmitter_receiver.html) you should have that too.
+To run the SIH, you will need a [flight controller hardware](https://docs.px4.io/master/en/flight_controller/) (e.g. a Pixhawk-series board).
+If you are planning to use a [radio control transmitter and receiver pair](https://docs.px4.io/master/en/getting_started/rc_transmitter_receiver.html) you should have that too.
 Alternatively, using *QGroundControl*, a [joystick](https://docs.qgroundcontrol.com/en/SetupView/Joystick.html) can be used to emulate a radio control system.
 
 The SIH is compatible with all Pixhawk-series boards except those based on FMUv2.

--- a/en/test_and_ci/test_flights.md
+++ b/en/test_and_ci/test_flights.md
@@ -37,30 +37,30 @@ Multicopter
 
 Frame | Flight Controller | UUID
 --- | --- | ---
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk Mini](https://docs.px4.io/en/flight_controller/pixhawk_mini.html) | 002400283335510A33373538 (f450-v3)
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 1](https://docs.px4.io/en/flight_controller/pixhawk.html) | 000100000000363533353336510900500021 (f450-v3)
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Cube](https://docs.px4.io/en/flight_controller/pixhawk-2.html) (Pixhawk 2.1) | 00010000000033343537313751050040001c (F450 Pixhawk v2 cube)
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixracer](https://docs.px4.io/en/flight_controller/pixracer.html) | 00010000000037373430333551170037002a (F450-Pixracer)
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 3 Pro](https://docs.px4.io/en/flight_controller/pixhawk3_pro.html) | 000100000000303236353136510500180036 (Pixhawk pro)
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhack V3](https://docs.px4.io/en/flight_controller/pixhack_v3.html) | 003200293036511638363834 (f450-v5-m)
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 4](https://docs.px4.io/en/flight_controller/pixhawk4.html) | 000200000000383339333038510700320016 (F450-v5)
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 4 Mini](https://docs.px4.io/en/flight_controller/pixhawk4_mini.html) | 0002000000003432333830385115003a0033 (F450-v5-m)
-[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) [UAVCAN](https://zubax.com/technologies/uavcan) | [Pixhawk 4](https://docs.px4.io/en/flight_controller/pixhawk4.html) | 000200000000323634353237511800200021 (F450-Pixhawk4)
-Holybro [QAV250](https://docs.px4.io/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html) | [Pixhawk 4 Mini](https://docs.px4.io/en/flight_controller/pixhawk4_mini.html) |000200000000343233383038511500420032 (f450-v5-m)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk Mini](https://docs.px4.io/master/en/flight_controller/pixhawk_mini.html) | 002400283335510A33373538 (f450-v3)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 1](https://docs.px4.io/master/en/flight_controller/pixhawk.html) | 000100000000363533353336510900500021 (f450-v3)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Cube](https://docs.px4.io/master/en/flight_controller/pixhawk-2.html) (Pixhawk 2.1) | 00010000000033343537313751050040001c (F450 Pixhawk v2 cube)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixracer](https://docs.px4.io/master/en/flight_controller/pixracer.html) | 00010000000037373430333551170037002a (F450-Pixracer)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 3 Pro](https://docs.px4.io/master/en/flight_controller/pixhawk3_pro.html) | 000100000000303236353136510500180036 (Pixhawk pro)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhack V3](https://docs.px4.io/master/en/flight_controller/pixhack_v3.html) | 003200293036511638363834 (f450-v5-m)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 4](https://docs.px4.io/master/en/flight_controller/pixhawk4.html) | 000200000000383339333038510700320016 (F450-v5)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) | [Pixhawk 4 Mini](https://docs.px4.io/master/en/flight_controller/pixhawk4_mini.html) | 0002000000003432333830385115003a0033 (F450-v5-m)
+[DJI F450](https://www.getfpv.com/dji-flamewheel-f450-basic-kit.html) [UAVCAN](https://zubax.com/technologies/uavcan) | [Pixhawk 4](https://docs.px4.io/master/en/flight_controller/pixhawk4.html) | 000200000000323634353237511800200021 (F450-Pixhawk4)
+Holybro [QAV250](https://docs.px4.io/master/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html) | [Pixhawk 4 Mini](https://docs.px4.io/master/en/flight_controller/pixhawk4_mini.html) |000200000000343233383038511500420032 (f450-v5-m)
 NXP Semiconductor [KIT-HGDRONEK66](https://www.nxp.com/applications/solutions/industrial/unmanned-aerial-vehicles-uavs/uavs-drones-and-rovers/rddrone-fmuk66-px4-robotic-drone-fmu-reference-design:RDDRONE-FMUK66) ("[Hovergames](https://www.hovergames.com/)")| [RDDRONE-FMUK66](https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/k-seriesperformancem4/k6x-ethernet/rddrone-fmuk66-px4-robotic-drone-fmu-reference-design:RDDRONE-FMUK66?tid=vanRDDRONE-FMUK66) | 00030016ffffffffffff4e45362050130029
 
 Fixed Wing
 
 Frame | Flight Controller | UUID
 --- | --- | ---
-[Phantom Wing](https://hobbyking.com/en_us/phantom-fpv-flying-wing-epo-airplane-1550mm-v2-kit.html) | [Pixhawk 1](https://docs.px4.io/en/flight_controller/pixhawk.html) | 0001000000003035333330365104003c0020 (f450-v2)
+[Phantom Wing](https://hobbyking.com/en_us/phantom-fpv-flying-wing-epo-airplane-1550mm-v2-kit.html) | [Pixhawk 1](https://docs.px4.io/master/en/flight_controller/pixhawk.html) | 0001000000003035333330365104003c0020 (f450-v2)
 
 
 VTOL
 
 Frame | Flight Controller | UUID
 --- | --- | ---
-[Convergence VTOL](https://www.horizonhobby.com/convergence-vtol-bnf-basic-efl11050) | [Pixhawk 4 Mini](https://docs.px4.io/en/flight_controller/pixhawk4_mini.html) | 000200000000343233383038511500350039 (vtol-v5-m)
-[Delta Quad Pro](https://px4.io/portfolio/deltaquad-vtol/) | [Dropix](https://docs.px4.io/en/flight_controller/dropix.html) | 0001000000003437393931375114004c0042 (delta-v2)
+[Convergence VTOL](https://www.horizonhobby.com/convergence-vtol-bnf-basic-efl11050) | [Pixhawk 4 Mini](https://docs.px4.io/master/en/flight_controller/pixhawk4_mini.html) | 000200000000343233383038511500350039 (vtol-v5-m)
+[Delta Quad Pro](https://px4.io/portfolio/deltaquad-vtol/) | [Dropix](https://docs.px4.io/master/en/flight_controller/dropix.html) | 0001000000003437393931375114004c0042 (delta-v2)
 
 {% endif %} <!-- END: details above displayed only in master -->

--- a/en/uavcan/README.md
+++ b/en/uavcan/README.md
@@ -1,6 +1,6 @@
 # UAVCAN Introduction
 
-![](../../assets/uavcan-logo-transparent.png)
+![UAVCAN Logo](../../assets/uavcan-logo-transparent.png)
 
 [UAVCAN](http://uavcan.org) is an onboard network which allows the autopilot to connect to avionics.
 It supports hardware like:
@@ -26,21 +26,30 @@ All motor controllers provide status feedback and implement field-oriented-contr
 
 ## Initial Setup
 
-The following instructions provide a step-by-step guide to connect and setup a quadcopter with ESCs and GPS connected via UAVCAN. The hardware of choice is a Pixhawk 2.1, Zubax Orel 20 ESCs and a Zubax GNSS GPS module.
+The following instructions provide a step-by-step guide to connect and setup a quadcopter with ESCs and GPS connected via UAVCAN.
+The hardware of choice is a Pixhawk 2.1, Zubax Orel 20 ESCs and a Zubax GNSS GPS module.
 
 ### Wiring
 
-The first step is to connect all UAVCAN enabled devices with the flight controller. The following diagram displays how to wire all components. The used Zubax devices all support a redundant CAN interface in which the second bus is optional but increases the robustness of the connection. 
+The first step is to connect all UAVCAN enabled devices with the flight controller.
+The following diagram displays how to wire all components.
+The used Zubax devices all support a redundant CAN interface in which the second bus is optional but increases the robustness of the connection.
 
-![](../../assets/UAVCAN_wiring.png)
+![UAVCAN Wiring](../../assets/UAVCAN_wiring.png)
 
-It is important to mention that some devices require an external power supply \(e.g. Zubax Orel 20\) and others can be powered by the CAN connection \(e.g Zubax GNSS\) itself. Please refer to the documentation of your hardware before continuing with the setup.
+It is important to mention that some devices require an external power supply \(e.g. Zubax Orel 20\) and others can be powered by the CAN connection \(e.g Zubax GNSS\) itself.
+Please refer to the documentation of your hardware before continuing with the setup.
 
 ### Firmware Setup
 
-Next, follow the instructions in [UAVCAN Configuration](../uavcan/node_enumeration.md) to activate the UAVCAN functionalities in the firmware. Disconnect your power supply and reconnect it. After the power cycle all UAVCAN devices should be detected which is confirmed by a beeping motor on the Orel 20 ESCs. You can now continue with the general setup and calibration. 
+Next, follow the instructions in [UAVCAN Configuration](../uavcan/node_enumeration.md) to activate the UAVCAN functionalities in the firmware.
+Disconnect your power supply and reconnect it.
+After the power cycle all UAVCAN devices should be detected which is confirmed by a beeping motor on the Orel 20 ESCs.
+You can now continue with the general setup and calibration.
 
-Depending on the used hardware, it can be reasonable to perform an update of the firmware on the UAVCAN devices. This can be done via the UAVCAN itself and the PX4 firmware. For more details please refer to the instructions in [UAVCAN Firmware](../uavcan/node_firmware.md).
+Depending on the used hardware, it can be reasonable to perform an update of the firmware on the UAVCAN devices.
+This can be done via the UAVCAN itself and the PX4 firmware.
+For more details please refer to the instructions in [UAVCAN Firmware](../uavcan/node_firmware.md).
 
 ## Upgrading Node Firmware
 
@@ -48,7 +57,8 @@ The PX4 middleware will automatically upgrade firmware on UAVCAN nodes if the ma
 
 ## Enumerating and Configuring Motor Controllers
 
-The ID and rotational direction of each motor controller can be assigned after installation in a simple setup routine: [UAVCAN Node Enumeration](../uavcan/node_enumeration.md). The routine can be started by the user through QGroundControl.
+The ID and rotational direction of each motor controller can be assigned after installation in a simple setup routine: [UAVCAN Node Enumeration](../uavcan/node_enumeration.md).
+The routine can be started by the user through QGroundControl.
 
 ## Useful links
 


### PR DESCRIPTION
Links were pointing to the default root, which has redirects to PX4 v1.9. This just makes the files always point to the latest user guide docs. We could fix to point to version that matches current, but decided going to latest might make more sense for now. May revisit.