### PR TITLE
Update instructions for spawning different vehilces in the fleet

### DIFF
--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -21,6 +21,7 @@ Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>] [-w <wo
    ```
    - Supported vehicle types are: `iris`, `plane`, `standard_vtol`.
    - The number after the colon indicates the number of vehicles (of that type) to spawn.
+   - Maximum number of vehicles is 255.
 
 Each vehicle instance is allocated a unique MAVLink system id (1, 2, 3, etc.) and can be accessed from a unique remote offboard UDP port (14540, 14541, 14542, etc.).
 

--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -14,7 +14,13 @@ Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>] [-w <wo
 - `<model>`: The [vehicle type/model](../simulation/gazebo_vehicles.md) to spawn, e.g.: `iris` (default), `plane`, `standard_vtol`.
 - `<number_of_vehicles>`: The number of vehicles to spawn. Default is 3. Maximum is 255.
 - `<world>`: The [world](../simulation/gazebo_worlds.md) that the vehicle should be spawned into, e.g.: `empty` (default)
-- `<script>: This overrides the `-n` and `-s` allows spawning a heterogeneous script, e.g.: `-s "iris:3,plane:2,standard_vtol:3"`
+- `<script>`: Spawn multiple vehicles of different types (overriding the values in `-m` and `-n`). 
+  For example: 
+   ```
+   -s "iris:3,plane:2,standard_vtol:3"
+   ```
+   - Supported vehicle types are: `iris`, `plane`, `standard_vtol`.
+   - The number after the colon indicates the number of vehicles (of that type) to spawn.
 
 Each vehicle instance is allocated a unique MAVLink system id (1, 2, 3, etc.) and can be accessed from a unique remote offboard UDP port (14540, 14541, 14542, etc.).
 

--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -8,12 +8,13 @@ A different approach is used for simulation with and without ROS.
 
 To simulate multiple iris or plane vehicles in Gazebo use the following commands in the terminal (from the root of the *Firmware* tree):
 ```
-Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>] [-w <world>]
+Tools/gazebo_sitl_multiple_run.sh [-m <model>] [-n <number_of_vehicles>] [-w <world>] [-s <script>]
 ```
 
 - `<model>`: The [vehicle type/model](../simulation/gazebo_vehicles.md) to spawn, e.g.: `iris` (default), `plane`, `standard_vtol`.
 - `<number_of_vehicles>`: The number of vehicles to spawn. Default is 3. Maximum is 255.
 - `<world>`: The [world](../simulation/gazebo_worlds.md) that the vehicle should be spawned into, e.g.: `empty` (default)
+- `<script>: This overrides the `-n` and `-s` allows spawning a heterogeneous script, e.g.: `-s "iris:3,plane:2,standard_vtol:3"`
 
 Each vehicle instance is allocated a unique MAVLink system id (1, 2, 3, etc.) and can be accessed from a unique remote offboard UDP port (14540, 14541, 14542, etc.).
 


### PR DESCRIPTION
This adds instructions for https://github.com/PX4/Firmware/pull/15147, where heterogenous vehicle fleets can be spawned through the scripting option `-s`