### PR TITLE
Heading anchors > explict anchors

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -19,7 +19,8 @@ This guide explains how to:
 * Communicate/integrate with external robotics APIs.
 
 
-## Support {#support}
+<a id="support"></a>
+## Support
 
 [Support](contribute/support.md) provide links to the [discussion boards](http://discuss.px4.io/) and other support channels.
 
@@ -45,7 +46,8 @@ You can access these by clicking the language-switcher icon:
 ![Gitbook Language Selector](../assets/gitbook/gitbook_language_selector.png)
 
 
-## Calendar & Events {#calendar}
+<a id="calendar"></a>
+## Calendar & Events
 
 The *Dronecode Calendar* shows important events for platform developers and users. 
 Select the links below to display the calendar in your timezone (and to add it to your own calendar):

--- a/en/README.md
+++ b/en/README.md
@@ -19,7 +19,6 @@ This guide explains how to:
 * Communicate/integrate with external robotics APIs.
 
 
-<a id="support"></a>
 ## Support
 
 [Support](contribute/support.md) provide links to the [discussion boards](http://discuss.px4.io/) and other support channels.

--- a/en/advanced/out_of_tree_modules.md
+++ b/en/advanced/out_of_tree_modules.md
@@ -42,7 +42,8 @@ To create an external module:
   ```
 
 
-## Out-of-Tree uORB Message Definitions {#uorb_message_definitions}
+<a id="uorb_message_definitions"></a>
+## Out-of-Tree uORB Message Definitions
 
 uORB messages can also be defined out-of-tree. For this, the `$EXTERNAL_MODULES_LOCATION/msg` folder must exist.
 
@@ -69,7 +70,8 @@ The new uORB messages can be used like any other uORB message as described [here
 > **Warning** The out-of-tree uORB message definitions cannot have the same name as any of the normal uORB messages.
 
 
-## Building External Modules and uORB Messages {#building}
+<a id="building"></a>
+## Building External Modules and uORB Messages
 
 Execute `make px4_sitl EXTERNAL_MODULES_LOCATION=<path>`.
  

--- a/en/advanced/parameters_and_configurations.md
+++ b/en/advanced/parameters_and_configurations.md
@@ -216,7 +216,8 @@ param_get(my_param_handle, &my_param);
 ```
 
 
-## Parameter Meta Data {#parameter_metadata}
+<a id="parameter_metadata"></a>
+## Parameter Meta Data
 
 PX4 uses an extensive parameter metadata system to drive the user-facing presentation of parameters, and to set the default value for each parameter in firmware.
 
@@ -230,7 +231,8 @@ The build system extracts the metadata (using `make parameters_metadata`) to bui
 > **Warning** After adding a *new* parameter file you should call `make clean` before building to generate the new parameters (parameter files are added as part of the *cmake* configure step, which happens for clean builds and if a cmake file is modified).
 
 
-### c Parameter Metadata {#c_metadata}
+<a id="c_metadata"></a>
+### c Parameter Metadata
 
 The legacy approach for defining parameter metadata is in a file with extension **.c** (at time of writing this is the approach most commonly used in the source tree).
 
@@ -285,7 +287,8 @@ The purpose of each line is given below (for more detail see [module_schema.yaml
  */
 ```
 
-### YAML Metadata {#yaml_metadata}
+<a id="yaml_metadata"></a>
+### YAML Metadata
 
 > **Note** At time of writing YAML parameter definitions cannot be used in *libraries*.
 
@@ -295,7 +298,8 @@ It supports all the same metadata, along with new features like multi-instance d
 - The YAML parameter metadata schema is here: [validation/module_schema.yaml](https://github.com/PX4/PX4-Autopilot/blob/master/validation/module_schema.yaml).
 - An example of YAML definitions being used can be found in the MAVLink parameter definitions: [/src/modules/mavlink/module.yaml](https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/mavlink/module.yaml).
 
-#### Multi-Instance (Templated) Meta Data {#multi_instance_metadata}
+<a id="multi_instance_metadata"></a>
+#### Multi-Instance (Templated) Meta Data
 
 Templated parameter definitions are supported in [YAML parameter definitions](https://github.com/PX4/PX4-Autopilot/blob/master/validation/module_schema.yaml) (templated parameter code is not supported).
 

--- a/en/airframes/adding_a_new_frame.md
+++ b/en/airframes/adding_a_new_frame.md
@@ -23,7 +23,8 @@ These aspects are mostly independent, which means that many configurations share
 
 > **Note** New airframe files are only automatically added to the build system after a clean build (run `make clean`).
 
-### Config File {#config-file}
+<a id="config-file"></a>
+### Config File
 
 A typical configuration file is shown below ([original file here](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing)).
 
@@ -99,7 +100,8 @@ set PWM_DISARMED 1000
 > **Warning** If you want to reverse a channel, never do this on your RC transmitter or with e.g `RC1_REV`. The channels are only reversed when flying in manual mode, when you switch in an autopilot flight mode, the channels output will still be wrong (it only inverts your RC signal). Thus for a correct channel assignment change either your PWM signals with `PWM_MAIN_REV1` (e.g. for channel one) or change the signs of the output scaling in the corresponding mixer (see below).
 
 
-### Mixer File {#mixer-file}
+<a id="mixer-file"></a>
+### Mixer File
 
 > **Note** First read [Concepts > Mixing](../concept/mixing.md).
   This provides background information required to interpret this mixer file.

--- a/en/concept/architecture.md
+++ b/en/concept/architecture.md
@@ -10,7 +10,8 @@ All PX4 [airframes](../airframes/README.md) share a single codebase (this includ
 - The system can deal with varying workload
 
 
-## High-Level Software Architecture{#architecture}
+<a id="architecture"></a>
+## High-Level Software Architecture
 
 The diagram below provides a detailed overview of the building blocks of PX4. 
 The top part of the diagram contains middleware blocks, while the lower
@@ -50,7 +51,8 @@ The use of the publish-subscribe scheme means that:
 > blocks to be rapidly and easily replaced, even at runtime.
 
 
-### Flight Stack {#flight-stack}
+<a id="flight-stack"></a>
+### Flight Stack
 
 The flight stack is a collection of guidance, navigation and control algorithms 
 for autonomous drones. 
@@ -89,7 +91,8 @@ factors, such as the motor arrangements with respect to the center of gravity,
 or the vehicle's rotational inertia.
 
 
-### Middleware {#middleware}
+<a id="middleware"></a>
+### Middleware
 
 The [middleware](../middleware/README.md) consists primarily of device drivers
 for embedded sensors, communication with the external world (companion computer,
@@ -112,7 +115,8 @@ considerably slower.
 The message update rates can be [inspected](../middleware/uorb.md)
 in real-time on the system by running `uorb top`.
 
-## Runtime Environment {#runtime-environment}
+<a id="runtime-environment"></a>
+## Runtime Environment
 
 PX4 runs on various operating systems that provide a POSIX-API (such as Linux, macOS, NuttX or QuRT).
 It should also have some form of real-time scheduling (e.g. FIFO).

--- a/en/concept/mixing.md
+++ b/en/concept/mixing.md
@@ -85,7 +85,8 @@ For a multicopter things are a bit different: control 0 (roll) is connected to a
   In the event of manual IO failsafe override (if the PX4FMU stops communicating with the PX4IO board) only the mapping/mixing defined by control group 0 inputs for roll, pitch, yaw and throttle are used (other mappings are ignored).
 
 
-### Control Group #6 (First Payload) {#control_group_6}
+<a id="control_group_6"></a>
+### Control Group #6 (First Payload)
 
 * 0: function 0
 * 1: function 1
@@ -159,12 +160,14 @@ Mixers are defined in plain-text files using the [syntax](#mixer_syntax) below.
 Files for pre-defined airframes can be found in [ROMFS/px4fmu_common/mixers](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/mixers).
 These can be used as a basis for customisation, or for general testing purposes.
 
-### Mixer File Names {#mixer_file_names}
+<a id="mixer_file_names"></a>
+### Mixer File Names
 
 A mixer file must be named **XXXX._main_.mix** if it is responsible for the mixing of MAIN outputs or **XXXX._aux_.mix** if it mixes AUX outputs.
 
 
-### Mixer Loading {#loading_mixer}
+<a id="loading_mixer"></a>
+### Mixer Loading
 
 The default set of mixer files (in PX4 firmware) are defined in [px4fmu_common/init.d/airframes/](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d/airframes/).
 These can be overridden by mixer files with the same name in the SD card directory **/etc/mixers/** (SD card mixer files are loaded by preference).
@@ -184,7 +187,8 @@ The AUX mixer filename (prefix `YYYY` above) depends on airframe settings and/or
 > **Note** Mixer file loading is implemented in [ROMFS/px4fmu_common/init.d/rc.interface](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d/rc.interface).
 
 
-### Loading a Custom Mixer {#loading_custom_mixer}
+<a id="loading_custom_mixer"></a>
+### Loading a Custom Mixer
 
 PX4 loads appropriately named mixer files from the SD card directory **/etc/mixers/**, by preference, and then the version in Firmware.
 
@@ -200,7 +204,8 @@ See above for more information on [mixer loading](#loading_mixer).
 >   ```
 
 
-### Syntax {#mixer_syntax}
+<a id="mixer_syntax"></a>
+### Syntax
 
 Mixer files are text files that define one or more mixer definitions: mappings between one or more inputs and one or more outputs. 
 
@@ -238,7 +243,8 @@ Some mixers definitions consist of a number of tags (e.g. `O` and `S`) that foll
 > **Note** Any line that does not begin with a single capital letter followed by a colon may be ignored (so explanatory text can be freely mixed with the definitions).
 
 
-#### Summing Mixer {#summing_mixer}
+<a id="summing_mixer"></a>
+#### Summing Mixer
 
 Summing mixers are used for actuator and servo control.
 
@@ -277,7 +283,8 @@ Whilst the calculations are performed as floating-point operations, the values s
 An example of a typical mixer file is explained [here](../airframes/adding_a_new_frame.md#mixer-file).
 
 
-#### Null Mixer {#null_mixer}
+<a id="null_mixer"></a>
+#### Null Mixer
 
 A null mixer consumes no controls and generates a single actuator output with a value that is always zero.
 
@@ -290,7 +297,8 @@ Z:
 ```
 
 
-#### Multirotor Mixer {#multirotor_mixer}
+<a id="multirotor_mixer"></a>
+#### Multirotor Mixer
 
 The multirotor mixer combines four control inputs (roll, pitch, yaw, thrust) into a set of actuator outputs intended to drive motor speed controllers.
 
@@ -319,7 +327,8 @@ Idlespeed is relative to the maximum speed of motors and it is the speed at whic
 
 In the case where an actuator saturates, all actuator values are rescaled so that the saturating actuator is limited to 1.0.
 
-#### Helicopter Mixer {#helicopter_mixer}
+<a id="helicopter_mixer"></a>
+#### Helicopter Mixer
 
 The helicopter mixer combines three control inputs (roll, pitch, thrust) into four outputs (swash-plate servos and main motor ESC setting).
 The first output of the helicopter mixer is the throttle setting for the main motor.
@@ -394,7 +403,8 @@ S: 0 2  10000  10000      0 -10000  10000
 - The second and third servo have a longer arm, by a ratio of 1.3054 compared to the first servo.
 - The servos are limited at -8000 and 8000 because they are mechanically constrained.
 
-#### VTOL Mixer {#vtol_mixer}
+<a id="vtol_mixer"></a>
+#### VTOL Mixer
 
 VTOL systems use a [multirotor mixer](#multirotor_mixer) for the multirotor outputs, and [summing mixers](#summing_mixer) for the fixed-wing actuators (and the tilting servos in case of a tiltrotor VTOL).
 

--- a/en/contribute/dev_call.md
+++ b/en/contribute/dev_call.md
@@ -1,4 +1,5 @@
-# Weekly Dev Call {#dev_call}
+<a id="dev_call"></a>
+# Weekly Dev Call
 
 The PX4 dev team syncs up on platform technical details and in-depth analysis. 
 There is also space in the agenda to discuss pull requests, major impacting issues and Q&A.

--- a/en/contribute/docs.md
+++ b/en/contribute/docs.md
@@ -199,7 +199,8 @@ Everything you need to install and build Gitbook locally is also explained in th
    ```
 
 
-## Translations {#translation}
+<a id="translation"></a>
+## Translations
 
 We'd love your help to translate *QGroundControl* and our guides for PX4, *QGroundControl* and MAVLink.
 For more information see: [Translation](../contribute/translation.md).

--- a/en/contribute/git_examples.md
+++ b/en/contribute/git_examples.md
@@ -1,6 +1,7 @@
 # GIT Examples
 
-## Contributing Code to PX4 {#contributing_code}
+<a id="contributing_code"></a>
+## Contributing Code to PX4
 
 Adding a feature to PX4 follows a defined workflow. In order to share your contributions on PX4, you can follow this example.
 

--- a/en/contribute/notation.md
+++ b/en/contribute/notation.md
@@ -71,7 +71,8 @@ $$w$$ | Relative airspeed.
 $$x,y,z$$ | Component of vector along coordinate axis x, y and z.
 $$N,E,D$$ | Component of vector along global north, east and down direction.
 
-### Superscripts / Indices {#superscripts}
+<a id="superscripts"></a>
+### Superscripts / Indices
 
 Superscripts / Indices | Description
 --- | ---

--- a/en/contribute/support.md
+++ b/en/contribute/support.md
@@ -4,7 +4,8 @@ This section shows how you can get help from the core dev team and the wider com
 
 > **Tip** Developers are most welcome to attend the [weekly dev call](../contribute/dev_call.md) and other [developer events](../README.md#calendar) to engage more deeply with the project.
 
-## Forums and Chat {#support}
+<a id="support"></a>
+## Forums and Chat
 
 The core development team and community are active on the following forums and chat channels.
 
@@ -26,7 +27,8 @@ If you are unsure what the problem is and you need help diagnosing
 * [Open a Github Issue](https://github.com/PX4/Devguide/issues) with a flight report with as much detail as possible and links to logs.
 
 
-## Weekly Dev Call {#dev_call}
+<a id="dev_call"></a>
+## Weekly Dev Call
 
 The [Dev Call](../contribute/dev_call.md) is a weekly meeting attended by the PX4 dev team to discuss platform technical details, coordinate activities and perform in-depth analysis.
 

--- a/en/debug/consoles.md
+++ b/en/debug/consoles.md
@@ -5,7 +5,8 @@ PX4 enables terminal access to the system through the [MAVLink Shell](../debug/m
 This page explains the main differences and how the console/shell are used.
 
 
-## System Console vs. Shells {#console_vs_shell}
+<a id="console_vs_shell"></a>
+## System Console vs. Shells
 
 The PX4 *System Console* provides low-level access to the system, debug output and analysis of the system boot process.
 
@@ -29,7 +30,8 @@ The [System Console](../debug/system_console.md) is essential when the system do
 The [MAVLink Shell](../debug/mavlink_shell.md) is much easier to setup, and so is more generally recommended for most debugging.
 
 
-## Using Consoles/Shells {#using_the_console}
+<a id="using_the_console"></a>
+## Using Consoles/Shells
 
 The MAVLink shell/console and the [System Console](../debug/system_console.md) are used in much the same way.
 

--- a/en/debug/mavlink_shell.md
+++ b/en/debug/mavlink_shell.md
@@ -10,7 +10,8 @@ While the shell cannot *directly* display the output of modules that it does not
 
 ## Opening the Shell
 
-### QGroundControl MAVLink Console {#qgroundcontrol}
+<a id="qgroundcontrol"></a>
+### QGroundControl MAVLink Console
 
 The easiest way to access shell is to use the [QGroundControl MAVLink Console](https://docs.qgroundcontrol.com/en/analyze_view/mavlink_console.html) (see **Analyze View > Mavlink Console**).
 

--- a/en/debug/profiling.md
+++ b/en/debug/profiling.md
@@ -49,7 +49,8 @@ Please watch out for them while using it:
   This does not affect single core embedded targets, since they always execute in one thread, but this limitation makes the profiler incompatible with many other applications.
   In the future the stack folder should be modified to support multiple stack traces per sample.
 
-## Implementation {#implementation}
+<a id="implementation"></a>
+## Implementation
 
 The script is located at `Debug/poor-mans-profiler.sh`.
 Once launched, it will perform the specified number of samples with the specified time interval.

--- a/en/debug/swd_debug.md
+++ b/en/debug/swd_debug.md
@@ -8,7 +8,8 @@ The SWD interface can also be used to add a new bootloader and/or firmware on a 
 
 This topic explains how to connect the SWD interface on different boards (actually performing debugging is then covered in the associated [debugging topics](#debugging_topics)).
 
-## SWD Interface Definition {#swd_interface}
+<a id="swd_interface"></a>
+## SWD Interface Definition
 
 The SWD interface consists of the following pins.
 
@@ -49,7 +50,8 @@ You can also create custom cables for connecting to different boards or probes.
   This reduces the risk or poor wiring contributing to debugging problems, and has the benefit that adapters usually provide a common interface for connecting to multiple popular flight controller boards.
 
 
-## Autopilot Debug Ports {#debug_ports}
+<a id="debug_ports"></a>
+## Autopilot Debug Ports
 
 Flight controllers commonly provide a debug port that exposes both the [SWD Interface](#swd_interface) and [System Console](../debug/system_console.md).
 
@@ -75,7 +77,8 @@ Autopilot | Connector
 
 
 
-## Pixhawk Standard Debug Ports {#pixhawk_standard_debug_ports}
+<a id="pixhawk_standard_debug_ports"></a>
+## Pixhawk Standard Debug Ports
 
 The Pixhawk project has defines a standard pinout and connector type for different Pixhawk FMU releases:
 
@@ -94,7 +97,8 @@ FMUv6X | Pixhawk 6 | [10 pin SH Debug](#pixhawk_debug_port_10_pin_sh)
 > **Note** There FMU and Pixhawk versions are (only) consistent after FMUv5X.
 
 
-### Pixhawk Debug Mini (6-Pin SH Debug Port) {#pixhawk_debug_port_6_pin_sh}
+<a id="pixhawk_debug_port_6_pin_sh"></a>
+### Pixhawk Debug Mini (6-Pin SH Debug Port)
 
 The [Pixhawk Connector Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf) defines a *6-Pin SH Debug Port* that provides access to both SWD pins and the [System Console](../debug/system_console.md).
 
@@ -127,7 +131,8 @@ You can connect to the debug port using a [cable like this one](https://www.digi
 ![6-pin JST SH Cable](../../assets/debug/cable_6pin_jst_sh.jpg)
 
 
-### Pixhawk Debug Full (10-Pin SH Debug Port) {#pixhawk_debug_port_10_pin_sh}
+<a id="pixhawk_debug_port_10_pin_sh"></a>
+### Pixhawk Debug Full (10-Pin SH Debug Port)
 
 The [Pixhawk Connector Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf)  defines a *10-Pin SH Debug Port* that provides access to both SWD pins and the [System Console](../debug/system_console.md).
 This essentially moves the solder pads from beside the [Pixhawk 6-Pin SH Debug Port](#pixhawk_debug_port_6_pin_sh) into the connector, and also adds an SWO pin.
@@ -156,12 +161,14 @@ You can connect to the debug port using a [cable like this one](https://www.digi
 ![10-pin JST SH Cable](../../assets/debug/cable_10pin_jst_sh.jpg) <!-- better to have image showing proper connections for SWD+SWO -->
 
 
-## Debug Probes {#debug_probes}
+<a id="debug_probes"></a>
+## Debug Probes
 
 The following section outlines some popular debug probes and adaptors for connecting them to autopilots running PX4.
 
 
-### Segger JLink EDU Mini Debug Probe {#segger_jlink_edu_mini}
+<a id="segger_jlink_edu_mini"></a>
+### Segger JLink EDU Mini Debug Probe
 
 The [Segger JLink EDU Mini](https://www.segger.com/products/debug-probes/j-link/models/j-link-edu-mini/) is an inexpensive and popular SWD debug probe. 
 The probe's connector pinout looks like the image below (connect to this using an ARM 10-pin mini connector like [FTSH-105-01-F-DV-K](https://www.digikey.com/products/en?keywords=SAM8796-ND)).
@@ -184,7 +191,8 @@ Debug Port | J-Link Mini
 <!-- Image of SWD cable and connector to debug port? --> 
 
 
-### Dronecode Probe {#dronecode_probe}
+<a id="dronecode_probe"></a>
+### Dronecode Probe
 
 The [Dronecode Probe](https://kb.zubax.com/display/MAINKB/Dronecode+Probe+documentation) is a generic JTAG/SWD + UART console adapter compatible with most ARM Cortex based designs, and in particular with Pixhawk series flight controllers (and other hardware that PX4 supports).
 
@@ -198,7 +206,8 @@ The probe provides a DCD-M connector cable for attaching to the [Pixhawk 6-Pin S
 > **Note** The *Dronecode Probe* is based on the [Black Magic Probe](#black_magic_probe).
 
 
-### Black Magic Probe {#black_magic_probe}
+<a id="black_magic_probe"></a>
+### Black Magic Probe
 
 The [Black Magic Probe](https://github.com/blacksphere/blackmagic/wiki) is much like the [Dronecode probe](#dronecode_probe) but does not come with the same adapters for directly connecting to Pixhawk series flight controllers.
 
@@ -206,7 +215,8 @@ Adapters can be purchased separately:
 - [Drone Code Debug Adapter](https://1bitsquared.com/products/drone-code-debug-adapter) (1 BIT SQUARED).
 
 
-## Next Steps {#debugging_topics}
+<a id="debugging_topics"></a>
+## Next Steps
 
 You've now connected the flight controller to an SWD debug probe!
 

--- a/en/debug/system_console.md
+++ b/en/debug/system_console.md
@@ -33,7 +33,8 @@ The System Console UART pinouts/debug ports are typically documented in [autopil
   - [DSP Debug Monitor/Console](https://docs.px4.io/master/en/flight_controller/snapdragon_flight_advanced.html#dsp-debug-monitorconsole)
 
 
-### Pixhawk Debug Port {#pixhawk_debug_port}
+<a id="pixhawk_debug_port"></a>
+### Pixhawk Debug Port
 
 Flight controllers that adhere to the Pixhawk Connector standard use the [Pixhawk Standard Debug Port](
 https://pixhawk.org/pixhawk-connector-standard/#dronecode_debug).

--- a/en/hardware/board_support_guide.md
+++ b/en/hardware/board_support_guide.md
@@ -8,7 +8,8 @@ Manufacturers who wish to deviate from the standard or create completely new boa
 > **Note** Boards that are not compliant with the requirements are [unsupported](#unsupported);
   they will not be listed on the PX4 website hardware list and will be removed from the codebase.
 
-## General Requirements {#general_requirements}
+<a id="general_requirements"></a>
+## General Requirements
 
 The general requirements for all supported boards are:
 
@@ -45,7 +46,8 @@ A Pixhawk board is one that conforms to the Pixhawk standards. These standards a
 
 PX4 generally only supports boards that are commercially available, which typically means that board standards released within the last five years are supported.
 
-### VER and REV ID (Hardware Revision and Version Sensing) {#ver_rev_id}
+<a id="ver_rev_id"></a>
+### VER and REV ID (Hardware Revision and Version Sensing)
 
 FMUv5 and onwards have an electrical sensing mechanism.
 This sensing coupled with optional configuration data will be used to define hardware’s configuration with respect to a mandatory device and power supply configuration. Manufacturers must obtain the VER and REV ID from PX4 board maintainers at [boards@px4.io](mailto:boards@px4.io) for releasing Pixhawk standard boards. 
@@ -88,7 +90,8 @@ The following requirements apply:
   *New* experimental boards are allocated [VER and REV IDs](#ver_rev_id) based on compatibility, in the same way as Manufacturer Supported boards.
   
 
-## Unsupported {#unsupported}
+<a id="unsupported"></a>
+## Unsupported
 
 This category includes all boards that aren't supported by the PX4 project or a manufacturer, and that fall outside the"experimental" support.
 

--- a/en/hardware/reference_design.md
+++ b/en/hardware/reference_design.md
@@ -8,7 +8,8 @@ All boards manufactured to a particular design are expected to be binary compati
 
 FMU generations 1-3 were designed as open hardware, while FMU generations 4 and 5 provided only pinout and power supply specifications (schematics were created by individual manufacturers). In order to better ensure compatibility, FMUv6 and onward will return to a complete reference design model.
 
-## Reference Design Generations {#reference_design_generations}
+<a id="reference_design_generations"></a>
+## Reference Design Generations
 
 * FMUv1: Development board \(STM32F407, 128 KB RAM, 1MB flash, [schematics](https://github.com/PX4/Hardware/tree/master/FMUv1)\) (no longer supported by PX4)
 * FMUv2: Pixhawk \(STM32F427, 168 MHz, 192 KB RAM, 1MB flash, [schematics](https://github.com/PX4/Hardware/tree/master/FMUv2)\)

--- a/en/middleware/micrortps.md
+++ b/en/middleware/micrortps.md
@@ -86,7 +86,8 @@ The *Agent* must be separately/manually compiled for the target computer.
 > **Tip** The bridge code can also be [manually generated](micrortps_manual_code_generation.md).
   Most users will not need to do so, but the linked topic provides a more detailed overview of the build process and can be useful for troubleshooting.
 
-### ROS2/ROS applications {#px4_ros_com}
+<a id="px4_ros_com"></a>
+### ROS2/ROS applications
 
 The [px4_ros_com](https://github.com/PX4/px4_ros_com) package, when built, generates everything needed to access PX4 uORB messages from a ROS2 node (for ROS you also need [ros1_bridge](https://github.com/ros2/ros1_bridge)).
 This includes all the required components of the *PX4 RTPS bridge*, including the `micrortps_agent` and the IDL files (required by the `micrortps_agent`).
@@ -148,7 +149,8 @@ rtps:
 > (required because if a message is sent from the client side, then it's received on the agent side, and vice-versa).
 
 
-## Client (PX4/PX4-Autopilot) {#client_firmware}
+<a id="client_firmware"></a>
+## Client (PX4/PX4-Autopilot)
 
 The *Client* source code is generated, compiled and built into the PX4 firmware as part of the normal build process.
 

--- a/en/middleware/uorb.md
+++ b/en/middleware/uorb.md
@@ -133,7 +133,8 @@ Make sure not to mix `orb_advertise_multi` and `orb_advertise` for the same topi
 The full API is documented in
 [src/modules/uORB/uORBManager.hpp](https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/uORB/uORBManager.hpp).
 
-## Message/Field Deprecation {#deprecation}
+<a id="deprecation"></a>
+## Message/Field Deprecation
 As there are external tools using uORB messages from log files, such as [Flight Review](https://github.com/PX4/flight_review), certain aspects need to be considered when updating existing messages:
 
 - Changing existing fields or messages that external tools rely on is generally acceptable if there are good reasons for the update.

--- a/en/middleware/uorb_graph.md
+++ b/en/middleware/uorb_graph.md
@@ -499,7 +499,8 @@ initializeGraph();
 </script>
 
 
-## Graph Properties{#instructions}
+<a id="instructions"></a>
+## Graph Properties
 The graph has the following properties:
 
 - Modules are shown in gray with rounded corners while topics are displayed as

--- a/en/ros/external_position_estimation.md
+++ b/en/ros/external_position_estimation.md
@@ -80,7 +80,8 @@ Parameter | Setting for External Position Estimation
 > **Tip** Reboot the flight controller in order for parameter changes to take effect.
 
 
-#### Tuning EKF2_EV_DELAY {#tuning-EKF2_EV_DELAY}
+<a id="tuning-EKF2_EV_DELAY"></a>
+#### Tuning EKF2_EV_DELAY
 
 [EKF2_EV_DELAY](../advanced/parameter_reference.md#EKF2_EV_DELAY) is the *Vision Position Estimator delay relative to IMU measurements*.
 
@@ -145,7 +146,8 @@ The setup for specific systems is covered [below](#setup_specific_systems).
 For other systems consult the vendor setup documentation.
 
 
-### Relaying Pose Data to PX4 {#relaying_pose_data_to_px4}
+<a id="relaying_pose_data_to_px4"></a>
+### Relaying Pose Data to PX4
 
 MAVROS has plugins to relay a visual estimation from a VIO or MoCap system using the following pipelines:
 
@@ -167,7 +169,8 @@ To use MoCap data with EKF2 you will have to [remap](http://wiki.ros.org/roslaun
 - Note that if you are sending odometry data to px4 using `child_frame_id = base_link`, then then you need to make sure that the `twist` portion of the `nav_msgs/Odometry` message is **expressed in body frame**, **not in inertial frame!!!!!**.
 
 
-### Reference Frames and ROS {#ros_reference_frames}
+<a id="ros_reference_frames"></a>
+### Reference Frames and ROS
 
 The local/world and world frames used by ROS and PX4 are different.
 
@@ -216,7 +219,8 @@ The name of `external_pose_parent_frame` has to match the frame_id of the odomet
 > **Note** When using the MAVROS *odom* plugin, it is important that no other node is publishing a transform between the external pose's reference and child frame.
   This might break the *tf* tree.
 
-## Specific System Setups {#setup_specific_systems}
+<a id="setup_specific_systems"></a>
+## Specific System Setups
 
 ### OptiTrack MoCap
 

--- a/en/setup/building_px4.md
+++ b/en/setup/building_px4.md
@@ -7,7 +7,8 @@ PX4 can be built on the console or in an IDE, for both simulated and hardware ta
 <span></span>
 > **Tip** For solutions to common build problems see [Troubleshooting](#troubleshooting) below.
 
-## Download the PX4 Source Code {#get_px4_code}
+<a id="get_px4_code"></a>
+## Download the PX4 Source Code
 
 The PX4 source code is stored on Github in the [PX4/PX4-Autopilot](https://github.com/PX4/PX4-Autopilot) repository.
 To get the *very latest* version onto your computer, enter the following command into a terminal:
@@ -20,7 +21,8 @@ git clone https://github.com/PX4/PX4-Autopilot.git --recursive
   [GIT Examples > Contributing code to PX4](../contribute/git_examples.md#contributing_code) provides a lot more information about using git to contribute to PX4. 
 
 
-## First Build (Using the jMAVSim Simulator) {#jmavsim_build}
+<a id="jmavsim_build"></a>
+## First Build (Using the jMAVSim Simulator)
 
 First we'll build a simulated target using a console environment.
 This allows us to validate the system setup before moving on to real hardware and an IDE.
@@ -54,9 +56,11 @@ This will reposition the vehicle.
   make px4_sitl gazebo
   ```
 
-## NuttX / Pixhawk Based Boards {#nuttx}
+<a id="nuttx"></a>
+## NuttX / Pixhawk Based Boards
 
-### Building {#building_nuttx}
+<a id="building_nuttx"></a>
+### Building
 
 To build for NuttX- or Pixhawk- based boards, navigate into the **PX4-Autopilot** directory and then call `make` with the build target for your board.
 
@@ -369,7 +373,8 @@ That's it! Start *Qt Creator*, then complete the steps in the video below to set
 {% youtube %}https://www.youtube.com/watch?v=0pa0gS30zNw&rel=0&vq=hd720{% endyoutube %}
 
 
-## PX4 Make Build Targets {#make_targets}
+<a id="make_targets"></a>
+## PX4 Make Build Targets
 
 The previous sections showed how you can call *make* to build a number of different targets, start simulators, use IDEs etc.
 This section shows how *make* options are constructed and how to find the available choices.
@@ -423,7 +428,8 @@ Specifically `VENDOR_MODEL_VARIANT` maps to a configuration file **boards/VENDOR
 Additional make targets are discussed in the following sections (list is not exhaustive):
 
 
-### Binary Size Profiling {#bloaty_compare_master}
+<a id="bloaty_compare_master"></a>
+### Binary Size Profiling
 
 The `bloaty_compare_master` build target allows you to get a better understanding of the impact of changes on code size.
 When it is used, the toolchain downloads the latest successful master build of a particular firmware and compares it to the local build (using the [bloaty](https://github.com/google/bloaty) size profiler for binaries).
@@ -481,7 +487,8 @@ Then use the make target, specifying the target build to compare (`px4_fmu-v2_de
 This shows that removing *mpu9250* from `px4_fmu-v2_default` would save 10.3 kB of flash.
 It also shows the sizes of different pieces of the *mpu9250* driver.
 
-## Firmware Version & Git Tags {#firmware_version}
+<a id="firmware_version"></a>
+## Firmware Version & Git Tags
 
 The *PX4 Firmware Version* and *Custom Firmware Version* are published using the MAVLink [AUTOPILOT_VERSION](https://mavlink.io/en/messages/common.html#AUTOPILOT_VERSION) message, and displayed in the *QGroundControl* **Setup > Summary** airframe panel:
 
@@ -493,7 +500,8 @@ The git tag should be formatted as `<PX4-version>-<vendor-version>` (e.g. the ta
 > **Warning** If you use a different git tag format, versions information may not be displayed properly.
 
 
-## Troubleshooting {#troubleshooting}
+<a id="troubleshooting"></a>
+## Troubleshooting
 
 ### General Build Errors
 
@@ -516,7 +524,8 @@ If building your own branch, it is possibly you have increased the firmware size
 In this case you will need to remove any drivers/modules that you don't need from the build. 
 
 
-### macOS: Too many open fileserror {#macos_open_files}
+<a id="macos_open_files"></a>
+### macOS: Too many open fileserror
 
 MacOS allows a default maximum of 256 open files in all running processes.
 The PX4 build system opens a large number of files, so you may exceed this number.

--- a/en/setup/dev_env_linux_ubuntu.md
+++ b/en/setup/dev_env_linux_ubuntu.md
@@ -12,7 +12,8 @@ Bash scripts are provided to help make it easy to install development environmen
 
 The instructions below explain how to download and use the scripts.
 
-## Gazebo, JMAVSim and NuttX (Pixhawk) Targets {#sim_nuttx}
+<a id="sim_nuttx"></a>
+## Gazebo, JMAVSim and NuttX (Pixhawk) Targets
 
 Use the [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/{{ book.px4_version }}/Tools/setup/ubuntu.sh) script to set up a development environment that includes [Gazebo 9](../simulation/gazebo.md) and [jMAVSim](../simulation/jmavsim.md) simulators, and/or the [NuttX/Pixhawk](../setup/building_px4.md#nuttx) toolchain.
 
@@ -59,7 +60,8 @@ sudo add-apt-repository --remove ppa:team-gcc-arm-embedded/ppa
 
 
 
-## Raspberry Pi {#raspberry-pi-hardware}
+<a id="raspberry-pi-hardware"></a>
+## Raspberry Pi
 
 <!-- NOTE: RaPi docker toolchain (for comparison) here: https://github.com/PX4/containers/blob/master/docker/Dockerfile_armhf -->
 
@@ -121,7 +123,8 @@ make
 Additional developer information for using PX4 on Raspberry Pi (including building PX4 natively) can be found here: [Raspberry Pi 2/3 Navio2 Autopilot](https://docs.px4.io/master/en/flight_controller/raspberry_pi_navio2.html).
 
 
-## ROS/Gazebo {#rosgazebo}
+<a id="rosgazebo"></a>
+## ROS/Gazebo
 
 This section explains how to install [ROS/Gazebo](../ros/README.md) ("Melodic") for use with PX4.
 
@@ -150,7 +153,8 @@ Setup instructions for Snapdragon Flight are provided in the *PX4 User Guide*:
 * [Configuration](https://docs.px4.io/master/en/flight_controller/snapdragon_flight_configuration.html)
 
 
-## Fast RTPS installation {#fast_rtps}
+<a id="fast_rtps"></a>
+## Fast RTPS installation
 
 [eProsima Fast RTPS](http://eprosima-fast-rtps.readthedocs.io/en/latest/) is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol.
 FastRTPS is used, via the [RTPS/ROS2 Interface: PX4-FastRTPS Bridge](../middleware/micrortps.md), to allow PX4 uORB topics to be shared with offboard components.

--- a/en/setup/dev_env_windows_bash_on_win.md
+++ b/en/setup/dev_env_windows_bash_on_win.md
@@ -65,7 +65,8 @@ To run JMAVSim:
  ```
 
 
-### Build Script Details {#build_script_details}
+<a id="build_script_details"></a>
+### Build Script Details
 
 The <a href="https://raw.githubusercontent.com/PX4/Devguide/{{ book.px4_version }}/build_scripts/windows_bash_nuttx.sh">windows_bash_nuttx.sh</a> build script modifies the Ubuntu build instructions to remove Ubuntu-specific and UI-dependent components, including the *Qt Creator* IDE and the simulators.
 

--- a/en/setup/dev_env_windows_cygwin.md
+++ b/en/setup/dev_env_windows_cygwin.md
@@ -12,7 +12,8 @@ The toolchain supports:
 
 This topic explains how download and use the environment, and how it can be extended and updated if needed (for example, to use a different compiler).
 
-## Installation Instructions {#installation}
+<a id="installation"></a>
+## Installation Instructions
 
 1. Download the latest version of the ready-to-use MSI installer from: [Github releases](https://github.com/PX4/windows-toolchain/releases) or [Amazon S3](https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.9.msi) (fast download).
 1. Run it, choose your desired installation location, let it install:
@@ -22,7 +23,8 @@ This topic explains how download and use the environment, and how it can be exte
    > **Note** If you missed this step you will need to [clone the PX4-Autopilot repository manually](#getting_started).
 
 
-## Getting Started {#getting_started}
+<a id="getting_started"></a>
+## Getting Started
 
 The toolchain uses a specially configured console window (started by running the **run-console.bat** script) from which you can call the normal PX4 build commands:
 
@@ -54,7 +56,8 @@ The toolchain uses a specially configured console window (started by running the
 Continue next to [the detailed instructions on how to build PX4](../setup/building_px4.md) (or see the section below for more general usage instructions).
 
 
-## Usage Instructions {#usage_instructions}
+<a id="usage_instructions"></a>
+## Usage Instructions
 
 The installation directory (default: **C:\PX4\**) contains a batch script for launching the PX4 SITL (linux like) bash console: **run-console.bat**
 
@@ -112,7 +115,8 @@ git submodule foreach --recursive git config --unset core.filemode # remove the 
 
 ## Additional Information
 
-### Features / Issues {#features}
+<a id="features"></a>
+### Features / Issues
 
 The following features are known to work (version 2.0):
 
@@ -128,7 +132,8 @@ Omissions:
 * Only NuttX and JMAVSim/SITL builds are supported.
 * [Known problems](https://github.com/orgs/PX4/projects/6) (Also use to report issues).
 
-### Shell Script Installation {#script_setup}
+<a id="script_setup"></a>
+### Shell Script Installation
 
 You can also install the environment using shell scripts in the Github project.
 
@@ -142,7 +147,8 @@ git clone https://github.com/PX4/windows-toolchain PX4
 1. Continue with [Getting Started](#getting_started) (or [Usage Instructions](#usage_instructions))
 
 
-### Manual Installation (for Toolchain Developers) {#manual_setup}
+<a id="manual_setup"></a>
+### Manual Installation (for Toolchain Developers)
 
 This section describes how to setup the Cygwin toolchain manually yourself while pointing to the corresponding scripts from the script based installation repo.
 The result should be the same as using the scripts or MSI installer.

--- a/en/setup/vscode.md
+++ b/en/setup/vscode.md
@@ -42,7 +42,8 @@ You must already have installed the command line [PX4 developer environment](../
    - Other prompts are optional, and may be installed if they seem useful. <!-- perhaps add screenshot of these prompts -->
 
 
-## Building PX4 {#building}
+<a id="building"></a>
+## Building PX4
 
 To build:
 1. Select your build target ("cmake build config"):
@@ -62,7 +63,8 @@ After building at least once you can now use [code completion](#code completion)
 
 ## Debugging 
 
-### SITL Debugging {#debugging_sitl}
+<a id="debugging_sitl"></a>
+### SITL Debugging
 
 To debug PX4 on SITL:
 1. Select the debug icon on the sidebar (marked in red) to display the debug panel.
@@ -84,7 +86,8 @@ After connecting to the SWD interface, hardware debugging in VSCode is then the 
 ![Image showing hardware targets with options for the different probes](../../assets/toolchain/vscode/vscode_hardware_debugging_options.png)
 
 
-## Code Completion {#code completion}
+<a id="code completion"></a>
+## Code Completion
 
 In order for the code completion to work (and other IntelliSense magic) you need an active configuration and to have [built the code](#building).
 

--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -120,7 +120,8 @@ The simulation can be further configured via environment variables:
 The syntax described here is simplified, and there are many other options that you can configure via *make* - for example, to set that you wish to connect to an IDE or debugger.
 For more information see: [Building the Code > PX4 Make Build Targets](../setup/building_px4.md#make_targets).
 
-### Run Simulation Faster than Realtime {#simulation_speed}
+<a id="simulation_speed"></a>
+### Run Simulation Faster than Realtime
 
 SITL can be run faster or slower than realtime when using jMAVSim or Gazebo.
 
@@ -172,7 +173,8 @@ To disable lockstep in Gazebo, edit [the model SDF file](https://github.com/PX4/
 
 To disable lockstep in jMAVSim, remove `-l` in [jmavsim_run.sh](https://github.com/PX4/PX4-Autopilot/blob/77097b6adc70afbe7e5d8ff9797ed3413e96dbf6/Tools/sitl_run.sh#L75), or make sure otherwise that the java binary is started without the `-lockstep` flag.
 
-### Startup Scripts {#scripts}
+<a id="scripts"></a>
+### Startup Scripts
 
 Scripts are used to control which parameter settings to use or which modules to start.
 They are located in the [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/PX4-Autopilot/tree/master/ROMFS/px4fmu_common/init.d-posix) directory, the `rcS` file is the main entry point.

--- a/en/simulation/flightgear.md
+++ b/en/simulation/flightgear.md
@@ -23,7 +23,8 @@ graph LR;
 > **Note** See [Simulation](/simulation/README.md) for general information about simulators, the simulation environment, and simulation configuration (e.g. supported vehicles).
 
 
-## Installation (Ubuntu Linux) {#installation}
+<a id="installation"></a>
+## Installation (Ubuntu Linux)
 
 > **Note** These instructions were tested on Ubuntu 18.04
 
@@ -52,7 +53,8 @@ graph LR;
 Additional installation instructions can be found on [FlightGear wiki](http://wiki.flightgear.org/Howto:Install_Flightgear_from_a_PPA).   
 
 
-## Running the Simulation {#running}
+<a id="running"></a>
+## Running the Simulation
 
 Run a simulation by starting PX4 SITL, specifying the airframe configuration of your choice.
 
@@ -156,11 +158,13 @@ You can tune your FG installation/settings by the following environment variable
 - `FG\_MODELS\_DIR` - absolute path to the folder containing the manually-downloaded aircraft models which should be used for simulation.
 - `FG\_ARGS\_EX` - any additional FG parameters.
 
-### Display the frame rate {#frame_rate}
+<a id="frame_rate"></a>
+### Display the frame rate
 
 In FlightGear you can display the frame rate by enabling it in: **View > View Options > Show frame rate**.
 
-### Set Custom Takeoff Location {#custom_takeoff_location}
+<a id="custom_takeoff_location"></a>
+### Set Custom Takeoff Location
 
 Takeoff location in SITL FlightGear can be set using additional variables.
 Setting the variable will override the default takeoff location.
@@ -176,7 +180,8 @@ FG_ARGS_EX="--airport=PHNL"  make px4_sitl_nolockstep flightgear_rascal
 The example above starts the simulation on the [Honolulu international airport](http://wiki.flightgear.org/Suggested_airports)
 
 
-### Using a Joystick {#joystick}
+<a id="joystick"></a>
+### Using a Joystick
 
 Joystick and thumb-joystick are supported through *QGroundControl* ([setup instructions here](../simulation/README.md#joystickgamepad-integration)).
 

--- a/en/simulation/flightgear_vehicles.md
+++ b/en/simulation/flightgear_vehicles.md
@@ -10,7 +10,8 @@ The supported types are: plane, autogyro and rover (there are specific frames wi
   (this page is a summary of vehicle-specific features).
 
 
-## Standard Plane {#standard_plane}
+<a id="standard_plane"></a>
+## Standard Plane
 
 FlightGear has models for many planes.
 The most suitable one for UAV development is currently the [Rascal RC plane](https://github.com/ThunderFly-aerospace/FlightGear-Rascal) (which also exists in multiple variants).
@@ -61,7 +62,8 @@ Rascal JSBsim variant.
 This variant does not have a direct `make` option but can be manually selected in the **rascal.json** configuration file (part of [PX4-FlightGear-Bridge](https://github.com/ThunderFly-aerospace/PX4-FlightGear-Bridge)).
 Simply change `Rascal110-YASim` to `Rascal110-JSBSim` in [this file](https://github.com/ThunderFly-aerospace/PX4-FlightGear-Bridge/blob/master/rascal.json#L2).
 
-## Autogyro {#autogyro}
+<a id="autogyro"></a>
+## Autogyro
 
 The only UAV autogyro model supported by FlightGear is [TF-G1 Autogyro](https://github.com/ThunderFly-aerospace/TF-G1).
 
@@ -72,7 +74,8 @@ make px4_sitl_nolockstep flightgear_tf-g1
 ![TF-G1 in FlightGear](../../assets/simulation/flightgear/vehicles/tf-g1.jpg)
 
 
-## Ackerman vehicle (UGV/Rover) {#ugv}
+<a id="ugv"></a>
+## Ackerman vehicle (UGV/Rover)
 
 ### TF-R1 Ground support Rover
 
@@ -85,7 +88,8 @@ make px4_sitl_nolockstep flightgear_tf-r1
 ![TF-R1 rover in FlightGear](../../assets/simulation/flightgear/vehicles/tf-r1_towing.jpg)
 
 
-## Quadrotor {#quadrotor}
+<a id="quadrotor"></a>
+## Quadrotor
 
 There is only an [incomplete multirotor model](https://github.com/ThunderFly-aerospace/FlightGear-TF-Mx1).
 This is not yet usable (it is numerically unstable and needs an additional work).

--- a/en/simulation/gazebo.md
+++ b/en/simulation/gazebo.md
@@ -23,7 +23,8 @@ graph LR;
 > **Note** See [Simulation](/simulation/README.md) for general information about simulators, the simulation environment, and simulation configuration (e.g. supported vehicles).
 
 
-## Installation {#installation}
+<a id="installation"></a>
+## Installation
 
 Gazebo 9 setup is included in our standard build instructions:
 - **macOS:** [Development Environment on Mac](../setup/dev_env_mac.md)
@@ -116,7 +117,8 @@ pxh> commander takeoff
 
 ## Usage/Configuration Options
 
-### Headless Mode {#headless}
+<a id="headless"></a>
+### Headless Mode
 
 Gazebo can be run in a *headless* mode in which the Gazebo UI is not launched.
 This starts up more quickly and uses less system resources (i.e. it is a more "lightweight" way to run the simulation).
@@ -126,7 +128,8 @@ Simply prefix the normal `make` command with `HEADLESS=1` as shown:
 HEADLESS=1 make px4_sitl gazebo_plane
 ```
 
-### Set Custom Takeoff Location {#custom_takeoff_location}
+<a id="custom_takeoff_location"></a>
+### Set Custom Takeoff Location
 
 The takeoff location in SITL Gazebo can be set using environment variables.
 This will override both the default takeoff location, and any value [set for the world](#set_world_location).
@@ -166,7 +169,8 @@ This can cause difficulty when using a distance sensor.
 If there are unexpected results we recommend you change the model in **iris.model** from `uneven_ground` to `asphalt_plane`.
 
 
-### Simulating GPS Noise {#gps_noise}
+<a id="gps_noise"></a>
+### Simulating GPS Noise
 
 Gazebo can simulate GPS noise that is similar to that typically found in real systems (otherwise reported GPS values will be noise-free/perfect).
 This is useful when working on applications that might be impacted by GPS noise - e.g. precision positioning.
@@ -197,7 +201,8 @@ To enable/disable GPS noise:
 The next time you build/restart Gazebo it will use the new GPS noise setting.
 
 
-## Loading a Specific World {#set_world}
+<a id="set_world"></a>
+## Loading a Specific World
 
 PX4 supports a number of [Gazebo Worlds](../simulation/gazebo_worlds.md), which are stored in [PX4/sitl_gazebo/worlds](https://github.com/PX4/sitl_gazebo/tree/master/worlds))
 By default Gazebo displays a flat featureless plane, as defined in [empty.world](https://github.com/PX4/sitl_gazebo/blob/master/worlds/empty.world).
@@ -218,7 +223,8 @@ This is useful if testing a new world that is not yet included with PX4.
 > **Tip** If the loaded world does not align with the map, you may need to [set the world location](#set_world_location).
   
 
-## Set World Location {#set_world_location}
+<a id="set_world_location"></a>
+## Set World Location
 
 The vehicle gets spawned very close to the origin of the world model at some simulated GPS location.
 
@@ -255,7 +261,8 @@ https://youtu.be/-a2WWLni5do
 
 
 
-## Starting Gazebo and PX4 Separately {#start_px4_sim_separately}
+<a id="start_px4_sim_separately"></a>
+## Starting Gazebo and PX4 Separately
 
 For extended development sessions it might be more convenient to start Gazebo and PX4 separately or even from within an IDE.
 
@@ -298,7 +305,8 @@ make px4_sitl_default gazebo_plane_cam
 > **Note** The simulated camera is implemented in [PX4/sitl_gazebo/src/gazebo_geotagged_images_plugin.cpp](https://github.com/PX4/sitl_gazebo/blob/master/src/gazebo_geotagged_images_plugin.cpp).
 
 
-## Simulated Parachute/Flight Termination {#flight_termination}
+<a id="flight_termination"></a>
+## Simulated Parachute/Flight Termination
 
 *Gazebo* can be used to simulate deploying a [parachute](https://docs.px4.io/master/en/peripherals/parachute.html) during [Flight Termination](https://docs.px4.io/master/en/advanced_config/flight_termination.html) (flight termination is triggered by the PWM command that is simulated in *Gazebo*).
 
@@ -316,7 +324,8 @@ For more information see:
 - [Parachute](https://docs.px4.io/master/en/peripherals/parachute.html)
 - [Safety Configuration (Failsafes)](https://docs.px4.io/master/en/config/safety.html)
 
-## Video Streaming {#video}
+<a id="video"></a>
+## Video Streaming
 
 PX4 SITL for Gazebo supports UDP video streaming from a Gazebo camera sensor attached to a vehicle model.
 When streaming is enabled, you can connect to this stream from *QGroundControl* (on UDP port 5600) and view video of the Gazebo environment from the simulated vehicle - just as you would from a real camera.

--- a/en/simulation/gazebo_vehicles.md
+++ b/en/simulation/gazebo_vehicles.md
@@ -10,19 +10,22 @@ Supported vehicle types include: mutirotors, VTOL, VTOL Tailsitter, Plane, Rover
 > **Note** The [Gazebo](../simulation/gazebo.md) page shows how to install Gazebo, how to enable video and load custom maps, and many other configuration options.
 
 ## Multicopter
-### Quadrotor (Default) {#quadrotor}
+<a id="quadrotor"></a>
+### Quadrotor (Default)
 
 ```sh
 make px4_sitl gazebo
 ```
 
-### Quadrotor with Optical Flow {#quadrotor_optical_flow}
+<a id="quadrotor_optical_flow"></a>
+### Quadrotor with Optical Flow
 
 ```sh
 make px4_sitl gazebo_iris_opt_flow
 ```
 
-### 3DR Solo (Quadrotor) {#3dr_solo}
+<a id="3dr_solo"></a>
+### 3DR Solo (Quadrotor)
 
 ```sh
 make px4_sitl gazebo_solo
@@ -31,7 +34,8 @@ make px4_sitl gazebo_solo
 ![3DR Solo in Gazebo](../../assets/simulation/gazebo/vehicles/solo.png)
 
 
-### Typhoon H480 (Hexrotor) {#typhoon_h480}
+<a id="typhoon_h480"></a>
+### Typhoon H480 (Hexrotor)
 
 ```
 make px4_sitl gazebo_typhoon_h480
@@ -41,9 +45,11 @@ make px4_sitl gazebo_typhoon_h480
 
 > **Note** This target also supports [video streaming simulation](#video).
 
-## Plane/Fixed Wing {#fixed_wing}
+<a id="fixed_wing"></a>
+## Plane/Fixed Wing
 
-### Standard Plane {#standard_plane}
+<a id="standard_plane"></a>
+### Standard Plane
 
 ```sh
 make px4_sitl gazebo_plane
@@ -52,7 +58,8 @@ make px4_sitl gazebo_plane
 ![Plane in Gazebo](../../assets/simulation/gazebo/vehicles/plane.png)
 
 
-#### Standard Plane with Catapult Launch {#standard_plane_catapult}
+<a id="standard_plane_catapult"></a>
+#### Standard Plane with Catapult Launch
 
 ```sh
 make px4_sitl gazebo_plane_catapult
@@ -65,7 +72,8 @@ The plane will automatically be launched as soon as the vehicle is armed.
 
 ## VTOL
 
-### Standard VTOL {#standard_vtol}
+<a id="standard_vtol"></a>
+### Standard VTOL
 
 ```sh
 make px4_sitl gazebo_standard_vtol
@@ -73,7 +81,8 @@ make px4_sitl gazebo_standard_vtol
 
 ![Standard VTOL in Gazebo](../../assets/simulation/gazebo/vehicles/standard_vtol.png)
 
-### Tailsitter VTOL {#tailsitter_vtol}
+<a id="tailsitter_vtol"></a>
+### Tailsitter VTOL
 
 ```sh
 make px4_sitl gazebo_tailsitter
@@ -82,9 +91,11 @@ make px4_sitl gazebo_tailsitter
 ![Tailsitter VTOL in Gazebo](../../assets/simulation/gazebo/vehicles/tailsitter.png)
 
 
-## Unmmanned Ground Vehicle (UGV/Rover/Car) {#ugv}
+<a id="ugv"></a>
+## Unmmanned Ground Vehicle (UGV/Rover/Car)
 
-### Ackerman UGV {#ugv_ackerman}
+<a id="ugv_ackerman"></a>
+### Ackerman UGV
 
 ```sh
 make px4_sitl gazebo_rover
@@ -92,7 +103,8 @@ make px4_sitl gazebo_rover
 
 ![Rover in Gazebo](../../assets/simulation/gazebo/vehicles/rover.png)
 
-### Differential UGV {#ugv_differential}
+<a id="ugv_differential"></a>
+### Differential UGV
 
 ```sh
 make px4_sitl gazebo_r1_rover
@@ -101,9 +113,11 @@ make px4_sitl gazebo_r1_rover
 ![Rover in Gazebo](../../assets/simulation/gazebo/vehicles/r1_rover.png)
 
 
-## Unmanned Underwater Vehicle (UUV/Submarine) {#uuv}
+<a id="uuv"></a>
+## Unmanned Underwater Vehicle (UUV/Submarine)
 
-### HippoCampus TUHH UUV {#uuv_hippocampus}
+<a id="uuv_hippocampus"></a>
+### HippoCampus TUHH UUV
 
 ```sh
 make px4_sitl gazebo_uuv_hippocampus
@@ -111,9 +125,11 @@ make px4_sitl gazebo_uuv_hippocampus
 
 ![Submarine/UUV](../../assets/simulation/gazebo/vehicles/hippocampus.png)
 
-## Unmanned Surface Vehicle (USV/Boat) {#usv}
+<a id="usv"></a>
+## Unmanned Surface Vehicle (USV/Boat)
 
-### Boat {#usv_boat}
+<a id="usv_boat"></a>
+### Boat
 
 ```sh
 make px4_sitl gazebo_boat
@@ -121,9 +137,11 @@ make px4_sitl gazebo_boat
 
 ![Boat/USV](../../assets/simulation/gazebo/vehicles/boat.png)
 
-## Airship {#airship}
+<a id="airship"></a>
+## Airship
 
-### Cloudship {#cloudship}
+<a id="cloudship"></a>
+### Cloudship
 
 ```sh
 make px4_sitl gazebo_cloudship

--- a/en/simulation/gazebo_worlds.md
+++ b/en/simulation/gazebo_worlds.md
@@ -7,7 +7,8 @@ Developers can also manually specify the world to load: [Gazebo Simulation > Loa
 
 The source code for supported worlds can be found on GitHub here: [PX4/sitl_gazebo/worlds](https://github.com/PX4/sitl_gazebo/tree/master/worlds).
 
-## Empty (Default) {#empty_world}
+<a id="empty_world"></a>
+## Empty (Default)
 
 [PX4/sitl_gazebo/worlds/empty.world](https://github.com/PX4/sitl_gazebo/blob/master/worlds/empty.world)
 
@@ -48,7 +49,8 @@ The source code for supported worlds can be found on GitHub here: [PX4/sitl_gaze
 
 ![Yosemite](../../assets/simulation/gazebo/worlds/yosemite.jpg)
 
-## Model Specific Worlds {#model_specific_worlds}
+<a id="model_specific_worlds"></a>
+## Model Specific Worlds
 
 Some [vehicle models](../simulation/gazebo_vehicles.md) rely on the physics / plugins of a specific world.
 The PX4 toolchain will automatically spawn a world that has the same name as the vehicle model if one exists (instead of the default **empty.world**):

--- a/en/simulation/hitl.md
+++ b/en/simulation/hitl.md
@@ -6,7 +6,8 @@ This approach has the benefit of testing most of the actual flight code on the r
 PX4 supports HITL for multicopters (using jMAVSim or Gazebo) and VTOL (using Gazebo).
 
 
-## HITL-Compatible Airframes {#compatible_airframe}
+<a id="compatible_airframe"></a>
+## HITL-Compatible Airframes
 
 The current set of compatible airframes vs Simulators is:
 
@@ -18,7 +19,8 @@ Airframe | `SYS_AUTOSTART` | Gazebo | jMAVSim
 [DJI Flame Wheel f450](../airframes/airframe_reference.md#copter_quadrotor_x_dji_flame_wheel_f450) | 4011 | Y | Y
 
 
-## HITL Simulation Environment {#simulation_environment}
+<a id="simulation_environment"></a>
+## HITL Simulation Environment
 
 With Hardware-in-the-Loop (HITL) simulation the normal PX4 firmware is run on real hardware.
 JMAVSim or Gazebo (running on a development computer) are connected to the flight controller hardware via USB/UART.
@@ -113,7 +115,8 @@ Follow the appropriate setup steps for the specific simulator in the following s
    ```
 1. Start *QGroundControl*. It should autoconnect to PX4 and Gazebo.
 
-#### jMAVSim (Quadrotor only) {#jmavsim_hitl_configuration}
+<a id="jmavsim_hitl_configuration"></a>
+#### jMAVSim (Quadrotor only)
 
 > **Note** Make sure *QGroundControl* is not running!
 

--- a/en/simulation/jmavsim.md
+++ b/en/simulation/jmavsim.md
@@ -96,7 +96,8 @@ make px4_sitl_default jmavsim
 
 For more information see: [Simulation > Run Simulation Faster than Realtime](../simulation/README.md#simulation_speed).
 
-### Using a Joystick {#joystick}
+<a id="joystick"></a>
+### Using a Joystick
 
 Joystick and thumb-joystick support are supported through *QGroundControl* ([setup instructions here](../simulation/README.md#joystickgamepad-integration)).
 

--- a/en/simulation/jsbsim.md
+++ b/en/simulation/jsbsim.md
@@ -13,7 +13,8 @@ Rotational earth effects are also modeled into the dynamics.
 > **Note** See [Simulation](/simulation/README.md) for general information about simulators, the simulation environment, and simulation configuration (e.g. supported vehicles).
 
 
-## Installation (Ubuntu Linux) {#installation}
+<a id="installation"></a>
+## Installation (Ubuntu Linux)
 
 > **Note** These instructions were tested on Ubuntu 18.04
 
@@ -25,7 +26,8 @@ Rotational earth effects are also modeled into the dynamics.
 1. (Optional) FlightGear may (optionally) be used for visualisation.
    To install FlightGear, refer to the [FlightGear installation instructions](../simulation/flightgear.md)).
 
-## Running the Simulation {#running}
+<a id="running"></a>
+## Running the Simulation
 
 JSBSim SITL simulation can be conveniently run through a `make` command as shown below:
 ```sh

--- a/en/simulation/multi_vehicle_simulation_gazebo.md
+++ b/en/simulation/multi_vehicle_simulation_gazebo.md
@@ -4,7 +4,8 @@ This topic explains how to simulate multiple UAV vehicles using Gazebo and SITL 
 A different approach is used for simulation with and without ROS.
 
 
-## Multiple Vehicle with Gazebo (No ROS) {#no_ros}
+<a id="no_ros"></a>
+## Multiple Vehicle with Gazebo (No ROS)
 
 To simulate multiple iris or plane vehicles in Gazebo use the following commands in the terminal (from the root of the *Firmware* tree):
 ```
@@ -28,25 +29,29 @@ Each vehicle instance is allocated a unique MAVLink system id (1, 2, 3, etc.) an
 > **Note** The 255-vehicle limitation occurs because mavlink `MAV_SYS_ID` only supports 255 vehicles in the same network
   The `MAV_SYS_ID` and various UDP ports are allocated in the SITL rcS: [init.d-posix/rcS](https://github.com/PX4/PX4-Autopilot/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS#L108-L112)
 
-### Video: Multiple Multicopter (Iris) {#video_mc}
+<a id="video_mc"></a>
+### Video: Multiple Multicopter (Iris)
 
 {% youtube %}
 https://youtu.be/Mskx_WxzeCk
 {% endyoutube %}
 
-### Video: Multiple Plane {#video_fw}
+<a id="video_fw"></a>
+### Video: Multiple Plane
 
 {% youtube %}
 https://youtu.be/aEzFKPMEfjc
 {% endyoutube %}
 
-### Video: Multiple VTOL {#video_vtol}
+<a id="video_vtol"></a>
+### Video: Multiple VTOL
 
 {% youtube %}
 https://youtu.be/lAjjTFFZebI
 {% endyoutube %}
 
-## Multiple Vehicles with ROS and Gazebo {#with_ros}
+<a id="with_ros"></a>
+## Multiple Vehicles with ROS and Gazebo
 
 This example demonstrates a setup that opens the Gazebo client GUI showing two Iris vehicles in an empty world.
 You can then control the vehicles with *QGroundControl* and MAVROS in a similar way to how you would manage a single vehicle.

--- a/en/test_and_ci/docker.md
+++ b/en/test_and_ci/docker.md
@@ -32,7 +32,8 @@ sudo usermod -aG docker $USER
 ```
 
 
-## Container Hierarchy {#px4_containers}
+<a id="px4_containers"></a>
+## Container Hierarchy
 
 The available containers are listed below (from [Github](https://github.com/PX4/containers/blob/master/README.md#container-hierarchy)):
 
@@ -81,7 +82,8 @@ Or to start a bash session using the NuttX toolchain:
 > **Tip** The script is easy because you don't need to know anything much about *Docker* or think about what container to use. However it is not particularly robust! The manual approach discussed in the [section below](#manual_start) is more flexible and should be used if you have any problems with the script.
 
 
-### Calling Docker Manually {#manual_start}
+<a id="manual_start"></a>
+### Calling Docker Manually
 
 The syntax of a typical command is shown below.
 This runs a Docker container that has support for X forwarding (makes the simulation GUI available from inside the container).
@@ -195,7 +197,8 @@ In that case the native graphics driver for your host system must be installed. 
 More information on this can be found [here](http://gernotklingler.com/blog/howto-get-hardware-accelerated-opengl-support-docker/).
 
 
-## Virtual Machine Support {#virtual_machine}
+<a id="virtual_machine"></a>
+## Virtual Machine Support
 
 Any recent Linux distribution should work.
 

--- a/en/test_and_ci/test_flights.md
+++ b/en/test_and_ci/test_flights.md
@@ -31,7 +31,8 @@ The tests performed for each platform are linked below:
 * [MC_05 - Indoor Flight (Manual Modes)](../test_cards/mc_05_indoor_flight_manual_modes.md)
 
 
-## Test Vehicles/Autopilots {#fleet}
+<a id="fleet"></a>
+## Test Vehicles/Autopilots
 
 Multicopter
 

--- a/en/tutorials/linux_sbus.md
+++ b/en/tutorials/linux_sbus.md
@@ -9,7 +9,8 @@ For RC types other than S.Bus, you can just connect the receiver directly to the
 Then [Start the PX4 RC Driver](#start_driver) on the device, as shown below.
 
 
-## Starting the Driver {#start_driver}
+<a id="start_driver"></a>
+## Starting the Driver
 
 To start the RC driver on a particular UART (e.g. in this case `/dev/ttyS2`): 
 ```
@@ -19,7 +20,8 @@ rc_input start -d /dev/ttyS2
 For other driver usage information see: [rc_input](../middleware/modules_driver.md#rcinput).
 
 
-## Signal Inverter Circuit (S.Bus only) {#signal_inverter_circuit}
+<a id="signal_inverter_circuit"></a>
+## Signal Inverter Circuit (S.Bus only)
 
 S.Bus is an *inverted* UART communication signal.
 


### PR DESCRIPTION
Gitbook supports setting anchors explicitly in headings, but most systems do not - including vuepress and github. This makes the links explicit so they don't screw up heading in vuepress
