### PR TITLE
Fixed "sudo apt install geographiclib -y"

### DIFF
--- a/build_scripts/ubuntu_sim_ros_melodic.sh
+++ b/build_scripts/ubuntu_sim_ros_melodic.sh
@@ -85,7 +85,7 @@ if [[ ! -z $unsupported_os ]]; then
 fi
 
 #Install geographiclib
-sudo apt install geographiclib -y
+sudo apt install geographiclib-tools -y
 echo "Downloading dependent script 'install_geographiclib_datasets.sh'"
 # Source the install_geographiclib_datasets.sh script directly from github
 install_geo=$(wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh -O -)


### PR DESCRIPTION
changed to "sudo apt install geographiclib-tools -y" 
In accordance with Ubuntu documentation for the new name: 
https://www.howtoinstall.me/ubuntu/18-04/geographiclib-tools/