### PR TITLE
Remove code markup types not supported (gdb, cpp, text)

### DIFF
--- a/en/debug/gdb_debugging.md
+++ b/en/debug/gdb_debugging.md
@@ -149,13 +149,13 @@ arm-none-eabi-gdb build/px4_fmu-v2_default/px4_fmu-v2_default.elf
 Then in the GDB prompt, start with the last instructions in R8, with the first address in flash (recognizable because it starts with `0x080`, the first is `0x0808439f`).
 The execution is left to right. So one of the last steps before the hard fault was when ```mavlink_log.c``` tried to publish something,
 
-```gdb
+```sh
 (gdb) info line *0x0808439f
 Line 77 of "../src/modules/systemlib/mavlink_log.c" starts at address 0x8084398 <mavlink_vasprintf+36>
    and ends at 0x80843a0 <mavlink_vasprintf+44>.
 ```
 
-```gdb
+```sh
 (gdb) info line *0x08087c4e
 Line 311 of "../src/modules/uORB/uORBDevices_nuttx.cpp"
    starts at address 0x8087c4e <uORB::DeviceNode::publish(orb_metadata const*, void*, void const*)+2>

--- a/en/debug/simulation_debugging.md
+++ b/en/debug/simulation_debugging.md
@@ -46,7 +46,7 @@ make px4_sitl_default gazebo___lldb
 where the last parameter is the &lt;viewer\_model\_debugger&gt; triplet (using three underscores implies the default &#39;iris&#39; model).
 This will start the debugger and launch the SITL application. In order to break into the debugger shell and halt the execution, hit ```CTRL-C```:
 
-```gdb
+```sh
 Process 16529 stopped
 * thread #1: tid = 0x114e6d, 0x00007fff90f4430a libsystem_kernel.dylib`__read_nocancel + 10, name = 'px4', queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
     frame #0: 0x00007fff90f4430a libsystem_kernel.dylib`__read_nocancel + 10

--- a/en/middleware/micrortps.md
+++ b/en/middleware/micrortps.md
@@ -406,7 +406,7 @@ fastrtpsgen -example x64Linux2.6gcc ../micrortps_client/micrortps_agent/idl/sens
 This creates a basic subscriber and publisher, and a main-application to run them.
 To print out the data from the `sensor_combined` topic, modify the `onNewDataMessage()` method in **sensor_combined_Subscriber.cxx**:
 
-```c++
+```cpp
 void sensor_combined_Subscriber::SubListener::onNewDataMessage(Subscriber* sub)
 {
     // Take data
@@ -476,7 +476,7 @@ With the `px4_ros_com` built successfully, one can now take advantage of the gen
 
 To create a listener node on ROS2, lets take as an example the `sensor_combined_listener.cpp` node under `px4_ros_com/src/listeners`:
 
-```c++
+```cpp
 #include <rclcpp/rclcpp.hpp>
 #include <px4_msgs/msg/sensor_combined.hpp>
 ```
@@ -484,7 +484,7 @@ To create a listener node on ROS2, lets take as an example the `sensor_combined_
 The above brings to use the required C++ libraries to interface with the ROS2 middleware.
 It also includes the required message header file.
 
-```c++
+```cpp
 /**
  * @brief Sensor Combined uORB topic data callback
  */
@@ -494,7 +494,7 @@ class SensorCombinedListener : public rclcpp::Node
 
 The above creates a `SensorCombinedListener` class that subclasses the generic `rclcpp::Node` base class.
 
-```c++
+```cpp
 public:
 	explicit SensorCombinedListener() : Node("sensor_combined_listener") {
 		subscription_ = this->create_subscription<px4_msgs::msg::SensorCombined>(
@@ -520,7 +520,7 @@ public:
 This creates a callback function for when the `sensor_combined` uORB messages are received (now as DDS messages).
 It outputs the content of the message fields each time the message is received.
 
-```c++
+```cpp
 private:
 	rclcpp::Subscription<px4_msgs::msg::SensorCombined>::SharedPtr subscription_;
 };
@@ -528,7 +528,7 @@ private:
 
 The above create a subscription to the `sensor_combined_topic` which can be matched with one or more compatible ROS publishers.
 
-```c++
+```cpp
 int main(int argc, char *argv[])
 {
 	std::cout << "Starting sensor_combined listener node..." << std::endl;
@@ -550,7 +550,7 @@ A ROS2 advertiser node publishes data into the DDS/RTPS network (and hence to PX
 
 Taking as an example the `debug_vect_advertiser.cpp` under `px4_ros_com/src/advertisers`:
 
-```c++
+```cpp
 #include <chrono>
 #include <rclcpp/rclcpp.hpp>
 #include <px4_msgs/msg/debug_vect.hpp>
@@ -560,14 +560,14 @@ using namespace std::chrono_literals;
 
 Bring in the required headers, including the `debug_vect` msg header.
 
-```c++
+```cpp
 class DebugVectAdvertiser : public rclcpp::Node
 {
 ```
 
 The above creates a `DebugVectAdvertiser` class that subclasses the generic `rclcpp::Node` base class.
 
-```c++
+```cpp
 public:
 	DebugVectAdvertiser() : Node("debug_vect_advertiser") {
 		publisher_ = this->create_publisher<px4_msgs::msg::DebugVect>("DebugVect_PubSubTopic", 10);
@@ -596,7 +596,7 @@ private:
 This creates a function for when messages are to be sent.
 The messages are sent based on a timed callback, which sends two messages per second based on a timer.
 
-```c++
+```cpp
 int main(int argc, char *argv[])
 {
 	std::cout << "Starting debug_vect advertiser node..." << std::endl;
@@ -755,7 +755,7 @@ For UART transport on a Raspberry Pi or any other OBC you will have to enable th
    ```
 
    And make sure that the `enable_uart` value is set to 1:
-   ```txt
+   ```
     enable_uart=1
    ```
 

--- a/en/middleware/micrortps_throughput_test.md
+++ b/en/middleware/micrortps_throughput_test.md
@@ -10,7 +10,7 @@ It sends and receives 256-byte messages (simultaneously) at maximum rate, and th
 First create a new uORB message for this test in the folder **/PX4-Autopilot/msg/**.
 The message file will be called **throughput_256.msg** and have the following content:
 
-```text
+```
 uint8[256] data
 ```
 

--- a/en/uavcan/bootloader_installation.md
+++ b/en/uavcan/bootloader_installation.md
@@ -44,7 +44,7 @@ arm-none-eabi-gdb /path/to/your/bootloader/image.elf
 
 At the `gdb` prompt, run:
 
-```gdb
+```sh
 target extended /dev/ttyACM0
 monitor connect_srst enable
 monitor swdp_scan
@@ -71,7 +71,7 @@ arm-none-eabi-gdb /path/to/your/bootloader/image.elf
 
 At the `gdb` prompt, run:
 
-```gdb
+```sh
 target extended-remote localhost:3333
 monitor reset halt
 set mem inaccessible-by-default off


### PR DESCRIPTION
Replaces code block highlighting styles that don't work with vuepress (or gitbook) with styles that will work.