### PR TITLE
Fix shell script typo in 'Adding a new airframe'

### DIFF
--- a/en/airframes/adding_a_new_frame.md
+++ b/en/airframes/adding_a_new_frame.md
@@ -56,7 +56,7 @@ The next section specifies vehicle-specific parameters, including [tuning gains]
 ```bash
 sh /etc/init.d/rc.fw_defaults
 
-if [ $AUTOCNF == yes ]
+if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 2
 	param set FW_AIRSPD_MAX 15


### PR DESCRIPTION
Just noticed this when reading. Using `==` works with bash, but not with sh.

By the way, the "edit page" button leading to automatically creating a fork and letting me suggest changes is very sleek!