### PR TITLE
Add installation instructions for ROS noetic

### DIFF
--- a/build_scripts/ubuntu_sim_ros_noetic.sh
+++ b/build_scripts/ubuntu_sim_ros_noetic.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+## Bash script for setting up ROS Noetic (with Gazebo 11) development environment for PX4 on Ubuntu LTS (20.04). 
+## It installs the common dependencies for all targets (including Qt Creator)
+##
+## Installs:
+## - Common dependencies libraries and tools as defined in `ubuntu_sim_common_deps.sh`
+## - ROS Noetic (including Gazebo11)
+## - MAVROS
+
+if [[ $(lsb_release -sc) == *"focal"* ]]; then
+  echo "OS version detected as $(lsb_release -sc) (20.04)."
+  echo "ROS Noetic requires at least Ubuntu 20.04."
+  echo "Exiting ...."
+  return 1;
+fi
+
+echo "Downloading dependent script 'ubuntu_sim_common_deps.sh'"
+# Source the ubuntu_sim_common_deps.sh script directly from github
+common_deps=$(wget https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_common_deps.sh -O -)
+wget_return_code=$?
+# If there was an error downloading the dependent script, we must warn the user and exit at this point.
+if [[ $wget_return_code -ne 0 ]]; then echo "Error downloading 'ubuntu_sim_common_deps.sh'. Sorry but I cannot proceed further :("; exit 1; fi
+# Otherwise source the downloaded script.
+. <(echo "${common_deps}")
+
+# ROS Noetic
+## Gazebo simulator dependencies
+sudo apt-get install protobuf-compiler libeigen3-dev libopencv-dev -y
+
+## ROS Gazebo: http://wiki.ros.org/noetic/Installation/Ubuntu
+## Setup keys
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+## For keyserver connection problems substitute hkp://pgp.mit.edu:80 or hkp://keyserver.ubuntu.com:80 above.
+sudo apt-get update
+## Get ROS/Gazebo
+sudo apt install ros-noetic-desktop-full python3-rosdep -y
+## Initialize rosdep
+sudo rosdep init
+rosdep update
+## Setup environment variables
+rossource="source /opt/ros/noetic/setup.bash"
+if grep -Fxq "$rossource" ~/.bashrc; then echo ROS setup.bash already in .bashrc;
+else echo "$rossource" >> ~/.bashrc; fi
+eval $rossource
+
+## Install rosinstall and other dependencies
+sudo apt install python3-rosinstall python3-rosinstall-generator python3-wstool build-essential -y
+
+
+
+# MAVROS: https://dev.px4.io/en/ros/mavros_installation.html
+## Install dependencies
+sudo apt-get install python3-catkin-tools python3-rosinstall-generator -y
+
+## Create catkin workspace
+mkdir -p ~/catkin_ws/src
+cd ~/catkin_ws
+catkin init
+wstool init src
+
+
+## Install MAVLink
+###we use the Kinetic reference for all ROS distros as it's not distro-specific and up to date
+rosinstall_generator --rosdistro kinetic mavlink | tee /tmp/mavros.rosinstall
+
+## Build MAVROS
+### Get source (upstream - released)
+rosinstall_generator --upstream mavros | tee -a /tmp/mavros.rosinstall
+
+### Setup workspace & install deps
+wstool merge -t src /tmp/mavros.rosinstall
+wstool update -t src
+if ! rosdep install --from-paths src --ignore-src -y; then
+    # (Use echo to trim leading/trailing whitespaces from the unsupported OS name
+    unsupported_os=$(echo $(rosdep db 2>&1| grep Unsupported | awk -F: '{print $2}'))
+    rosdep install --from-paths src --ignore-src --rosdistro noetic -y --os ubuntu:bionic
+fi
+
+if [[ ! -z $unsupported_os ]]; then
+    >&2 echo -e "\033[31mYour OS ($unsupported_os) is unsupported. Assumed an Ubuntu 18.04 installation,"
+    >&2 echo -e "and continued with the installation, but if things are not working as"
+    >&2 echo -e "expected you have been warned."
+fi
+
+#Install geographiclib
+sudo apt install geographiclib-tools -y
+echo "Downloading dependent script 'install_geographiclib_datasets.sh'"
+# Source the install_geographiclib_datasets.sh script directly from github
+install_geo=$(wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh -O -)
+wget_return_code=$?
+# If there was an error downloading the dependent script, we must warn the user and exit at this point.
+if [[ $wget_return_code -ne 0 ]]; then echo "Error downloading 'install_geographiclib_datasets.sh'. Sorry but I cannot proceed further :("; exit 1; fi
+# Otherwise source the downloaded script.
+sudo bash -c "$install_geo"
+
+## Build!
+catkin build
+## Re-source environment to reflect new packages/build environment
+catkin_ws_source="source ~/catkin_ws/devel/setup.bash"
+if grep -Fxq "$catkin_ws_source" ~/.bashrc; then echo ROS catkin_ws setup.bash already in .bashrc; 
+else echo "$catkin_ws_source" >> ~/.bashrc; fi
+eval $catkin_ws_source
+

--- a/en/setup/dev_env_linux_ubuntu.md
+++ b/en/setup/dev_env_linux_ubuntu.md
@@ -7,6 +7,9 @@ Bash scripts are provided to help make it easy to install development environmen
 - **[ubuntu.sh](https://github.com/PX4/Firmware/blob/{{ book.px4_version }}/Tools/setup/ubuntu.sh)**: Installs [Gazebo 9](../simulation/gazebo.md) and [jMAVSim](../simulation/jmavsim.md) simulators and/or [NuttX/Pixhawk](../setup/building_px4.md#nuttx) tools. Does not include dependencies for [FastRTPS](#fast_rtps).
 - **[ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_melodic.sh)**: Installs [ROS "Melodic"](#rosgazebo) and PX4 on Ubuntu 18.04 LTS (and later).
 
+- **[ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/ubuntu_sim_ros_noetic.sh)**: Installs [ROS "Noetic"](#rosgazebo) and PX4 on Ubuntu 20.04 LTS.
+
+
 > **Tip** The scripts have been tested on *clean* Ubuntu 18.04 LTS and Ubuntu 20.04 LTS installations.
   They *may* not work as expected if installed "on top" of an existing system, or on a different Ubuntu release.
 


### PR DESCRIPTION
This commit as installation scripts for ROS noetic on Ubuntu focal fosa

catkin is still broken (https://github.com/catkin/catkin_tools/issues/594)
```
Traceback (most recent call last):
  File "/usr/bin/catkin", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3254, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3237, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3266, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 584, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 901, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 787, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'osrf-pycommon>0.1.1' distribution was not found and is required by catkin-tools
ROS catkin_ws setup.bash already in .bashrc

```