### PR TITLE
param show-for-airframe

### DIFF
--- a/en/advanced/parameters_and_configurations.md
+++ b/en/advanced/parameters_and_configurations.md
@@ -36,6 +36,9 @@ You can use the `-c` flag to show all parameters that have changed (from their d
 param show -c
 ```
 
+You can use `param show-for-airframe` to show all parameters that have changed from their defaults for just the current airframe's definition file (and defaults it imports).
+
+
 ### Exporting and Loading Parameters
 
 You can save any parameters that have been *touched* since all parameters were last reset to their firmware-defined defaults (this includes any parameters that have been changed, even if they have been changed back to their default).

--- a/en/airframes/adding_a_new_frame.md
+++ b/en/airframes/adding_a_new_frame.md
@@ -8,6 +8,8 @@ Adding a configuration is straightforward: create a new config file in the [init
 
 Developers who do not want to create their own configuration can instead customize existing configurations using text files on the microSD card, as detailed on the [custom system startup](../concept/system_startup.md) page.
 
+> **Note** To determine which parameters/values need to be set in the configuration file, you can first assign a generic airframe and tune the vehicle, and then use [`param show-for-airframe`](../middleware/modules_command.html#param) to list the parameters that changed.
+
 ## Configuration File Overview
 
 The configuration in the config and mixer files consists of several main blocks:


### PR DESCRIPTION
@bkueng This change just updates the normal param guide docs.

Any idea why this would not be showing up in https://dev.px4.io/master/en/middleware/modules_command.html#param ?